### PR TITLE
feat: detect proxy loops and respond with 508 Loop Detected

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,38 @@ pnpm typecheck        # Type-check all packages
 pnpm format           # Format all files with Prettier
 ```
 
+## Proxying Between Portless Apps
+
+If your frontend dev server (e.g. Vite, webpack) proxies API requests to another portless app, make sure the proxy rewrites the `Host` header. Without this, the proxy sends the **original** Host header, causing portless to route the request back to the frontend in an infinite loop.
+
+**Vite** (`vite.config.ts`):
+
+```ts
+server: {
+  proxy: {
+    "/api": {
+      target: "http://api.myapp.localhost:1355",
+      changeOrigin: true,  // Required: rewrites Host header to match target
+      ws: true,
+    },
+  },
+}
+```
+
+**webpack-dev-server** (`webpack.config.js`):
+
+```js
+devServer: {
+  proxy: [{
+    context: ["/api"],
+    target: "http://api.myapp.localhost:1355",
+    changeOrigin: true,  // Required: rewrites Host header to match target
+  }],
+}
+```
+
+Portless detects this misconfiguration and responds with `508 Loop Detected` along with a message pointing to this fix.
+
 ## Requirements
 
 - Node.js 20+

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -177,6 +177,23 @@ sudo portless trust
 
 This adds the portless local CA to your system trust store. After that, restart the browser.
 
+### Proxy loop (508 Loop Detected)
+
+If your dev server proxies requests to another portless app (e.g. Vite proxying `/api` to `api.myapp.localhost:1355`), the proxy must rewrite the `Host` header. Without this, portless routes the request back to the original app, creating an infinite loop.
+
+Fix: set `changeOrigin: true` in the proxy config (Vite, webpack-dev-server, etc.):
+
+```ts
+// vite.config.ts
+proxy: {
+  "/api": {
+    target: "http://api.myapp.localhost:1355",
+    changeOrigin: true,
+    ws: true,
+  },
+}
+```
+
 ### Requirements
 
 - Node.js 20+


### PR DESCRIPTION
## Summary

- Detect proxy loops by counting hops in `X-Forwarded-For` header
- Respond with `508 Loop Detected` and a helpful error message when hop count exceeds 10
- Apply loop detection to both HTTP requests and WebSocket upgrades
- Add documentation about this pitfall in README.md and SKILL.md

## Problem

When a frontend dev server (e.g. Vite) proxies API requests to another portless app **without `changeOrigin: true`**, the original `Host` header is preserved. Portless routes based on `Host`, so the request loops back to the frontend, creating an infinite Vite <-> portless cycle. Each hop appends to `X-Forwarded-For` until Node.js hits its 16KB header size limit and returns `431 Request Header Fields Too Large` -- a confusing error with no actionable message.

## Solution

- Count comma-separated entries in `X-Forwarded-For` in `handleRequest` and `handleUpgrade`
- If >= 10 hops, respond with `508 Loop Detected` and a message pointing to the fix (`changeOrigin: true`)
- Log a warning via `onError` with specific details about the misconfiguration

## Documentation

- **README.md**: Added "Proxying Between Portless Apps" section with Vite and webpack examples
- **SKILL.md**: Added "Proxy loop (508 Loop Detected)" troubleshooting entry

## Test plan

- [x] Request with 20 hops in `X-Forwarded-For` returns 508
- [x] Request with 2 hops passes through normally (200)
- [x] WebSocket upgrade with 20 hops destroys the socket
- [x] All 140 existing tests still pass

Closes #47