### PR TITLE
feat: add Windows (win32) platform support

### DIFF
--- a/packages/portless/package.json
+++ b/packages/portless/package.json
@@ -22,7 +22,8 @@
   },
   "os": [
     "darwin",
-    "linux"
+    "linux",
+    "win32"
   ],
   "scripts": {
     "build": "tsup",

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -109,17 +109,26 @@ describe("isProxyRunning", () => {
 });
 
 describe("resolveStateDir", () => {
-  it("returns system dir for privileged ports", () => {
-    expect(resolveStateDir(80)).toBe(SYSTEM_STATE_DIR);
-    expect(resolveStateDir(443)).toBe(SYSTEM_STATE_DIR);
-    expect(resolveStateDir(1023)).toBe(SYSTEM_STATE_DIR);
-  });
+  if (process.platform === "win32") {
+    it("always returns user dir on Windows", () => {
+      expect(resolveStateDir(80)).toBe(USER_STATE_DIR);
+      expect(resolveStateDir(443)).toBe(USER_STATE_DIR);
+      expect(resolveStateDir(1024)).toBe(USER_STATE_DIR);
+      expect(resolveStateDir(8080)).toBe(USER_STATE_DIR);
+    });
+  } else {
+    it("returns system dir for privileged ports", () => {
+      expect(resolveStateDir(80)).toBe(SYSTEM_STATE_DIR);
+      expect(resolveStateDir(443)).toBe(SYSTEM_STATE_DIR);
+      expect(resolveStateDir(1023)).toBe(SYSTEM_STATE_DIR);
+    });
 
-  it("returns user dir for non-privileged ports", () => {
-    expect(resolveStateDir(1024)).toBe(USER_STATE_DIR);
-    expect(resolveStateDir(8080)).toBe(USER_STATE_DIR);
-    expect(resolveStateDir(3000)).toBe(USER_STATE_DIR);
-  });
+    it("returns user dir for non-privileged ports", () => {
+      expect(resolveStateDir(1024)).toBe(USER_STATE_DIR);
+      expect(resolveStateDir(8080)).toBe(USER_STATE_DIR);
+      expect(resolveStateDir(3000)).toBe(USER_STATE_DIR);
+    });
+  }
 });
 
 describe("constants", () => {
@@ -131,8 +140,12 @@ describe("constants", () => {
     expect(PRIVILEGED_PORT_THRESHOLD).toBe(1024);
   });
 
-  it("SYSTEM_STATE_DIR is /tmp/portless", () => {
-    expect(SYSTEM_STATE_DIR).toBe("/tmp/portless");
+  it("SYSTEM_STATE_DIR is a temp-based path", () => {
+    if (process.platform === "win32") {
+      expect(SYSTEM_STATE_DIR).toContain("portless");
+    } else {
+      expect(SYSTEM_STATE_DIR).toBe("/tmp/portless");
+    }
   });
 
   it("USER_STATE_DIR is in home directory", () => {


### PR DESCRIPTION
## Summary

Adds Windows support to portless. Closes #15.

- Adds `"win32"` to the `os` field in `package.json` so `npm install -g portless` works on Windows
- Windows certificate trust store via `certutil -addstore -user Root` (user-scoped, shows Windows security prompt)
- Windows PID-on-port lookup via `netstat -ano | findstr` (replaces `lsof`)
- `shell: true` for `spawn` on Windows so `.cmd` wrappers (next.cmd, vite.cmd, etc.) resolve correctly
- `os.tmpdir()` for system state directory on Windows instead of hardcoded `/tmp`
- Skips privileged port / sudo checks on Windows (not applicable — any user can bind any port)
- `chmodSafe` / `chmodSafeAsync` wrappers that are no-ops on Windows (POSIX permissions don't apply)
- Platform-aware error messages (`netstat` vs `lsof`, "Administrator" vs `sudo`)
- Tests updated with platform-conditional assertions

## What's NOT changed

- Core proxy logic (`proxy.ts`, `routes.ts`, `utils.ts`, `types.ts`) — already cross-platform
- No new dependencies added
- All 137 existing tests pass unchanged on macOS/Linux

## Files changed

| File | Changes |
|------|---------|
| `package.json` | Add `"win32"` to `os` array |
| `certs.ts` | Add `isCATrustedWindows`, `trustCA` Windows branch, `chmodSafe` helpers |
| `cli-utils.ts` | Add `IS_WINDOWS`, Windows `findPidOnPort`, `shell: true` for spawn, state dir fix |
| `cli.ts` | Platform-aware error messages, skip sudo checks on Windows |
| `cli-utils.test.ts` | Platform-conditional test assertions |

## Prerequisites for Windows users

- **openssl**: Bundled with [Git for Windows](https://gitforwindows.org/) (in PATH by default). Also available via `winget install OpenSSL`.
- **certutil**: Ships with all Windows versions (system tool).
- **netstat**: Ships with all Windows versions (system tool).

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run build` succeeds
- [x] `pnpm run lint` passes
- [x] All 137 unit tests pass on macOS
- [x] Tested on Windows — proxy start, app registration, browsing via `.localhost` URL
- [ ] Linux regression testing