### PR TITLE
feat: support wildcard subdomain routing

### DIFF
--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -105,7 +105,7 @@ describe("createProxyServer", () => {
 
       const res = await request(server, { host: "other.localhost" });
       expect(res.status).toBe(404);
-      expect(res.body).toContain("Active apps:");
+      expect(res.body).toContain("Active apps");
       expect(res.body).toContain("myapp.localhost");
       expect(res.body).toContain("api.localhost");
     });
@@ -151,6 +151,74 @@ describe("createProxyServer", () => {
       const res = await request(server, { host: "myapp.localhost" });
       expect(res.status).toBe(200);
       expect(res.body).toBe("hello from backend");
+    });
+
+    it("routes wildcard subdomain to matching parent route", async () => {
+      const backend = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("wildcard hit");
+        })
+      );
+      await listen(backend);
+      const backendAddr = backend.address();
+      if (!backendAddr || typeof backendAddr === "string") throw new Error("no addr");
+
+      const routes: RouteInfo[] = [{ hostname: "myapp.localhost", port: backendAddr.port }];
+      const server = trackServer(
+        createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "tenant.myapp.localhost" });
+      expect(res.status).toBe(200);
+      expect(res.body).toBe("wildcard hit");
+    });
+
+    it("prefers exact match over wildcard subdomain match", async () => {
+      const exactBackend = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("exact");
+        })
+      );
+      await listen(exactBackend);
+      const exactAddr = exactBackend.address();
+      if (!exactAddr || typeof exactAddr === "string") throw new Error("no addr");
+
+      const wildcardBackend = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("wildcard");
+        })
+      );
+      await listen(wildcardBackend);
+      const wildcardAddr = wildcardBackend.address();
+      if (!wildcardAddr || typeof wildcardAddr === "string") throw new Error("no addr");
+
+      const routes: RouteInfo[] = [
+        { hostname: "tenant.myapp.localhost", port: exactAddr.port },
+        { hostname: "myapp.localhost", port: wildcardAddr.port },
+      ];
+      const server = trackServer(
+        createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "tenant.myapp.localhost" });
+      expect(res.status).toBe(200);
+      expect(res.body).toBe("exact");
+    });
+
+    it("returns 404 when subdomain does not match any route", async () => {
+      const routes: RouteInfo[] = [{ hostname: "myapp.localhost", port: 4001 }];
+      const server = trackServer(
+        createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "other.localhost" });
+      expect(res.status).toBe(404);
     });
 
     it("strips port from Host header for matching", async () => {

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -275,6 +275,20 @@ ${body}
 </html>`;
 }
 
+/**
+ * Find the route matching a given host. Matches exact hostname first, then
+ * falls back to wildcard subdomain matching (e.g. tenant.myapp.localhost
+ * matches a route registered for myapp.localhost).
+ */
+function findRoute(
+  routes: { hostname: string; port: number }[],
+  host: string
+): { hostname: string; port: number } | undefined {
+  return (
+    routes.find((r) => r.hostname === host) || routes.find((r) => host.endsWith("." + r.hostname))
+  );
+}
+
 /** Server type returned by createProxyServer (plain HTTP/1.1 or net.Server TLS wrapper). */
 export type ProxyServer = http.Server | net.Server;
 
@@ -329,7 +343,7 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
       return;
     }
 
-    const route = routes.find((r) => r.hostname === host);
+    const route = findRoute(routes, host);
 
     if (!route) {
       const safeHost = escapeHtml(host);
@@ -444,7 +458,7 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
 
     const routes = getRoutes();
     const host = getRequestHost(req).split(":")[0];
-    const route = routes.find((r) => r.hostname === host);
+    const route = findRoute(routes, host);
 
     if (!route) {
       socket.destroy();


### PR DESCRIPTION
## Summary

- Add wildcard subdomain matching to the proxy so that `tenant.myapp.localhost` routes to the app registered as `myapp.localhost`
- Exact hostname matches still take priority over wildcard matches
- Both HTTP and WebSocket upgrade handlers use the same `findRoute` helper

Closes #37