### PR TITLE
feat: add tailscale serve provider mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,16 @@ npm install -g portless
 # Start the proxy (once, no sudo needed)
 portless proxy start
 
-# Run your app (auto-starts the proxy if needed)
+# Run your app (builtin provider, auto-starts proxy if needed)
 portless myapp next dev
 # -> http://myapp.localhost:1355
+
+# Run your app with tailscale serve
+portless --provider tailscale myapp next dev
+# -> https://<node>.<tailnet>.ts.net/myapp
 ```
 
-> The proxy auto-starts when you run an app. You can also start it explicitly with `portless proxy start`.
+> Builtin mode auto-starts the proxy when you run an app. Tailscale mode requires `tailscale` to be installed and connected.
 
 ## Why
 
@@ -42,7 +46,7 @@ Portless fixes all of this by giving each dev server a stable, named `.localhost
 ## Usage
 
 ```bash
-# Basic
+# Builtin provider (default)
 portless myapp next dev
 # -> http://myapp.localhost:1355
 
@@ -52,6 +56,10 @@ portless api.myapp pnpm start
 
 portless docs.myapp next dev
 # -> http://docs.myapp.localhost:1355
+
+# Tailscale provider
+portless --provider tailscale myapp next dev
+# -> https://<node>.<tailnet>.ts.net/myapp
 ```
 
 ### In package.json
@@ -59,12 +67,13 @@ portless docs.myapp next dev
 ```json
 {
   "scripts": {
-    "dev": "portless myapp next dev"
+    "dev": "portless myapp next dev",
+    "dev:tailnet": "portless --provider tailscale myapp next dev"
   }
 }
 ```
 
-The proxy auto-starts when you run an app. Or start it explicitly: `portless proxy start`.
+Builtin mode auto-starts the proxy when you run an app. You can also start it explicitly: `portless proxy start`.
 
 ## How It Works
 
@@ -80,11 +89,29 @@ flowchart TD
     Proxy --> App2
 ```
 
-1. **Start the proxy** -- auto-starts when you run an app, or start explicitly with `portless proxy start`
-2. **Run apps** -- `portless <name> <command>` assigns a free port and registers with the proxy
-3. **Access via URL** -- `http://<name>.localhost:1355` routes through the proxy to your app
+1. **Choose provider** -- builtin (default) or tailscale (`--provider tailscale`)
+2. **Run apps** -- `portless <name> <command>` assigns a free local port and starts your app
+3. **Builtin URL** -- `http://<name>.localhost:1355` through the local proxy
+4. **Tailscale URL** -- `https://<node>.<tailnet>.ts.net/<name>` via `tailscale serve`
 
 Apps are assigned a random port (4000-4999) via the `PORT` and `HOST` environment variables. Most frameworks (Next.js, Express, Nuxt, etc.) respect these automatically. For frameworks that ignore `PORT` (Vite, Astro, React Router, Angular), portless auto-injects the correct `--port` and `--host` flags.
+
+## Tailscale Provider
+
+Tailscale mode is tailnet-only in this release (no Funnel support).
+
+```bash
+# Verify tailscale is installed and connected
+tailscale status
+
+# Run app via tailscale serve
+portless --provider tailscale myapp pnpm dev
+
+# Replace an existing tailscale path mount for this app
+portless --provider tailscale --force myapp pnpm dev
+```
+
+Portless registers `/<name>` with `tailscale serve` while your app is running and removes it on process exit.
 
 ## HTTP/2 + HTTPS
 
