### PR TITLE
feat(cli): add --auto mode for automatic project name inference

### DIFF
--- a/packages/portless/src/auto.test.ts
+++ b/packages/portless/src/auto.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { sanitizeForHostname, inferProjectName, detectWorktreePrefix } from "./auto.js";
+
+// ---------------------------------------------------------------------------
+// sanitizeForHostname
+// ---------------------------------------------------------------------------
+
+describe("sanitizeForHostname", () => {
+  it("lowercases input", () => {
+    expect(sanitizeForHostname("MyApp")).toBe("myapp");
+  });
+
+  it("replaces invalid characters with hyphens", () => {
+    expect(sanitizeForHostname("my_app")).toBe("my-app");
+    expect(sanitizeForHostname("my app")).toBe("my-app");
+  });
+
+  it("collapses consecutive hyphens", () => {
+    expect(sanitizeForHostname("my--app")).toBe("my-app");
+    expect(sanitizeForHostname("a___b")).toBe("a-b");
+  });
+
+  it("trims leading and trailing hyphens", () => {
+    expect(sanitizeForHostname("-myapp-")).toBe("myapp");
+    expect(sanitizeForHostname("--myapp--")).toBe("myapp");
+    expect(sanitizeForHostname("@myapp!")).toBe("myapp");
+  });
+
+  it("returns empty string for entirely invalid input", () => {
+    expect(sanitizeForHostname("@@@")).toBe("");
+    expect(sanitizeForHostname("---")).toBe("");
+    expect(sanitizeForHostname("")).toBe("");
+  });
+
+  it("preserves valid characters", () => {
+    expect(sanitizeForHostname("my-app-123")).toBe("my-app-123");
+  });
+
+  it("handles mixed case and underscores", () => {
+    expect(sanitizeForHostname("My_Feature_Branch")).toBe("my-feature-branch");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// inferProjectName
+// ---------------------------------------------------------------------------
+
+describe("inferProjectName", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(process.env.TMPDIR || "/tmp", "portless-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("reads name from package.json", () => {
+    fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ name: "my-cool-app" }));
+    const result = inferProjectName(tmpDir);
+    expect(result.name).toBe("my-cool-app");
+    expect(result.source).toBe("package.json");
+  });
+
+  it("strips scoped package name prefix", () => {
+    fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ name: "@org/myapp" }));
+    const result = inferProjectName(tmpDir);
+    expect(result.name).toBe("myapp");
+    expect(result.source).toBe("package.json");
+  });
+
+  it("walks up directories to find package.json", () => {
+    fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ name: "parent-app" }));
+    const subDir = path.join(tmpDir, "src", "components");
+    fs.mkdirSync(subDir, { recursive: true });
+    const result = inferProjectName(subDir);
+    expect(result.name).toBe("parent-app");
+    expect(result.source).toBe("package.json");
+  });
+
+  it("skips package.json with empty name", () => {
+    fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ name: "" }));
+    const result = inferProjectName(tmpDir);
+    expect(result.source).not.toBe("package.json");
+  });
+
+  it("skips package.json without name field", () => {
+    fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ version: "1.0.0" }));
+    const result = inferProjectName(tmpDir);
+    expect(result.source).not.toBe("package.json");
+  });
+
+  it("falls back to git root directory name", () => {
+    fs.mkdirSync(path.join(tmpDir, ".git"));
+    const result = inferProjectName(tmpDir);
+    expect(result.source).toBe("git root");
+    expect(result.name).toBeTruthy();
+  });
+
+  it("falls back to cwd basename", () => {
+    const namedDir = path.join(tmpDir, "my-project");
+    fs.mkdirSync(namedDir);
+    const result = inferProjectName(namedDir);
+    expect(result.name).toBe("my-project");
+    expect(result.source).toBe("directory name");
+  });
+
+  it("sanitizes the package.json name", () => {
+    fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ name: "My_App" }));
+    const result = inferProjectName(tmpDir);
+    expect(result.name).toBe("my-app");
+  });
+
+  it("skips package.json whose name sanitizes to empty", () => {
+    fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ name: "@@@" }));
+    const result = inferProjectName(tmpDir);
+    expect(result.source).not.toBe("package.json");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectWorktreePrefix
+// ---------------------------------------------------------------------------
+
+describe("detectWorktreePrefix", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(process.env.TMPDIR || "/tmp", "portless-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // These tests exercise the filesystem-based fallback path. The git CLI
+  // fails naturally in temp dirs outside any real git repo.
+
+  /**
+   * Set up a fake worktree: a .git file pointing to a gitdir, and a HEAD
+   * file inside that gitdir with the given branch ref.
+   */
+  function setupWorktree(dir: string, branch: string) {
+    const worktreeName = "wt";
+    const gitdir = path.join(tmpDir, "fake-bare.git", "worktrees", worktreeName);
+    fs.mkdirSync(gitdir, { recursive: true });
+    fs.writeFileSync(path.join(gitdir, "HEAD"), `ref: refs/heads/${branch}\n`);
+    fs.writeFileSync(path.join(dir, ".git"), `gitdir: ${gitdir}\n`);
+  }
+
+  it("returns null for a main checkout (.git directory)", () => {
+    fs.mkdirSync(path.join(tmpDir, ".git"));
+    const result = detectWorktreePrefix(tmpDir);
+    expect(result).toBeNull();
+  });
+
+  it("uses branch name as prefix from .git file", () => {
+    setupWorktree(tmpDir, "feature-auth");
+    const result = detectWorktreePrefix(tmpDir);
+    expect(result).toEqual({ prefix: "feature-auth", source: "git branch" });
+  });
+
+  it("returns null when branch is main", () => {
+    setupWorktree(tmpDir, "main");
+    const result = detectWorktreePrefix(tmpDir);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when branch is master", () => {
+    setupWorktree(tmpDir, "master");
+    const result = detectWorktreePrefix(tmpDir);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for submodule .git file", () => {
+    const gitdir = path.join(tmpDir, "fake.git", "modules", "my-submodule");
+    fs.mkdirSync(gitdir, { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, ".git"), `gitdir: ${gitdir}\n`);
+    const result = detectWorktreePrefix(tmpDir);
+    expect(result).toBeNull();
+  });
+
+  it("uses last segment of branch name with slashes", () => {
+    setupWorktree(tmpDir, "feature/My_Branch");
+    const result = detectWorktreePrefix(tmpDir);
+    expect(result).toEqual({ prefix: "my-branch", source: "git branch" });
+  });
+
+  it("returns null when no .git found at all", () => {
+    const result = detectWorktreePrefix(tmpDir);
+    expect(result).toBeNull();
+  });
+
+  it("walks up directories to find .git file", () => {
+    setupWorktree(tmpDir, "deep-feature");
+    const subDir = path.join(tmpDir, "src", "lib");
+    fs.mkdirSync(subDir, { recursive: true });
+    const result = detectWorktreePrefix(subDir);
+    expect(result).toEqual({ prefix: "deep-feature", source: "git branch" });
+  });
+
+  it("returns null for detached HEAD", () => {
+    const worktreeName = "wt";
+    const gitdir = path.join(tmpDir, "fake-bare.git", "worktrees", worktreeName);
+    fs.mkdirSync(gitdir, { recursive: true });
+    fs.writeFileSync(path.join(gitdir, "HEAD"), "abc123def456\n");
+    fs.writeFileSync(path.join(tmpDir, ".git"), `gitdir: ${gitdir}\n`);
+    const result = detectWorktreePrefix(tmpDir);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for .git file with no gitdir line", () => {
+    fs.writeFileSync(path.join(tmpDir, ".git"), "something unexpected\n");
+    const result = detectWorktreePrefix(tmpDir);
+    expect(result).toBeNull();
+  });
+
+  it("uses last segment even when it matches a default branch name", () => {
+    setupWorktree(tmpDir, "feature/main");
+    const result = detectWorktreePrefix(tmpDir);
+    expect(result).toEqual({ prefix: "main", source: "git branch" });
+  });
+
+  it("uses last segment for feature/master", () => {
+    setupWorktree(tmpDir, "feature/master");
+    const result = detectWorktreePrefix(tmpDir);
+    expect(result).toEqual({ prefix: "master", source: "git branch" });
+  });
+
+  it("returns null when branch sanitizes to empty", () => {
+    setupWorktree(tmpDir, "@@@");
+    const result = detectWorktreePrefix(tmpDir);
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectWorktreePrefix (git CLI path)
+// ---------------------------------------------------------------------------
+
+describe("detectWorktreePrefix (git CLI path)", () => {
+  let gitAvailable = true;
+  try {
+    execFileSync("git", ["--version"], { stdio: "ignore" });
+  } catch {
+    gitAvailable = false;
+  }
+
+  // Skip the entire block if git is not available
+  if (!gitAvailable) {
+    it.skip("git not available", () => {});
+    return;
+  }
+
+  function runGit(cwd: string, args: string[]): string {
+    return execFileSync("git", args, {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  }
+
+  function initRepoWithCommit(repoDir: string): void {
+    fs.mkdirSync(repoDir, { recursive: true });
+    runGit(repoDir, ["init"]);
+    runGit(repoDir, ["branch", "-M", "main"]);
+    runGit(repoDir, [
+      "-c",
+      "user.name=Test",
+      "-c",
+      "user.email=t@t",
+      "commit",
+      "--allow-empty",
+      "-m",
+      "init",
+    ]);
+  }
+
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(process.env.TMPDIR || "/tmp", "portless-git-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns null for a single worktree (no linked worktrees)", () => {
+    const repo = path.join(tmpDir, "repo");
+    initRepoWithCommit(repo);
+
+    const result = detectWorktreePrefix(repo);
+    expect(result).toBeNull();
+  });
+
+  it("returns prefix for a linked worktree on a non-default branch", () => {
+    const repo = path.join(tmpDir, "repo");
+    initRepoWithCommit(repo);
+
+    runGit(repo, ["branch", "feature-auth"]);
+    const wtDir = path.join(tmpDir, "wt-feature-auth");
+    runGit(repo, ["worktree", "add", wtDir, "feature-auth"]);
+
+    const result = detectWorktreePrefix(wtDir);
+    expect(result).toEqual({ prefix: "feature-auth", source: "git branch" });
+  });
+
+  it("returns null for the primary checkout on main when worktrees exist", () => {
+    const repo = path.join(tmpDir, "repo");
+    initRepoWithCommit(repo);
+
+    runGit(repo, ["branch", "feature-auth"]);
+    const wtDir = path.join(tmpDir, "wt-feature-auth");
+    runGit(repo, ["worktree", "add", wtDir, "feature-auth"]);
+
+    const result = detectWorktreePrefix(repo);
+    expect(result).toBeNull();
+  });
+
+  it("returns last segment as prefix for slash-prefixed branch (feature/main)", () => {
+    const repo = path.join(tmpDir, "repo");
+    initRepoWithCommit(repo);
+
+    runGit(repo, ["branch", "feature/main"]);
+    const wtDir = path.join(tmpDir, "wt-feature-main");
+    runGit(repo, ["worktree", "add", wtDir, "feature/main"]);
+
+    const result = detectWorktreePrefix(wtDir);
+    expect(result).toEqual({ prefix: "main", source: "git branch" });
+  });
+});

--- a/packages/portless/src/auto.ts
+++ b/packages/portless/src/auto.ts
@@ -1,0 +1,266 @@
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+// ---------------------------------------------------------------------------
+// Hostname sanitization
+// ---------------------------------------------------------------------------
+
+/**
+ * Sanitize a string for use as a .localhost hostname label.
+ * Lowercases, replaces invalid characters with hyphens, collapses consecutive
+ * hyphens, and trims leading/trailing hyphens.
+ */
+export function sanitizeForHostname(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+// ---------------------------------------------------------------------------
+// Project name inference
+// ---------------------------------------------------------------------------
+
+export interface InferredName {
+  name: string;
+  source: string;
+}
+
+/**
+ * Infer the project name by walking up from `cwd`:
+ *   1. package.json `name` field (strips `@scope/` prefix)
+ *   2. Git repo root directory name
+ *   3. Current directory basename
+ *
+ * First match that yields a non-empty sanitized name wins.
+ */
+export function inferProjectName(cwd: string = process.cwd()): InferredName {
+  // 1. Walk up looking for package.json
+  const pkgResult = findPackageJsonName(cwd);
+  if (pkgResult) {
+    const sanitized = sanitizeForHostname(pkgResult);
+    if (sanitized) {
+      return { name: sanitized, source: "package.json" };
+    }
+  }
+
+  // 2. Git repo root directory name
+  const gitRoot = findGitRoot(cwd);
+  if (gitRoot) {
+    const sanitized = sanitizeForHostname(path.basename(gitRoot));
+    if (sanitized) {
+      return { name: sanitized, source: "git root" };
+    }
+  }
+
+  // 3. Current directory basename
+  const sanitized = sanitizeForHostname(path.basename(cwd));
+  if (sanitized) {
+    return { name: sanitized, source: "directory name" };
+  }
+
+  throw new Error("Could not infer a project name from package.json, git root, or directory name");
+}
+
+/**
+ * Walk up from `startDir` looking for a package.json with a `name` field.
+ * Returns the name (with `@scope/` prefix stripped) or null.
+ */
+function findPackageJsonName(startDir: string): string | null {
+  let dir = startDir;
+  for (;;) {
+    const pkgPath = path.join(dir, "package.json");
+    try {
+      const raw = fs.readFileSync(pkgPath, "utf-8");
+      const pkg = JSON.parse(raw);
+      if (typeof pkg.name === "string" && pkg.name) {
+        // Strip scoped prefix: @org/myapp → myapp
+        return pkg.name.replace(/^@[^/]+\//, "");
+      }
+    } catch {
+      // No package.json here or invalid JSON; keep walking
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+/**
+ * Find the git repo root by trying `git rev-parse --show-toplevel` first,
+ * then falling back to walking up and looking for a `.git` directory.
+ */
+function findGitRoot(startDir: string): string | null {
+  // Try git CLI
+  try {
+    const toplevel = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      cwd: startDir,
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (toplevel) return toplevel;
+  } catch {
+    // git binary unavailable or not a git repo
+  }
+
+  // Fallback: walk up looking for .git directory
+  let dir = startDir;
+  for (;;) {
+    const gitPath = path.join(dir, ".git");
+    try {
+      const stat = fs.statSync(gitPath);
+      if (stat.isDirectory()) return dir;
+      // .git file (worktree or submodule) — the actual repo root is elsewhere,
+      // but this directory is inside a git repo so it's a reasonable fallback
+      if (stat.isFile()) return dir;
+    } catch {
+      // No .git here; keep walking
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Worktree detection
+// ---------------------------------------------------------------------------
+
+export interface WorktreePrefix {
+  prefix: string;
+  source: string;
+}
+
+/** Branch names that represent the default/primary checkout — no prefix needed. */
+const DEFAULT_BRANCHES = new Set(["main", "master"]);
+
+/**
+ * Convert a branch name to a worktree prefix. Uses only the last segment
+ * after the final `/` (e.g. `feature/auth` → `auth`). Returns null for
+ * default branches, detached HEAD, or names that sanitize to empty.
+ */
+function branchToPrefix(branch: string): string | null {
+  if (!branch || branch === "HEAD" || DEFAULT_BRANCHES.has(branch)) return null;
+  const lastSegment = branch.split("/").pop()!;
+  const prefix = sanitizeForHostname(lastSegment);
+  return prefix || null;
+}
+
+/**
+ * Detect if the current directory is inside a multi-worktree git repo and
+ * return the current branch name as a prefix for hostname composition.
+ *
+ * Heuristic:
+ *   1. `git worktree list` — if there are multiple worktrees, this repo
+ *      uses worktrees and checkouts need distinguishing.
+ *   2. `git rev-parse --abbrev-ref HEAD` — get the current branch name.
+ *   3. If the branch is `main` or `master`, no prefix (primary checkout).
+ *   4. Otherwise, the sanitized branch name is the prefix.
+ *
+ * Falls back to parsing `.git` file + HEAD when git CLI is unavailable.
+ */
+export function detectWorktreePrefix(cwd: string = process.cwd()): WorktreePrefix | null {
+  // Primary: git CLI
+  const cliResult = detectWorktreeViaCli(cwd);
+  if (cliResult !== undefined) return cliResult;
+
+  // Fallback: parse .git file and HEAD when git binary is unavailable
+  return detectWorktreeViaFilesystem(cwd);
+}
+
+/**
+ * Use git CLI to detect worktree prefix. Returns:
+ *   - `{ prefix, source }` if in a non-default-branch worktree
+ *   - `null` if not in a worktree setup, or on main/master
+ *   - `undefined` if git CLI is unavailable (caller should try fallback)
+ */
+function detectWorktreeViaCli(cwd: string): WorktreePrefix | null | undefined {
+  try {
+    const listOutput = execFileSync("git", ["worktree", "list", "--porcelain"], {
+      cwd,
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+
+    // Count worktrees — each block starts with "worktree "
+    const worktreeCount = listOutput.split("\n").filter((l) => l.startsWith("worktree ")).length;
+    if (worktreeCount <= 1) return null;
+
+    // Multiple worktrees exist — use branch name as prefix
+    const branch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+      cwd,
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+
+    const prefix = branchToPrefix(branch);
+    if (!prefix) return null;
+
+    return { prefix, source: "git branch" };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Fallback worktree detection when git CLI is unavailable. Walks up from
+ * `startDir` looking for a `.git` file (worktrees have a file, not a
+ * directory) and reads the branch name from the gitdir's HEAD file.
+ */
+function detectWorktreeViaFilesystem(startDir: string): WorktreePrefix | null {
+  let dir = startDir;
+  for (;;) {
+    const gitPath = path.join(dir, ".git");
+    try {
+      const stat = fs.statSync(gitPath);
+      if (stat.isDirectory()) {
+        // Regular .git directory — not a worktree
+        return null;
+      }
+      if (stat.isFile()) {
+        const content = fs.readFileSync(gitPath, "utf-8").trim();
+        const match = content.match(/^gitdir:\s*(.+)$/);
+        if (!match) return null;
+
+        const gitdir = match[1];
+        // Only treat as a worktree if gitdir points into a /worktrees/ path.
+        // Submodules point to /modules/ instead.
+        if (!gitdir.match(/\/worktrees\/[^/]+$/)) return null;
+
+        // Read the branch name from the worktree's HEAD file
+        const branch = readBranchFromHead(path.resolve(dir, gitdir));
+        const prefix = branchToPrefix(branch ?? "");
+        if (!prefix) return null;
+
+        return { prefix, source: "git branch" };
+      }
+    } catch {
+      // No .git here; keep walking
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+/**
+ * Read the current branch name from a gitdir's HEAD file.
+ * Returns null for detached HEAD or unreadable files.
+ */
+function readBranchFromHead(gitdir: string): string | null {
+  try {
+    const head = fs.readFileSync(path.join(gitdir, "HEAD"), "utf-8").trim();
+    const refMatch = head.match(/^ref: refs\/heads\/(.+)$/);
+    return refMatch ? refMatch[1] : null;
+  } catch {
+    return null;
+  }
+}

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -39,6 +39,10 @@ npm install -g portless
 portless proxy start
 
 # Run your app (auto-starts the proxy if needed)
+portless run next dev
+# -> http://<project>.localhost:1355
+
+# Or with an explicit name
 portless myapp next dev
 # -> http://myapp.localhost:1355
 ```
@@ -52,7 +56,7 @@ The proxy auto-starts when you run an app. You can also start it explicitly with
 ```json
 {
   "scripts": {
-    "dev": "portless myapp next dev"
+    "dev": "portless run next dev"
   }
 }
 ```
@@ -119,6 +123,7 @@ First run generates a local CA and prompts for sudo to add it to the system trus
 
 | Command                             | Description                                                   |
 | ----------------------------------- | ------------------------------------------------------------- |
+| `portless run <cmd> [args...]`      | Infer name from project, run through proxy (auto-starts)      |
 | `portless <name> <cmd> [args...]`   | Run app at `http://<name>.localhost:1355` (auto-starts proxy) |
 | `portless list`                     | Show active routes                                            |
 | `portless trust`                    | Add local CA to system trust store (for HTTPS)                |


### PR DESCRIPTION
## Summary

This is a fusion of the ideas in #13 and #34, landing as `portless run`.

**From #13 (auto-naming):** The core idea. `portless run <cmd>` infers the project name automatically so you can use the same `"dev": "portless run next dev"` script everywhere, even in monorepos with turborepo. Name inference walks up from cwd: `package.json` name (stripping `@scope/`), git repo root, then directory basename.

**From #34 (branch-based subdomains):** The worktree isolation idea. When you're in a git worktree, the URL automatically gets a prefix: `http://<worktree>.<project>.localhost:1355`. This solves the parallel-agents and multi-checkout use case without any flags.

### What's different from those PRs

| | #13 | #34 | This PR |
|---|---|---|---|
| Auto-name inference | `portless run` | — | `portless run` |
| Branch-based subdomains | — | `--branches` flag | Worktree detection (automatic, no flag) |
| `.portlessrc.json` config | Yes | — | Not included |
| Scope | `portless run` only | Named mode only | `portless run` only |

**Key design choices:**

- **Worktrees instead of branches.** #34's `--branches` flag prefixes based on `git branch --show-current`, which means switching branches in the same checkout changes your URL and breaks any open tabs. Worktree detection only activates when you're actually in a separate worktree, so the primary checkout is stable and each worktree gets its own URL by construction. This is a better fit for the parallel-agents use case that motivated #34.

- **No `.portlessrc.json`.** #13 included a config file for overriding auto-derived names in monorepos. We're deferring this. The inference heuristic (package.json, git root, dirname) handles the common cases, and we can add config later if needed without breaking anything.

- **No `--branches` flag.** Since worktree detection is automatic and doesn't require opting in, there's no flag to manage. Named mode (`portless myapp <cmd>`) is still available when you want explicit control.

## Test plan

- [x] Unit tests for `auto.ts`: project name inference (package.json, git root, dirname), hostname sanitization, worktree detection (CLI and file-based fallback)
- [x] CLI integration tests for `portless run` subcommand dispatch (no args, `run list`, `run --version`, `run --help`)
- [x] CLI integration tests for `PORTLESS=0` bypass in run mode
- [x] All 188 tests passing