### PR TITLE
feat(cli): inject PORTLESS_URL into child process environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,12 @@ portless proxy stop              # Stop the proxy
 --foreground                     # Run proxy in foreground instead of daemon
 --force                          # Override a route registered by another process
 
-# Environment variables
+# Injected into child processes
+PORT                             # Ephemeral port the child should listen on
+HOST                             # Always 127.0.0.1
+PORTLESS_URL                     # Public URL (e.g. http://myapp.localhost:1355)
+
+# Configuration
 PORTLESS_PORT=<number>           # Override the default proxy port
 PORTLESS_HTTPS=1                 # Always enable HTTPS
 PORTLESS_STATE_DIR=<path>        # Override the state directory

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -40,6 +40,7 @@ describe("CLI", () => {
       expect(stdout).toContain("-p");
       expect(stdout).toContain("--foreground");
       expect(stdout).toContain("PORTLESS_STATE_DIR");
+      expect(stdout).toContain("PORTLESS_URL");
     });
 
     it("prints help and exits 0 with -h", () => {

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -414,6 +414,7 @@ async function runApp(
       ...process.env,
       PORT: port.toString(),
       HOST: "127.0.0.1",
+      PORTLESS_URL: finalUrl,
       __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: ".localhost",
     },
     onCleanup: () => {
@@ -526,6 +527,11 @@ ${chalk.bold("Environment variables:")}
   PORTLESS_HTTPS=1              Always enable HTTPS (set in .bashrc / .zshrc)
   PORTLESS_STATE_DIR=<path>     Override the state directory
   PORTLESS=0 | PORTLESS=skip    Run command directly without proxy
+
+${chalk.bold("Child process environment:")}
+  PORT                          Ephemeral port the child should listen on
+  HOST                          Always 127.0.0.1
+  PORTLESS_URL                  Public URL of the app (e.g. http://myapp.localhost:1355)
 
 ${chalk.bold("Skip portless:")}
   PORTLESS=0 pnpm dev           # Runs command directly without proxy


### PR DESCRIPTION
## Summary

- Sets the `PORTLESS_URL` environment variable when spawning child processes via `portless <name> <command>`
- Allows child processes to discover their assigned portless URL without manual configuration

## Test plan

- [x] CLI test verifying `PORTLESS_URL` is set in child environment