### PR TITLE
docs: add git worktree documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Features
 
-- **`portless run` subcommand**: Automatically infer the project name from `package.json`, git root, or directory name instead of specifying it manually. (#55)
+- **`portless run` subcommand**: Automatically infer the project name from `package.json`, git root, or directory name instead of specifying it manually. In git worktrees, the branch name is prepended as a subdomain prefix (e.g. `fix-ui.myapp.localhost`) so each worktree gets a unique URL with no config changes. (#55, #68)
 - **`portless alias` command**: Register routes for services not spawned by portless (e.g. Docker containers with published ports). Aliases persist across stale-route cleanup. (#73)
 - **`PORTLESS_URL` env var**: Child processes now receive `PORTLESS_URL` containing the public `.localhost` URL (e.g. `http://myapp.localhost:1355`) so apps can self-reference their own URL. (#56)
 - **`--app-port` flag**: Specify a fixed port for the app instead of automatic assignment. Also configurable via `PORTLESS_APP_PORT` env var. Useful when integrating with tools that provide their own port. (#72)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,26 @@ portless docs.myapp next dev
 #   tenant2.myapp.localhost:1355  -> myapp
 ```
 
+### Git Worktrees
+
+`portless run` automatically detects git worktrees. When you're in a linked worktree, the branch name is prepended as a subdomain so each worktree gets its own URL without any config changes:
+
+```bash
+# Main worktree (main/master branch) -- no prefix, works normally
+portless run next dev
+# -> http://myapp.localhost:1355
+
+# Linked worktree on branch "fix-ui" -- branch name becomes a prefix
+portless run next dev
+# -> http://fix-ui.myapp.localhost:1355
+
+# Linked worktree on branch "feature/auth" -- uses last segment
+portless run next dev
+# -> http://auth.myapp.localhost:1355
+```
+
+This means you can put `portless run` in your `package.json` once and it just works everywhere -- the main checkout uses the plain name, and each worktree gets a unique subdomain. No `--force` needed, no name collisions.
+
 ### In package.json
 
 ```json

--- a/apps/docs/src/app/changelog/page.mdx
+++ b/apps/docs/src/app/changelog/page.mdx
@@ -11,7 +11,7 @@
 
 ### Features
 
-- **`portless run` subcommand** -- Automatically infer the project name from `package.json`, git root, or directory name instead of specifying it manually
+- **`portless run` subcommand** -- Automatically infer the project name from `package.json`, git root, or directory name instead of specifying it manually. In git worktrees, the branch name is prepended as a subdomain prefix (e.g. `fix-ui.myapp.localhost`) so each worktree gets a unique URL with no config changes
 - **`portless alias` command** -- Register routes for services not spawned by portless (e.g. Docker containers with published ports)
 - **`PORTLESS_URL` env var** -- Child processes receive `PORTLESS_URL` containing the public `.localhost` URL so apps can self-reference their own URL
 - **`--app-port` flag** -- Specify a fixed port for the app instead of automatic assignment, also configurable via `PORTLESS_APP_PORT` env var

--- a/apps/docs/src/app/page.mdx
+++ b/apps/docs/src/app/page.mdx
@@ -46,6 +46,20 @@ portless docs.myapp next dev
 # -> http://docs.myapp.localhost:1355
 ```
 
+## Git Worktrees
+
+`portless run` automatically detects git worktrees. In a linked worktree, the branch name is prepended as a subdomain so each worktree gets its own URL without any config changes:
+
+```bash
+# Main worktree -- no prefix
+portless run next dev   # -> http://myapp.localhost:1355
+
+# Linked worktree on branch "fix-ui"
+portless run next dev   # -> http://fix-ui.myapp.localhost:1355
+```
+
+Put `portless run` in your `package.json` once and it works everywhere -- the main checkout uses the plain name, each worktree gets a unique subdomain. No collisions, no `--force`.
+
 ## How it works
 
 Portless runs a reverse proxy on port 1355. Each app registers a route mapping its hostname to an assigned port. Requests to `http://<name>.localhost:1355` are proxied to the app.

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -73,6 +73,20 @@ portless docs.myapp next dev     # http://docs.myapp.localhost:1355
 
 Wildcard subdomain routing: any subdomain of a registered route routes to that app automatically (e.g. `tenant1.myapp.localhost:1355` routes to the `myapp` app without extra registration). Exact matches take priority over wildcards.
 
+### Git worktrees
+
+`portless run` automatically detects git worktrees. In a linked worktree, the branch name is prepended as a subdomain prefix so each worktree gets a unique URL:
+
+```bash
+# Main worktree -- no prefix
+portless run next dev   # -> http://myapp.localhost:1355
+
+# Linked worktree on branch "fix-ui"
+portless run next dev   # -> http://fix-ui.myapp.localhost:1355
+```
+
+No config changes needed. Put `portless run` in `package.json` once and it works in all worktrees.
+
 ### Bypassing portless
 
 Set `PORTLESS=0` or `PORTLESS=skip` to run the command directly without the proxy:


### PR DESCRIPTION
## Summary

- Document automatic worktree detection in `portless run` -- branch name is prepended as a subdomain prefix (e.g. `fix-ui.myapp.localhost`) so each worktree gets a unique URL with no config changes
- Added worktree section to README, SKILL.md, and docs site Getting Started page
- Updated 0.5.0 changelog entry to mention worktree support (closes #68)

Addresses #68 documentation gap.