### PR TITLE
fix: add README and homepage for npm package

### DIFF
--- a/packages/portless/.gitignore
+++ b/packages/portless/.gitignore
@@ -1,0 +1,1 @@
+README.md

--- a/packages/portless/package.json
+++ b/packages/portless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portless",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Replace port numbers with stable, named .localhost URLs. For humans and agents.",
   "type": "module",
   "main": "./dist/index.js",
@@ -29,7 +29,7 @@
     "dev": "tsup --watch",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
-    "prepublishOnly": "pnpm build",
+    "prepublishOnly": "cp ../../README.md . && pnpm build",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
@@ -47,7 +47,7 @@
     "type": "git",
     "url": "https://github.com/vercel-labs/portless.git"
   },
-  "homepage": "https://github.com/vercel-labs/portless#readme",
+  "homepage": "https://port1355.dev",
   "bugs": {
     "url": "https://github.com/vercel-labs/portless/issues"
   },


### PR DESCRIPTION
## Summary

- Copy root `README.md` into the package at publish time (`prepublishOnly`) so it appears on npmjs.com
- Update `homepage` to `https://port1355.dev`
- Add `.gitignore` in `packages/portless/` to exclude the copied README from version control

Published as `portless@0.5.1`.