@@ -111,15 +138,16 @@ sudo portless trust
 ## Commands
 
 ```bash
-portless <name> <cmd> [args...]  # Run app at http://<name>.localhost:1355
-portless list                    # Show active routes
-portless trust                   # Add local CA to system trust store
+portless <name> <cmd> [args...]                       # Run app with builtin provider
+portless --provider tailscale <name> <cmd> [args...] # Run app with tailscale provider
+portless list                                         # Show routes for active provider
+portless trust                                        # Add local CA to system trust store (builtin only)
 
 # Disable portless (run command directly)
 PORTLESS=0 pnpm dev              # Bypasses proxy, uses default port
 # Also accepts PORTLESS=skip
 
-# Proxy control
+# Builtin proxy control
 portless proxy start             # Start the proxy (port 1355, daemon)
 portless proxy start --https     # Start with HTTP/2 + TLS
 portless proxy start -p 80       # Start on port 80 (requires sudo)
@@ -127,6 +155,7 @@ portless proxy start --foreground  # Start in foreground (for debugging)
 portless proxy stop              # Stop the proxy
 
 # Options
+--provider <builtin|tailscale>   # Select routing provider (default: builtin)
 -p, --port <number>              # Port for the proxy (default: 1355)
                                  # Ports < 1024 require sudo
 --https                          # Enable HTTP/2 + TLS with auto-generated certs
@@ -137,6 +166,7 @@ portless proxy stop              # Stop the proxy
 --force                          # Override a route registered by another process
 
 # Environment variables
+PORTLESS_PROVIDER=<name>         # Default provider (builtin or tailscale)
 PORTLESS_PORT=<number>           # Override the default proxy port
 PORTLESS_HTTPS=1                 # Always enable HTTPS
 PORTLESS_STATE_DIR=<path>        # Override the state directory
@@ -206,3 +236,4 @@ Portless detects this misconfiguration and responds with `508 Loop Detected` alo
 
 - Node.js 20+
 - macOS or Linux
+- Tailscale CLI (optional, only for `--provider tailscale`)

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -39,6 +39,8 @@ describe("CLI", () => {
       expect(stdout).toContain("--port");
       expect(stdout).toContain("-p");
       expect(stdout).toContain("--foreground");
+      expect(stdout).toContain("--provider");
+      expect(stdout).toContain("PORTLESS_PROVIDER");
       expect(stdout).toContain("PORTLESS_STATE_DIR");
     });
 
@@ -92,6 +94,42 @@ describe("CLI", () => {
       const { status, stdout } = run(["proxy", "unknown"]);
       expect(status).toBe(1);
       expect(stdout).toContain("proxy start");
+    });
+
+    it("exits 1 when proxy command is used with tailscale provider", () => {
+      const { status, stderr } = run(["--provider", "tailscale", "proxy", "start"]);
+      expect(status).toBe(1);
+      expect(stderr).toContain("only available with the builtin provider");
+    });
+  });
+
+  describe("provider", () => {
+    it("exits 1 for invalid --provider value", () => {
+      const { status, stderr } = run(["--provider", "invalid", "--help"]);
+      expect(status).toBe(1);
+      expect(stderr).toContain("Invalid provider");
+    });
+
+    it("exits 1 for invalid PORTLESS_PROVIDER value", () => {
+      const { status, stderr } = run(["--help"], {
+        env: { PORTLESS_PROVIDER: "invalid" },
+      });
+      expect(status).toBe(1);
+      expect(stderr).toContain("Invalid PORTLESS_PROVIDER");
+    });
+
+    it("exits 1 for trust command in tailscale provider", () => {
+      const { status, stderr } = run(["--provider", "tailscale", "trust"]);
+      expect(status).toBe(1);
+      expect(stderr).toContain("only available with the builtin provider");
+    });
+
+    it("fails with actionable message when tailscale is not installed", () => {
+      const { status, stderr } = run(["--provider", "tailscale", "myapp", "echo", "hello"], {
+        env: { PATH: "/tmp/portless-no-path" },
+      });
+      expect(status).toBe(1);
+      expect(stderr).toContain("Tailscale CLI not found");
     });
   });
 

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -9,7 +9,15 @@ import { spawn, spawnSync } from "node:child_process";
 import { createSNICallback, ensureCerts, isCATrusted, trustCA } from "./certs.js";
 import { createProxyServer } from "./proxy.js";
 import { fixOwnership, formatUrl, isErrnoException, parseHostname } from "./utils.js";
-import { FILE_MODE, RouteConflictError, RouteStore } from "./routes.js";
+import { DEFAULT_ROUTE_PROVIDER, FILE_MODE, RouteConflictError, RouteStore } from "./routes.js";
+import {
+  ensureTailscaleReady,
+  formatTailscaleUrl,
+  registerServePath,
+  tailscalePathFor,
+  unregisterServePath,
+} from "./tailscale.js";
+import type { RouteProvider } from "./types.js";
 import {
   PRIVILEGED_PORT_THRESHOLD,
   discoverState,
@@ -43,6 +51,57 @@ const EXIT_TIMEOUT_MS = 2000;
 /** Timeout (ms) for the sudo spawn when auto-starting the proxy. */
 const SUDO_SPAWN_TIMEOUT_MS = 30_000;
 
+/** Supported provider values for --provider / PORTLESS_PROVIDER. */
+const SUPPORTED_PROVIDERS: readonly RouteProvider[] = ["builtin", "tailscale"];
+
+function parseProvider(raw: string | undefined): RouteProvider | null {
+  if (!raw) return DEFAULT_ROUTE_PROVIDER;
+  if (raw === "builtin" || raw === "tailscale") return raw;
+  return null;
+}
+
+function parseGlobalProvider(args: string[]): {
+  provider: RouteProvider;
+  args: string[];
+  error?: string;
+} {
+  const index = args.indexOf("--provider");
+  if (index === -1) {
+    const provider = parseProvider(process.env.PORTLESS_PROVIDER);
+    if (!provider) {
+      return {
+        provider: DEFAULT_ROUTE_PROVIDER,
+        args,
+        error: `Invalid PORTLESS_PROVIDER value: ${process.env.PORTLESS_PROVIDER}`,
+      };
+    }
+    return { provider, args };
+  }
+
+  const value = args[index + 1];
+  if (!value || value.startsWith("-")) {
+    return {
+      provider: DEFAULT_ROUTE_PROVIDER,
+      args,
+      error: "Error: --provider requires one of: builtin, tailscale.",
+    };
+  }
+
+  const provider = parseProvider(value);
+  if (!provider) {
+    return {
+      provider: DEFAULT_ROUTE_PROVIDER,
+      args,
+      error: `Error: Invalid provider "${value}". Use one of: ${SUPPORTED_PROVIDERS.join(", ")}.`,
+    };
+  }
+
+  return {
+    provider,
+    args: [...args.slice(0, index), ...args.slice(index + 2)],
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Proxy server lifecycle
 // ---------------------------------------------------------------------------
@@ -69,14 +128,14 @@ function startProxyServer(
   fixOwnership(routesPath);
 
   // Cache routes in memory and reload on file change (debounced)
-  let cachedRoutes = store.loadRoutes();
+  let cachedRoutes = store.loadRoutes(false, "builtin");
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
   let watcher: fs.FSWatcher | null = null;
   let pollingInterval: ReturnType<typeof setInterval> | null = null;
 
   const reloadRoutes = () => {
     try {
-      cachedRoutes = store.loadRoutes();
+      cachedRoutes = store.loadRoutes(false, "builtin");
     } catch {
       // File may be mid-write; keep existing cached routes
     }
@@ -270,18 +329,34 @@ async function stopProxy(store: RouteStore, proxyPort: number, tls: boolean): Pr
   }
 }
 
-function listRoutes(store: RouteStore, proxyPort: number, tls: boolean): void {
-  const routes = store.loadRoutes();
+function listRoutes(
+  store: RouteStore,
+  proxyPort: number,
+  tls: boolean,
+  provider: RouteProvider
+): void {
+  const routes = store.loadRoutes(false, provider);
 
   if (routes.length === 0) {
     console.log(chalk.yellow("No active routes."));
-    console.log(chalk.gray("Start an app with: portless <name> <command>"));
+    console.log(
+      chalk.gray(
+        provider === "tailscale"
+          ? "Start an app with: portless --provider tailscale <name> <command>"
+          : "Start an app with: portless <name> <command>"
+      )
+    );
     return;
   }
 
   console.log(chalk.blue.bold("\nActive routes:\n"));
   for (const route of routes) {
-    const url = formatUrl(route.hostname, proxyPort, tls);
+    let url = formatUrl(route.hostname, proxyPort, tls);
+    if (provider === "tailscale") {
+      url = route.tailscaleBaseUrl
+        ? formatTailscaleUrl(route.tailscaleBaseUrl, route.hostname)
+        : `[unknown-tailnet-url]${tailscalePathFor(route.hostname)}`;
+    }
     console.log(
       `  ${chalk.cyan(url)}  ${chalk.gray("->")}  ${chalk.white(`localhost:${route.port}`)}  ${chalk.gray(`(pid ${route.pid})`)}`
     );
@@ -289,7 +364,7 @@ function listRoutes(store: RouteStore, proxyPort: number, tls: boolean): void {
   console.log();
 }
 
-async function runApp(
+async function runBuiltinApp(
   store: RouteStore,
   proxyPort: number,
   stateDir: string,
@@ -391,7 +466,7 @@ async function runApp(
 
   // Register route
   try {
-    store.addRoute(hostname, port, process.pid, force);
+    store.addRoute(hostname, port, process.pid, { force, provider: "builtin" });
   } catch (err) {
     if (err instanceof RouteConflictError) {
       console.error(chalk.red(`Error: ${err.message}`));
@@ -418,12 +493,119 @@ async function runApp(
     },
     onCleanup: () => {
       try {
-        store.removeRoute(hostname);
+        store.removeRoute(hostname, "builtin");
       } catch {
         // Lock acquisition may fail during cleanup; non-fatal
       }
     },
   });
+}
+
+async function runTailscaleApp(
+  store: RouteStore,
+  name: string,
+  commandArgs: string[],
+  force: boolean
+): Promise<void> {
+  const hostname = parseHostname(name);
+
+  console.log(chalk.blue.bold(`\nportless\n`));
+  console.log(chalk.gray(`-- ${hostname} (served via tailscale)`));
+
+  let baseUrl: string;
+  try {
+    const status = ensureTailscaleReady();
+    baseUrl = status.baseUrl;
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(chalk.red(`Error: ${message}`));
+    console.error(chalk.blue("If Tailscale is installed, make sure you're connected:"));
+    console.error(chalk.cyan("  tailscale up"));
+    process.exit(1);
+  }
+
+  const port = await findFreePort();
+  console.log(chalk.green(`-- Using port ${port}`));
+
+  try {
+    registerServePath(hostname, port, { force });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(chalk.red(`Error: ${message}`));
+    process.exit(1);
+  }
+
+  try {
+    store.addRoute(hostname, port, process.pid, {
+      force,
+      provider: "tailscale",
+      tailscalePath: tailscalePathFor(hostname),
+      tailscaleBaseUrl: baseUrl,
+      tailscaleHttpsPort: 443,
+    });
+  } catch (err) {
+    try {
+      unregisterServePath(hostname, { ignoreMissing: true });
+    } catch {
+      // Best-effort rollback if route persistence fails.
+    }
+    if (err instanceof RouteConflictError) {
+      console.error(chalk.red(`Error: ${err.message}`));
+      process.exit(1);
+    }
+    throw err;
+  }
+
+  const finalUrl = formatTailscaleUrl(baseUrl, hostname);
+  console.log(chalk.cyan.bold(`\n  -> ${finalUrl}\n`));
+
+  injectFrameworkFlags(commandArgs, port);
+
+  console.log(chalk.gray(`Running: PORT=${port} HOST=127.0.0.1 ${commandArgs.join(" ")}\n`));
+
+  spawnCommand(commandArgs, {
+    env: {
+      ...process.env,
+      PORT: port.toString(),
+      HOST: "127.0.0.1",
+      __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: ".localhost",
+    },
+    onCleanup: () => {
+      try {
+        unregisterServePath(hostname, { ignoreMissing: true });
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.warn(chalk.yellow(`Warning: ${message}`));
+        console.warn(
+          chalk.gray(
+            `Manual cleanup: tailscale serve --yes --https=443 --set-path=/${hostname} off`
+          )
+        );
+      }
+      try {
+        store.removeRoute(hostname, "tailscale");
+      } catch {
+        // Lock acquisition may fail during cleanup; non-fatal
+      }
+    },
+  });
+}
+
+async function runApp(
+  provider: RouteProvider,
+  store: RouteStore,
+  proxyPort: number,
+  stateDir: string,
+  name: string,
+  commandArgs: string[],
+  tls: boolean,
+  force: boolean
+): Promise<void> {
+  if (provider === "tailscale") {
+    await runTailscaleApp(store, name, commandArgs, force);
+    return;
+  }
+  await runBuiltinApp(store, proxyPort, stateDir, name, commandArgs, tls, force);
 }
 
 // ---------------------------------------------------------------------------
@@ -441,7 +623,19 @@ async function main() {
     });
   }
 
-  const args = process.argv.slice(2);
+  const rawArgs = process.argv.slice(2);
+  const providerResult = parseGlobalProvider(rawArgs);
+  if (providerResult.error) {
+    console.error(chalk.red(providerResult.error));
+    console.error(
+      chalk.gray(
+        `Valid providers: ${SUPPORTED_PROVIDERS.join(", ")} (default: ${DEFAULT_ROUTE_PROVIDER})`
+      )
+    );
+    process.exit(1);
+  }
+  const provider = providerResult.provider;
+  const args = providerResult.args;
 
   // Block npx / pnpm dlx -- portless should be installed globally, not run
   // via npx. Running "sudo npx" is unsafe because it performs package
@@ -457,7 +651,13 @@ async function main() {
 
   // Skip portless if PORTLESS=0 or PORTLESS=skip
   const skipPortless = process.env.PORTLESS === "0" || process.env.PORTLESS === "skip";
-  if (skipPortless && args.length >= 2 && args[0] !== "proxy") {
+  if (
+    skipPortless &&
+    args.length >= 2 &&
+    args[0] !== "proxy" &&
+    args[0] !== "list" &&
+    args[0] !== "trust"
+  ) {
     // Just run the command directly, skipping the first arg (the name)
     spawnCommand(args.slice(1));
     return;
@@ -480,16 +680,17 @@ ${chalk.bold("Usage:")}
   ${chalk.cyan("portless proxy start --https")}     Start with HTTP/2 + TLS (auto-generates certs)
   ${chalk.cyan("portless proxy start -p 80")}       Start on port 80 (requires sudo)
   ${chalk.cyan("portless proxy stop")}              Stop the proxy
-  ${chalk.cyan("portless <name> <cmd>")}            Run your app through the proxy
-  ${chalk.cyan("portless list")}                    Show active routes
-  ${chalk.cyan("portless trust")}                   Add local CA to system trust store
+  ${chalk.cyan("portless <name> <cmd>")}            Run your app with the builtin provider
+  ${chalk.cyan("portless --provider tailscale <name> <cmd>")}  Run your app via tailscale serve
+  ${chalk.cyan("portless list")}                    Show active routes for the active provider
+  ${chalk.cyan("portless trust")}                   Add local CA to system trust store (builtin only)
 
 ${chalk.bold("Examples:")}
   portless proxy start                # Start proxy on port 1355
   portless proxy start --https        # Start with HTTPS/2 (faster page loads)
   portless myapp next dev             # -> http://myapp.localhost:1355
-  portless myapp vite dev             # -> http://myapp.localhost:1355
-  portless api.myapp pnpm start       # -> http://api.myapp.localhost:1355
+  portless --provider tailscale myapp next dev  # -> https://<node>.<tailnet>.ts.net/myapp
+  portless api.myapp pnpm start       # -> http://api.myapp.localhost:1355 (builtin default)
 
 ${chalk.bold("In package.json:")}
   {
@@ -499,10 +700,10 @@ ${chalk.bold("In package.json:")}
   }
 
 ${chalk.bold("How it works:")}
-  1. Start the proxy once (listens on port 1355 by default, no sudo needed)
-  2. Run your apps - they auto-start the proxy and register automatically
-  3. Access via http://<name>.localhost:1355
-  4. .localhost domains auto-resolve to 127.0.0.1
+  1. Choose a provider: builtin (default) or tailscale
+  2. Builtin mode uses a local proxy on port 1355 and .localhost hostnames
+  3. Tailscale mode uses tailscale serve paths on your tailnet
+  4. Run apps with portless; each app gets a random local port automatically
   5. Frameworks that ignore PORT (Vite, Astro, React Router, Angular) get
      --port and --host flags injected automatically
 
@@ -512,6 +713,7 @@ ${chalk.bold("HTTP/2 + HTTPS:")}
   system trust store. No browser warnings. No sudo required on macOS.
 
 ${chalk.bold("Options:")}
+  --provider <builtin|tailscale>  Select routing provider (default: builtin)
   -p, --port <number>           Port for the proxy to listen on (default: 1355)
                                 Ports < 1024 require sudo
   --https                       Enable HTTP/2 + TLS with auto-generated certs
@@ -522,6 +724,7 @@ ${chalk.bold("Options:")}
   --force                       Override an existing route registered by another process
 
 ${chalk.bold("Environment variables:")}
+  PORTLESS_PROVIDER=<name>      Default provider (builtin or tailscale)
   PORTLESS_PORT=<number>        Override the default proxy port (e.g. in .bashrc)
   PORTLESS_HTTPS=1              Always enable HTTPS (set in .bashrc / .zshrc)
   PORTLESS_STATE_DIR=<path>     Override the state directory
@@ -541,6 +744,13 @@ ${chalk.bold("Skip portless:")}
 
   // Trust command
   if (args[0] === "trust") {
+    if (provider === "tailscale") {
+      console.error(
+        chalk.red("Error: `portless trust` is only available with the builtin provider.")
+      );
+      console.error(chalk.blue("Use the default provider or run without --provider tailscale."));
+      process.exit(1);
+    }
     const { dir } = await discoverState();
     const result = trustCA(dir);
     if (result.trusted) {
@@ -559,16 +769,33 @@ ${chalk.bold("Skip portless:")}
 
   // List routes
   if (args[0] === "list") {
-    const { dir, port, tls } = await discoverState();
-    const store = new RouteStore(dir, {
+    const defaultPort = getDefaultPort();
+    const state =
+      provider === "tailscale"
+        ? {
+            dir: process.env.PORTLESS_STATE_DIR ?? resolveStateDir(defaultPort),
+            port: defaultPort,
+            tls: false,
+          }
+        : await discoverState();
+    const store = new RouteStore(state.dir, {
       onWarning: (msg) => console.warn(chalk.yellow(msg)),
     });
-    listRoutes(store, port, tls);
+    listRoutes(store, state.port, state.tls, provider);
     return;
   }
 
   // Proxy commands
   if (args[0] === "proxy") {
+    if (provider === "tailscale") {
+      console.error(
+        chalk.red("Error: `portless proxy` commands are only available with the builtin provider.")
+      );
+      console.error(chalk.blue("Run app routes in tailscale mode instead:"));
+      console.error(chalk.cyan("  portless --provider tailscale <name> <command...>"));
+      process.exit(1);
+    }
+
     if (args[1] === "stop") {
       const { dir, port, tls } = await discoverState();
       const store = new RouteStore(dir, {
@@ -822,11 +1049,19 @@ ${chalk.bold("Usage: portless proxy <command>")}
     process.exit(1);
   }
 
-  const { dir, port, tls } = await discoverState();
-  const store = new RouteStore(dir, {
+  const defaultPort = getDefaultPort();
+  const state =
+    provider === "tailscale"
+      ? {
+          dir: process.env.PORTLESS_STATE_DIR ?? resolveStateDir(defaultPort),
+          port: defaultPort,
+          tls: false,
+        }
+      : await discoverState();
+  const store = new RouteStore(state.dir, {
     onWarning: (msg) => console.warn(chalk.yellow(msg)),
   });
-  await runApp(store, port, dir, name, commandArgs, tls, force);
+  await runApp(provider, store, state.port, state.dir, name, commandArgs, state.tls, force);
 }
 
 main().catch((err: unknown) => {

--- a/packages/portless/src/routes.test.ts
+++ b/packages/portless/src/routes.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import { RouteStore } from "./routes.js";
+import { getRouteProvider, RouteStore } from "./routes.js";
 
 describe("RouteStore", () => {
   let tmpDir: string;
@@ -89,6 +89,37 @@ describe("RouteStore", () => {
       expect(loaded).toHaveLength(1);
       expect(loaded[0].hostname).toBe("app.localhost");
       expect(loaded[0].port).toBe(4001);
+    });
+
+    it("defaults legacy routes without provider to builtin", () => {
+      const routes = [{ hostname: "legacy.localhost", port: 4010, pid: process.pid }];
+      store.ensureDir();
+      fs.writeFileSync(store.getRoutesPath(), JSON.stringify(routes));
+      const loaded = store.loadRoutes();
+      expect(loaded).toHaveLength(1);
+      expect(getRouteProvider(loaded[0])).toBe("builtin");
+    });
+
+    it("loads provider-aware tailscale route metadata", () => {
+      const routes = [
+        {
+          hostname: "api.localhost",
+          port: 4011,
+          pid: process.pid,
+          provider: "tailscale",
+          tailscalePath: "/api.localhost",
+          tailscaleBaseUrl: "https://devbox.example.ts.net",
+          tailscaleHttpsPort: 443,
+        },
+      ];
+      store.ensureDir();
+      fs.writeFileSync(store.getRoutesPath(), JSON.stringify(routes));
+      const loaded = store.loadRoutes();
+      expect(loaded).toHaveLength(1);
+      expect(getRouteProvider(loaded[0])).toBe("tailscale");
+      expect(loaded[0].tailscalePath).toBe("/api.localhost");
+      expect(loaded[0].tailscaleBaseUrl).toBe("https://devbox.example.ts.net");
+      expect(loaded[0].tailscaleHttpsPort).toBe(443);
     });
 
     it("filters out routes with dead PIDs", () => {
@@ -183,6 +214,19 @@ describe("RouteStore", () => {
       const hostnames = routes.map((r) => r.hostname).sort();
       expect(hostnames).toEqual(["app1.localhost", "app2.localhost"]);
     });
+
+    it("stores tailscale provider metadata", () => {
+      store.addRoute("api.localhost", 4003, process.pid, {
+        provider: "tailscale",
+        tailscalePath: "/api.localhost",
+        tailscaleBaseUrl: "https://devbox.example.ts.net",
+        tailscaleHttpsPort: 443,
+      });
+      const routes = store.loadRoutes(false, "tailscale");
+      expect(routes).toHaveLength(1);
+      expect(routes[0].provider).toBe("tailscale");
+      expect(routes[0].tailscalePath).toBe("/api.localhost");
+    });
   });
 
   describe("removeRoute", () => {
@@ -207,6 +251,17 @@ describe("RouteStore", () => {
       const routes = store.loadRoutes();
       expect(routes).toHaveLength(1);
       expect(routes[0].hostname).toBe("app2.localhost");
+    });
+
+    it("removes only the selected provider route", () => {
+      store.addRoute("same.localhost", 4012, process.pid);
+      store.addRoute("same.localhost", 4013, process.pid, { provider: "tailscale" });
+      store.removeRoute("same.localhost", "tailscale");
+      const builtin = store.loadRoutes(false, "builtin");
+      const tailscale = store.loadRoutes(false, "tailscale");
+      expect(builtin).toHaveLength(1);
+      expect(tailscale).toHaveLength(0);
+      expect(builtin[0].port).toBe(4012);
     });
   });
 

--- a/packages/portless/src/routes.ts
+++ b/packages/portless/src/routes.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { RouteInfo } from "./types.js";
+import type { RouteInfo, RouteProvider } from "./types.js";
 import { fixOwnership, isErrnoException } from "./utils.js";
 import { SYSTEM_STATE_DIR } from "./cli-utils.js";
 
@@ -25,19 +25,89 @@ export const SYSTEM_DIR_MODE = 0o1777;
 /** File permission mode for shared state files in the system state directory. */
 export const SYSTEM_FILE_MODE = 0o666;
 
+/** Default provider used by legacy route entries that don't store a provider. */
+export const DEFAULT_ROUTE_PROVIDER: RouteProvider = "builtin";
+
 export interface RouteMapping extends RouteInfo {
   pid: number;
 }
 
-/** Runtime check that a parsed JSON value is a valid RouteMapping. */
-function isValidRoute(value: unknown): value is RouteMapping {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    typeof (value as RouteMapping).hostname === "string" &&
-    typeof (value as RouteMapping).port === "number" &&
-    typeof (value as RouteMapping).pid === "number"
-  );
+export interface AddRouteOptions {
+  force?: boolean;
+  provider?: RouteProvider;
+  tailscalePath?: string;
+  tailscaleBaseUrl?: string;
+  tailscaleHttpsPort?: number;
+}
+
+function isRouteProvider(value: unknown): value is RouteProvider {
+  return value === "builtin" || value === "tailscale";
+}
+
+/** Return a route's provider, defaulting legacy records to builtin. */
+export function getRouteProvider(route: Pick<RouteMapping, "provider">): RouteProvider {
+  return route.provider ?? DEFAULT_ROUTE_PROVIDER;
+}
+
+/** Parse and validate a route JSON entry, including legacy builtin routes. */
+function parseRoute(value: unknown): RouteMapping | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+
+  const route = value as Partial<RouteMapping>;
+  if (
+    typeof route.hostname !== "string" ||
+    typeof route.port !== "number" ||
+    typeof route.pid !== "number"
+  ) {
+    return null;
+  }
+
+  if (route.provider !== undefined && !isRouteProvider(route.provider)) {
+    return null;
+  }
+
+  const normalized: RouteMapping = {
+    hostname: route.hostname,
+    port: route.port,
+    pid: route.pid,
+    ...(route.provider ? { provider: route.provider } : {}),
+  };
+
+  if (route.tailscalePath !== undefined) {
+    if (typeof route.tailscalePath !== "string") return null;
+    normalized.tailscalePath = route.tailscalePath;
+  }
+  if (route.tailscaleBaseUrl !== undefined) {
+    if (typeof route.tailscaleBaseUrl !== "string") return null;
+    normalized.tailscaleBaseUrl = route.tailscaleBaseUrl;
+  }
+  if (route.tailscaleHttpsPort !== undefined) {
+    if (typeof route.tailscaleHttpsPort !== "number") return null;
+    normalized.tailscaleHttpsPort = route.tailscaleHttpsPort;
+  }
+
+  return normalized;
+}
+
+function normalizeAddRouteOptions(options: boolean | AddRouteOptions): Required<AddRouteOptions> {
+  if (typeof options === "boolean") {
+    return {
+      force: options,
+      provider: DEFAULT_ROUTE_PROVIDER,
+      tailscalePath: "",
+      tailscaleBaseUrl: "",
+      tailscaleHttpsPort: 443,
+    };
+  }
+  return {
+    force: options.force ?? false,
+    provider: options.provider ?? DEFAULT_ROUTE_PROVIDER,
+    tailscalePath: options.tailscalePath ?? "",
+    tailscaleBaseUrl: options.tailscaleBaseUrl ?? "",
+    tailscaleHttpsPort: options.tailscaleHttpsPort ?? 443,
+  };
 }
 
 /**
@@ -172,7 +242,7 @@ export class RouteStore {
    * already holds the lock (i.e. inside addRoute/removeRoute) to avoid
    * unprotected concurrent writes.
    */
-  loadRoutes(persistCleanup = false): RouteMapping[] {
+  loadRoutes(persistCleanup = false, provider?: RouteProvider): RouteMapping[] {
     if (!fs.existsSync(this.routesPath)) {
       return [];
     }
@@ -189,7 +259,7 @@ export class RouteStore {
         this.onWarning?.(`Corrupted routes file (expected array): ${this.routesPath}`);
         return [];
       }
-      const routes: RouteMapping[] = parsed.filter(isValidRoute);
+      const routes: RouteMapping[] = parsed.map(parseRoute).filter((r): r is RouteMapping => !!r);
       // Filter out stale routes whose owning process is no longer alive
       const alive = routes.filter((r) => this.isProcessAlive(r.pid));
       if (persistCleanup && alive.length !== routes.length) {
@@ -203,7 +273,10 @@ export class RouteStore {
           // Write may fail (permissions); non-fatal
         }
       }
-      return alive;
+      if (!provider) {
+        return alive;
+      }
+      return alive.filter((r) => getRouteProvider(r) === provider);
     } catch {
       return [];
     }
@@ -214,32 +287,61 @@ export class RouteStore {
     fixOwnership(this.routesPath);
   }
 
-  addRoute(hostname: string, port: number, pid: number, force = false): void {
+  addRoute(
+    hostname: string,
+    port: number,
+    pid: number,
+    options: boolean | AddRouteOptions = false
+  ): void {
     this.ensureDir();
     if (!this.acquireLock()) {
       throw new Error("Failed to acquire route lock");
     }
     try {
+      const normalizedOptions = normalizeAddRouteOptions(options);
+      const provider = normalizedOptions.provider;
       const routes = this.loadRoutes(true);
-      const existing = routes.find((r) => r.hostname === hostname);
-      if (existing && existing.pid !== pid && this.isProcessAlive(existing.pid) && !force) {
+      const existing = routes.find(
+        (r) => r.hostname === hostname && getRouteProvider(r) === provider
+      );
+      if (
+        existing &&
+        existing.pid !== pid &&
+        this.isProcessAlive(existing.pid) &&
+        !normalizedOptions.force
+      ) {
         throw new RouteConflictError(hostname, existing.pid);
       }
-      const filtered = routes.filter((r) => r.hostname !== hostname);
-      filtered.push({ hostname, port, pid });
+      const filtered = routes.filter(
+        (r) => !(r.hostname === hostname && getRouteProvider(r) === provider)
+      );
+      const next: RouteMapping = {
+        hostname,
+        port,
+        pid,
+        ...(provider !== DEFAULT_ROUTE_PROVIDER ? { provider } : {}),
+      };
+      if (provider === "tailscale") {
+        next.tailscalePath = normalizedOptions.tailscalePath || `/${hostname}`;
+        next.tailscaleBaseUrl = normalizedOptions.tailscaleBaseUrl || "";
+        next.tailscaleHttpsPort = normalizedOptions.tailscaleHttpsPort;
+      }
+      filtered.push(next);
       this.saveRoutes(filtered);
     } finally {
       this.releaseLock();
     }
   }
 
-  removeRoute(hostname: string): void {
+  removeRoute(hostname: string, provider: RouteProvider = DEFAULT_ROUTE_PROVIDER): void {
     this.ensureDir();
     if (!this.acquireLock()) {
       throw new Error("Failed to acquire route lock");
     }
     try {
-      const routes = this.loadRoutes(true).filter((r) => r.hostname !== hostname);
+      const routes = this.loadRoutes(true).filter(
+        (r) => !(r.hostname === hostname && getRouteProvider(r) === provider)
+      );
       this.saveRoutes(routes);
     } finally {
       this.releaseLock();

--- a/packages/portless/src/tailscale.test.ts
+++ b/packages/portless/src/tailscale.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import {
+  ensureTailscaleReady,
+  formatTailscaleUrl,
+  registerServePath,
+  tailscalePathFor,
+  unregisterServePath,
+  type TailscaleCommandRunner,
+} from "./tailscale.js";
+
+interface MockResult {
+  status?: number | null;
+  stdout?: string;
+  stderr?: string;
+  error?: Error;
+}
+
+function createRunner(
+  results: Record<string, MockResult>,
+  calls: string[][] = []
+): TailscaleCommandRunner {
+  return (args: string[]) => {
+    calls.push(args);
+    const key = args.join(" ");
+    const result = results[key];
+    if (!result) {
+      throw new Error(`Unexpected tailscale call: ${key}`);
+    }
+    return {
+      status: result.status ?? 0,
+      stdout: result.stdout ?? "",
+      stderr: result.stderr ?? "",
+      ...(result.error ? { error: result.error } : {}),
+    };
+  };
+}
+
+describe("tailscale", () => {
+  it("resolves base URL from Self.DNSName", () => {
+    const runner = createRunner({
+      version: { status: 0 },
+      "status --json": {
+        status: 0,
+        stdout: JSON.stringify({
+          Self: {
+            DNSName: "devbox.example.ts.net.",
+          },
+        }),
+      },
+    });
+    const ready = ensureTailscaleReady(runner);
+    expect(ready.dnsName).toBe("devbox.example.ts.net");
+    expect(ready.baseUrl).toBe("https://devbox.example.ts.net");
+  });
+
+  it("falls back to HostName and MagicDNSSuffix", () => {
+    const runner = createRunner({
+      version: { status: 0 },
+      "status --json": {
+        status: 0,
+        stdout: JSON.stringify({
+          Self: { HostName: "devbox" },
+          CurrentTailnet: { MagicDNSSuffix: "example.ts.net." },
+        }),
+      },
+    });
+    const ready = ensureTailscaleReady(runner);
+    expect(ready.dnsName).toBe("devbox.example.ts.net");
+  });
+
+  it("shows install guidance when tailscale binary is missing", () => {
+    const enoent = Object.assign(new Error("spawn tailscale ENOENT"), { code: "ENOENT" });
+    const runner = createRunner({
+      version: { status: null, error: enoent },
+    });
+    expect(() => ensureTailscaleReady(runner)).toThrow("Tailscale CLI not found");
+  });
+
+  it("registers a serve path", () => {
+    const calls: string[][] = [];
+    const runner = createRunner(
+      {
+        "serve --bg --yes --https=443 --set-path=/myapp http://127.0.0.1:4123": { status: 0 },
+      },
+      calls
+    );
+    registerServePath("myapp", 4123, { runner });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual([
+      "serve",
+      "--bg",
+      "--yes",
+      "--https=443",
+      "--set-path=/myapp",
+      "http://127.0.0.1:4123",
+    ]);
+  });
+
+  it("registers with --force by clearing old path first", () => {
+    const calls: string[][] = [];
+    const runner = createRunner(
+      {
+        "serve --yes --https=443 --set-path=/myapp off": {
+          status: 1,
+          stderr: "path not found",
+        },
+        "serve --bg --yes --https=443 --set-path=/myapp http://127.0.0.1:4123": { status: 0 },
+      },
+      calls
+    );
+    registerServePath("myapp", 4123, { force: true, runner });
+    expect(calls).toHaveLength(2);
+    expect(calls[0][calls[0].length - 1]).toBe("off");
+    expect(calls[1][calls[1].length - 1]).toBe("http://127.0.0.1:4123");
+  });
+
+  it("throws a force hint on conflict", () => {
+    const runner = createRunner({
+      "serve --bg --yes --https=443 --set-path=/myapp http://127.0.0.1:4123": {
+        status: 1,
+        stderr: "path already exists",
+      },
+    });
+    expect(() => registerServePath("myapp", 4123, { runner })).toThrow("Re-run with --force");
+  });
+
+  it("removes a serve path", () => {
+    const runner = createRunner({
+      "serve --yes --https=443 --set-path=/myapp off": { status: 0 },
+    });
+    expect(() => unregisterServePath("myapp", { runner })).not.toThrow();
+  });
+
+  it("ignores missing path errors when requested", () => {
+    const runner = createRunner({
+      "serve --yes --https=443 --set-path=/myapp off": {
+        status: 1,
+        stderr: "path does not exist",
+      },
+    });
+    expect(() => unregisterServePath("myapp", { ignoreMissing: true, runner })).not.toThrow();
+  });
+
+  it("builds canonical tailscale URLs", () => {
+    expect(tailscalePathFor("myapp")).toBe("/myapp");
+    expect(formatTailscaleUrl("https://devbox.example.ts.net", "myapp")).toBe(
+      "https://devbox.example.ts.net/myapp"
+    );
+  });
+});

--- a/packages/portless/src/tailscale.ts
+++ b/packages/portless/src/tailscale.ts
@@ -1,0 +1,219 @@
+import { spawnSync } from "node:child_process";
+
+const TAILSCALE_BINARY = "tailscale";
+const TAILSCALE_HTTPS_PORT = 443;
+
+interface TailscaleCommandResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  error?: Error;
+}
+
+export type TailscaleCommandRunner = (args: string[]) => TailscaleCommandResult;
+
+interface TailscaleStatusJson {
+  Self?: {
+    DNSName?: string;
+    HostName?: string;
+  };
+  CurrentTailnet?: {
+    MagicDNSSuffix?: string;
+  };
+}
+
+function defaultRunner(args: string[]): TailscaleCommandResult {
+  const result = spawnSync(TAILSCALE_BINARY, args, {
+    encoding: "utf-8",
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    ...(result.error ? { error: result.error } : {}),
+  };
+}
+
+function trimDot(value: string): string {
+  return value.endsWith(".") ? value.slice(0, -1) : value;
+}
+
+function normalizeSpace(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+function runOrThrow(
+  args: string[],
+  action: string,
+  runner: TailscaleCommandRunner = defaultRunner
+): TailscaleCommandResult {
+  const result = runner(args);
+  if (result.error) {
+    const errno = result.error as NodeJS.ErrnoException;
+    if (errno.code === "ENOENT") {
+      throw new Error(
+        "Tailscale CLI not found. Install Tailscale and ensure `tailscale` is on PATH."
+      );
+    }
+    throw new Error(`Failed to ${action}: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const details = normalizeSpace(result.stderr || result.stdout);
+    throw new Error(`Failed to ${action}: ${details || "unknown tailscale error"}`);
+  }
+  return result;
+}
+
+function parseStatusJson(raw: string): TailscaleStatusJson {
+  try {
+    return JSON.parse(raw) as TailscaleStatusJson;
+  } catch {
+    throw new Error("Failed to parse `tailscale status --json` output.");
+  }
+}
+
+function statusToDnsName(status: TailscaleStatusJson): string {
+  const dnsName = status.Self?.DNSName;
+  if (typeof dnsName === "string" && dnsName.length > 0) {
+    return trimDot(dnsName);
+  }
+
+  const host = status.Self?.HostName;
+  const suffix = status.CurrentTailnet?.MagicDNSSuffix;
+  if (
+    typeof host === "string" &&
+    host.length > 0 &&
+    typeof suffix === "string" &&
+    suffix.length > 0
+  ) {
+    return `${host}.${trimDot(suffix)}`;
+  }
+
+  throw new Error("Could not determine Tailscale node DNS name from `tailscale status --json`.");
+}
+
+export function ensureTailscaleReady(runner: TailscaleCommandRunner = defaultRunner): {
+  baseUrl: string;
+  dnsName: string;
+} {
+  runOrThrow(["version"], "check tailscale version", runner);
+  const statusResult = runOrThrow(["status", "--json"], "read tailscale status", runner);
+  const status = parseStatusJson(statusResult.stdout);
+  const dnsName = statusToDnsName(status);
+  return {
+    dnsName,
+    baseUrl: `https://${dnsName}`,
+  };
+}
+
+function isLikelyMissingPathError(stderr: string, stdout: string): boolean {
+  const text = `${stderr}\n${stdout}`.toLowerCase();
+  return (
+    text.includes("not found") ||
+    text.includes("no serve config") ||
+    text.includes("nothing to remove") ||
+    text.includes("does not exist")
+  );
+}
+
+function isPathConflictError(stderr: string, stdout: string): boolean {
+  const text = `${stderr}\n${stdout}`.toLowerCase();
+  return (
+    text.includes("already") ||
+    text.includes("exists") ||
+    text.includes("conflict") ||
+    text.includes("in use")
+  );
+}
+
+export function tailscalePathFor(hostname: string): string {
+  return `/${hostname}`;
+}
+
+export function formatTailscaleUrl(baseUrl: string, hostname: string): string {
+  const trimmed = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
+  return `${trimmed}${tailscalePathFor(hostname)}`;
+}
+
+export function unregisterServePath(
+  hostname: string,
+  options?: {
+    ignoreMissing?: boolean;
+    runner?: TailscaleCommandRunner;
+  }
+): void {
+  const runner = options?.runner ?? defaultRunner;
+  const path = tailscalePathFor(hostname);
+  const result = runner([
+    "serve",
+    "--yes",
+    `--https=${TAILSCALE_HTTPS_PORT}`,
+    `--set-path=${path}`,
+    "off",
+  ]);
+  if (result.error) {
+    const errno = result.error as NodeJS.ErrnoException;
+    if (errno.code === "ENOENT") {
+      throw new Error(
+        "Tailscale CLI not found. Install Tailscale and ensure `tailscale` is on PATH."
+      );
+    }
+    throw new Error(`Failed to remove Tailscale path ${path}: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    if (options?.ignoreMissing && isLikelyMissingPathError(result.stderr, result.stdout)) {
+      return;
+    }
+    const details = normalizeSpace(result.stderr || result.stdout);
+    throw new Error(
+      `Failed to remove Tailscale path ${path}: ${details || "unknown tailscale error"}`
+    );
+  }
+}
+
+export function registerServePath(
+  hostname: string,
+  port: number,
+  options?: {
+    force?: boolean;
+    runner?: TailscaleCommandRunner;
+  }
+): void {
+  const runner = options?.runner ?? defaultRunner;
+  const path = tailscalePathFor(hostname);
+
+  if (options?.force) {
+    unregisterServePath(hostname, { ignoreMissing: true, runner });
+  }
+
+  const target = `http://127.0.0.1:${port}`;
+  const result = runner([
+    "serve",
+    "--bg",
+    "--yes",
+    `--https=${TAILSCALE_HTTPS_PORT}`,
+    `--set-path=${path}`,
+    target,
+  ]);
+
+  if (result.error) {
+    const errno = result.error as NodeJS.ErrnoException;
+    if (errno.code === "ENOENT") {
+      throw new Error(
+        "Tailscale CLI not found. Install Tailscale and ensure `tailscale` is on PATH."
+      );
+    }
+    throw new Error(`Failed to add Tailscale path ${path}: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    if (!options?.force && isPathConflictError(result.stderr, result.stdout)) {
+      throw new Error(
+        `Tailscale path ${path} is already configured. Re-run with --force to replace it.`
+      );
+    }
+    const details = normalizeSpace(result.stderr || result.stdout);
+    throw new Error(
+      `Failed to add Tailscale path ${path}: ${details || "unknown tailscale error"}`
+    );
+  }
+}

--- a/packages/portless/src/types.ts
+++ b/packages/portless/src/types.ts
@@ -1,7 +1,14 @@
+/** Supported routing backends. */
+export type RouteProvider = "builtin" | "tailscale";
+
 /** Route info used by the proxy server to map hostnames to ports. */
 export interface RouteInfo {
   hostname: string;
   port: number;
+  provider?: RouteProvider;
+  tailscalePath?: string;
+  tailscaleBaseUrl?: string;
+  tailscaleHttpsPort?: number;
 }
 
 export interface ProxyServerOptions {

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -38,12 +38,16 @@ npm install -g portless
 # Start the proxy (once, no sudo needed)
 portless proxy start
 
-# Run your app (auto-starts the proxy if needed)
+# Run your app (builtin provider, auto-starts the proxy if needed)
 portless myapp next dev
 # -> http://myapp.localhost:1355
+
+# Run your app with tailscale serve
+portless --provider tailscale myapp next dev
+# -> https://<node>.<tailnet>.ts.net/myapp
 ```
 
-The proxy auto-starts when you run an app. You can also start it explicitly with `portless proxy start`.
+Builtin mode auto-starts the proxy when you run an app. Tailscale mode requires `tailscale` to be installed and connected.
 
 ## Integration Patterns
 
@@ -52,12 +56,13 @@ The proxy auto-starts when you run an app. You can also start it explicitly with
 ```json
 {
   "scripts": {
-    "dev": "portless myapp next dev"
+    "dev": "portless myapp next dev",
+    "dev:tailnet": "portless --provider tailscale myapp next dev"
   }
 }
 ```
 
-The proxy auto-starts when you run an app. Or start it explicitly: `portless proxy start`.
+Builtin mode auto-starts the proxy when you run an app. Or start it explicitly: `portless proxy start`.
 
 ### Multi-app setups with subdomains
 
@@ -85,6 +90,13 @@ PORTLESS=0 pnpm dev   # Bypasses proxy, uses default port
 
 Most frameworks (Next.js, Express, Nuxt, etc.) respect the `PORT` env var automatically. For frameworks that ignore `PORT` (Vite, Astro, React Router, Angular), portless auto-injects the correct `--port` and `--host` CLI flags.
 
+Tailscale mode uses `tailscale serve` with path mounts:
+
+1. Run with `--provider tailscale`
+2. Portless starts your app on a random local port
+3. Portless registers `/<name>` on your node's tailnet URL
+4. Portless removes the mapping when the app exits
+
 ### State directory
 
 Portless stores its state (routes, PID file, port file) in a directory that depends on the proxy port:
@@ -98,6 +110,7 @@ Override with the `PORTLESS_STATE_DIR` environment variable.
 
 | Variable             | Description                                     |
 | -------------------- | ----------------------------------------------- |
+| `PORTLESS_PROVIDER`  | Set provider (`builtin` or `tailscale`)         |
 | `PORTLESS_PORT`      | Override the default proxy port (default: 1355) |
 | `PORTLESS_HTTPS`     | Set to `1` to always enable HTTPS/HTTP/2        |
 | `PORTLESS_STATE_DIR` | Override the state directory                    |
@@ -117,19 +130,20 @@ First run generates a local CA and prompts for sudo to add it to the system trus
 
 ## CLI Reference
 
-| Command                             | Description                                                   |
-| ----------------------------------- | ------------------------------------------------------------- |
-| `portless <name> <cmd> [args...]`   | Run app at `http://<name>.localhost:1355` (auto-starts proxy) |
-| `portless list`                     | Show active routes                                            |
-| `portless trust`                    | Add local CA to system trust store (for HTTPS)                |
-| `portless proxy start`              | Start the proxy as a daemon (port 1355, no sudo)              |
-| `portless proxy start --https`      | Start with HTTP/2 + TLS (auto-generates certs)                |
-| `portless proxy start -p <number>`  | Start the proxy on a custom port                              |
-| `portless proxy start --foreground` | Start the proxy in foreground (for debugging)                 |
-| `portless proxy stop`               | Stop the proxy                                                |
-| `portless <name> --force <cmd>`     | Override an existing route registered by another process      |
-| `portless --help` / `-h`            | Show help                                                     |
-| `portless --version` / `-v`         | Show version                                                  |
+| Command                                                | Description                                                        |
+| ------------------------------------------------------ | ------------------------------------------------------------------ |
+| `portless <name> <cmd> [args...]`                      | Run app with builtin provider at `http://<name>.localhost:1355`    |
+| `portless --provider tailscale <name> <cmd> [args...]` | Run app with tailscale at `https://<node>.<tailnet>.ts.net/<name>` |
+| `portless list`                                        | Show active routes for the selected provider                       |
+| `portless trust`                                       | Add local CA to system trust store (builtin HTTPS only)            |
+| `portless proxy start`                                 | Start the proxy as a daemon (port 1355, no sudo)                   |
+| `portless proxy start --https`                         | Start with HTTP/2 + TLS (auto-generates certs)                     |
+| `portless proxy start -p <number>`                     | Start the proxy on a custom port                                   |
+| `portless proxy start --foreground`                    | Start the proxy in foreground (for debugging)                      |
+| `portless proxy stop`                                  | Stop the proxy                                                     |
+| `portless <name> --force <cmd>`                        | Override an existing route registered by another process           |
+| `portless --help` / `-h`                               | Show help                                                          |
+| `portless --version` / `-v`                            | Show version                                                       |
 
 ## Troubleshooting
 
@@ -140,6 +154,17 @@ The proxy auto-starts when you run an app with `portless <name> <cmd>`. If it do
 ```bash
 portless proxy start
 ```
+
+### Tailscale command fails
+
+If you run with `--provider tailscale` and see setup errors:
+
+```bash
+tailscale status
+tailscale up
+```
+
+`portless proxy start/stop` and `portless trust` are builtin-only commands.
 
 ### Port already in use
 
@@ -200,3 +225,4 @@ proxy: {
 - Node.js 20+
 - macOS or Linux
 - `openssl` (for `--https` cert generation; ships with macOS and most Linux distributions)
+- `tailscale` CLI (optional, for `--provider tailscale`)


### PR DESCRIPTION
## Summary

Add provider-based routing with a new `tailscale` mode using `tailscale serve` path mounts.

- Default remains `builtin`
- New provider controls:
  - `--provider <builtin|tailscale>`
  - `PORTLESS_PROVIDER=<builtin|tailscale>`

Closes #66.

## What changed

### CLI and behavior
- Added global provider parsing and validation
- Added tailscale app flow:
  - readiness checks (`tailscale version`, `tailscale status --json`)
  - register `/<name>` path on app start
  - cleanup path on app exit
- `portless list` now filters by active provider
- `portless proxy ...` and `portless trust` are builtin-only in tailscale mode

### Route state
- Extended route records with optional provider metadata
- Kept backward compatibility for legacy route entries (default provider remains builtin)

### Docs/help updates
- Updated `README.md`
- Updated `skills/portless/SKILL.md`
- Updated CLI `--help` output in `packages/portless/src/cli.ts`

### Tests
- Added `packages/portless/src/tailscale.test.ts`
- Expanded `packages/portless/src/cli.test.ts`
- Expanded `packages/portless/src/routes.test.ts`

## Validation

- `pnpm --filter portless test`

## Notes

- Tailscale mode is tailnet-only in this release (no Funnel support)
- Prior plan context: #7 (closed, plan-only)
