### PR TITLE
v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.5.0
+
+### Features
+
+- **`portless run` subcommand**: Automatically infer the project name from `package.json`, git root, or directory name instead of specifying it manually. (#55)
+- **`portless alias` command**: Register routes for services not spawned by portless (e.g. Docker containers with published ports). Aliases persist across stale-route cleanup. (#73)
+- **`PORTLESS_URL` env var**: Child processes now receive `PORTLESS_URL` containing the public `.localhost` URL (e.g. `http://myapp.localhost:1355`) so apps can self-reference their own URL. (#56)
+- **`--app-port` flag**: Specify a fixed port for the app instead of automatic assignment. Also configurable via `PORTLESS_APP_PORT` env var. Useful when integrating with tools that provide their own port. (#72)
+- **wildcard subdomain routing**: Subdomains now match registered hostnames (e.g. `tenant.myapp.localhost` matches `myapp.localhost`). Exact matches take priority over wildcard matches. (#71)
+- **`/etc/hosts` sync**: Automatically sync `.localhost` hostnames to `/etc/hosts` for environments where `.localhost` does not resolve to `127.0.0.1` by default. (#74)
+- **multi-distro Linux CA trust**: `portless trust` now supports Arch, Fedora/RHEL/CentOS, and openSUSE in addition to Debian/Ubuntu. Falls back to command probing when `/etc/os-release` detection fails. (#45)
+- **Expo and React Native support**: Auto-inject `--port` and `--host` flags for `expo start` and `react-native start`. (#42)
+- **branded error and status pages**: The proxy now renders styled HTML pages for 404, 502, 508, and other status codes instead of plain text. (#70)
+
+### Bug Fixes
+
+- **stream errors**: Handle proxy stream errors gracefully to prevent unhandled exceptions from crashing the proxy. (#57)
+
 ## 0.4.2
 
 ### Bug Fixes

--- a/apps/docs/src/app/changelog/page.mdx
+++ b/apps/docs/src/app/changelog/page.mdx
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.5.0
+
+### Features
+
+- **`portless run` subcommand** -- Automatically infer the project name from `package.json`, git root, or directory name instead of specifying it manually
+- **`portless alias` command** -- Register routes for services not spawned by portless (e.g. Docker containers with published ports)
+- **`PORTLESS_URL` env var** -- Child processes receive `PORTLESS_URL` containing the public `.localhost` URL so apps can self-reference their own URL
+- **`--app-port` flag** -- Specify a fixed port for the app instead of automatic assignment, also configurable via `PORTLESS_APP_PORT` env var
+- **Wildcard subdomain routing** -- Subdomains now match registered hostnames (e.g. `tenant.myapp.localhost` routes to `myapp.localhost`). Exact matches take priority
+- **`/etc/hosts` sync** -- Automatically sync `.localhost` hostnames to `/etc/hosts` for environments where `.localhost` does not resolve to `127.0.0.1`
+- **Multi-distro Linux CA trust** -- `portless trust` now supports Arch, Fedora/RHEL/CentOS, and openSUSE in addition to Debian/Ubuntu
+- **Expo and React Native support** -- Auto-inject `--port` and `--host` flags for `expo start` and `react-native start`
+- **Branded error and status pages** -- The proxy renders styled HTML pages for 404, 502, 508, and other status codes
+
+### Bug Fixes
+
+- **Stream errors** -- Handle proxy stream errors gracefully to prevent unhandled exceptions from crashing the proxy
+
 ## 0.4.2
 
 ### Bug Fixes

--- a/packages/portless/package.json
+++ b/packages/portless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portless",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Replace port numbers with stable, named .localhost URLs. For humans and agents.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- `portless run` subcommand with automatic project name inference
- `portless alias` for static route registration (e.g. Docker containers)
- `PORTLESS_URL` env var injected into child processes
- `--app-port` flag and `PORTLESS_APP_PORT` env var
- Wildcard subdomain routing
- `/etc/hosts` sync for environments where `.localhost` does not resolve
- Multi-distro Linux CA trust (Arch, Fedora, openSUSE)
- Expo and React Native framework support
- Branded HTML error/status pages
- Fix: handle proxy stream errors gracefully

Full changelog in `CHANGELOG.md`.