### PR TITLE
portless run -- auto-naming + .portlessrc.json for monorepo support

### DIFF
--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -59,6 +59,45 @@ The proxy auto-starts when you run an app. You can also start it explicitly with
 
 The proxy auto-starts when you run an app. Or start it explicitly: `portless proxy start`.
 
+### Monorepo / Turborepo (auto-name)
+
+Use `portless run` to auto-derive the app name from each package's `package.json` name. Every package can use the same script:
+
+```json
+{
+  "scripts": {
+    "dev": "portless run next dev"
+  }
+}
+```
+
+Run `turbo dev` and each package gets its own stable URL automatically.
+
+Name resolution order:
+
+1. `.portlessrc.json` name override (see below)
+2. `npm_package_name` env var (set by npm/pnpm/yarn/turbo)
+3. Nearest `package.json` name
+4. Directory basename
+
+Scoped packages are sanitized: `@acme/web` becomes `web`.
+
+### .portlessrc.json (name overrides)
+
+Place a `.portlessrc.json` in your repo root to map package names to friendlier route names:
+
+```json
+{
+  "names": {
+    "@acme/web-app": "web",
+    "@acme/backend": "api",
+    "@acme/docs-site": "docs"
+  }
+}
+```
+
+Without this file, `@acme/web-app` would be routed as `web-app.localhost`.
+
 ### Multi-app setups with subdomains
 
 ```bash
@@ -107,6 +146,7 @@ Override with the `PORTLESS_STATE_DIR` environment variable.
 | Command                             | Description                                                   |
 | ----------------------------------- | ------------------------------------------------------------- |
 | `portless <name> <cmd> [args...]`   | Run app at `http://<name>.localhost:1355` (auto-starts proxy) |
+| `portless run <cmd> [args...]`      | Auto-name from package.json and run (great for monorepos)     |
 | `portless list`                     | Show active routes                                            |
 | `portless proxy start`              | Start the proxy as a daemon (port 1355, no sudo)              |
 | `portless proxy start -p <number>`  | Start the proxy on a custom port                              |

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,6 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
 /** Type guard for Node.js system errors with an error code. */
 export function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
   return (
@@ -60,4 +63,111 @@ export function parseHostname(input: string): string {
   }
 
   return hostname;
+}
+
+/**
+ * Sanitize a package name into a valid hostname segment.
+ * - Strips npm scope (@scope/pkg -> pkg)
+ * - Replaces invalid hostname chars with hyphens
+ * - Lowercases
+ * - Trims leading/trailing hyphens
+ * Returns null if the result is empty.
+ */
+export function sanitizePackageName(name: string): string | null {
+  // Strip scope
+  let sanitized = name.replace(/^@[^/]+\//, "");
+  // Lowercase
+  sanitized = sanitized.toLowerCase();
+  // Replace invalid chars (anything not a-z, 0-9, hyphen, dot) with hyphen
+  sanitized = sanitized.replace(/[^a-z0-9.-]/g, "-");
+  // Collapse consecutive hyphens
+  sanitized = sanitized.replace(/-{2,}/g, "-");
+  // Trim leading/trailing hyphens
+  sanitized = sanitized.replace(/^-+|-+$/g, "");
+  return sanitized || null;
+}
+
+/**
+ * Portless config file shape.
+ */
+export interface PortlessConfig {
+  names?: Record<string, string>;
+}
+
+/**
+ * Search upward from `startDir` for a `.portlessrc.json` file.
+ * Returns the parsed config, or null if not found.
+ */
+export function loadPortlessConfig(startDir: string): PortlessConfig | null {
+  let dir = startDir;
+  while (true) {
+    const configPath = path.join(dir, ".portlessrc.json");
+    try {
+      const raw = fs.readFileSync(configPath, "utf-8");
+      return JSON.parse(raw) as PortlessConfig;
+    } catch {
+      // Not found or invalid; continue searching
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break; // reached filesystem root
+    dir = parent;
+  }
+  return null;
+}
+
+/**
+ * Auto-resolve the app name for `portless run`.
+ *
+ * Resolution order:
+ * 1. Check `.portlessrc.json` names map (keyed by npm_package_name or package.json name)
+ * 2. Sanitize the package name from npm_package_name env var or nearest package.json
+ * 3. Fall back to basename of cwd
+ *
+ * Returns the resolved name (without .localhost suffix).
+ */
+export function resolveAppName(cwd: string): string {
+  // Determine the raw package name
+  let packageName: string | undefined = process.env.npm_package_name;
+
+  if (!packageName) {
+    // Walk up to find nearest package.json
+    let dir = cwd;
+    while (true) {
+      const pkgPath = path.join(dir, "package.json");
+      try {
+        const raw = fs.readFileSync(pkgPath, "utf-8");
+        const pkg = JSON.parse(raw);
+        if (typeof pkg.name === "string" && pkg.name) {
+          packageName = pkg.name;
+        }
+        break;
+      } catch {
+        // Not found; continue up
+      }
+      const parent = path.dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  }
+
+  // Load config for overrides
+  const config = loadPortlessConfig(cwd);
+
+  // Check config name override
+  if (packageName && config?.names?.[packageName]) {
+    return config.names[packageName];
+  }
+
+  // Sanitize the package name
+  if (packageName) {
+    const sanitized = sanitizePackageName(packageName);
+    if (sanitized) return sanitized;
+  }
+
+  // Fallback: directory basename
+  const basename = path.basename(cwd);
+  const sanitized = sanitizePackageName(basename);
+  if (sanitized) return sanitized;
+
+  throw new Error("Could not determine app name. Provide a name explicitly: portless <name> <cmd>");
 }


### PR DESCRIPTION
right now using portless in a monorepo is annoying -- you have to hardcode a unique name in every single package's dev script (portless web next dev, portless api tsx watch ..., etc). this doesn't scale, especially with turborepo where you want every package to have the same script.

this adds two things:

`portless run <cmd>` -- auto-derives the app name from the package so you can use the same script everywhere:

"dev": "portless run next dev"

run turbo dev and each package gets its own stable url automatically. name comes from npm_package_name (set by pnpm/turbo), nearest package.json, or dir basename as fallback. scoped names like @acme/web get sanitized to web.

.portlessrc.json -- optional config at repo root to override auto-derived names:

{
  "names": {
    "web": "website",
    "api": "backend"
  }
}

no breaking changes -- `portless <name> <cmd>` still works exactly the same