### PR TITLE
feat(docs): add copy button to code blocks

### DIFF
--- a/apps/docs/next-env.d.ts
+++ b/apps/docs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -20,6 +20,7 @@
     "clsx": "^2.1.1",
     "geist": "^1.7.0",
     "just-bash": "^2.10.2",
+    "lucide-react": "^0.577.0",
     "next": "^16.1.6",
     "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",

--- a/apps/docs/src/components/code-block.tsx
+++ b/apps/docs/src/components/code-block.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState, useRef, isValidElement } from "react";
+import { Check, Copy } from "lucide-react";
+
+interface CodeBlockProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function CodeBlock({ children, className }: CodeBlockProps) {
+  const [copied, setCopied] = useState(false);
+  const preRef = useRef<HTMLPreElement>(null);
+
+  const handleCopy = async () => {
+    // Extract text content from the code block
+    const codeElement = preRef.current?.querySelector("code");
+    const text = codeElement?.textContent || "";
+
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error("Failed to copy:", err);
+    }
+  };
+
+  // Check if this is an actual code block (not inline code)
+  const hasCodeChild =
+    isValidElement(children) &&
+    typeof children.props === "object" &&
+    children.props !== null &&
+    "className" in children.props &&
+    typeof children.props.className === "string" &&
+    children.props.className.includes("language-");
+
+  if (!hasCodeChild) {
+    // Regular pre block without syntax highlighting
+    return (
+      <pre
+        className={`mb-4 overflow-x-auto rounded-lg border border-neutral-200 bg-neutral-50 p-4 text-[13px] leading-relaxed dark:border-neutral-800 dark:bg-neutral-900 ${className || ""}`}
+      >
+        {children}
+      </pre>
+    );
+  }
+
+  return (
+    <div className="group relative mb-4">
+      <pre
+        ref={preRef}
+        className={`overflow-x-auto rounded-lg border border-neutral-200 bg-neutral-50 p-4 pr-12 text-[13px] leading-relaxed dark:border-neutral-800 dark:bg-neutral-900 ${className || ""}`}
+      >
+        {children}
+      </pre>
+      <button
+        onClick={handleCopy}
+        className="absolute right-2 top-2 rounded-md bg-white p-2 opacity-0 transition-opacity hover:bg-neutral-50 group-hover:opacity-100 dark:bg-neutral-800 dark:hover:bg-neutral-700"
+        title={copied ? "Copied!" : "Copy code"}
+        aria-label={copied ? "Copied!" : "Copy code"}
+      >
+        {copied ? (
+          <Check className="h-4 w-4 text-green-600 dark:text-green-400" />
+        ) : (
+          <Copy className="h-4 w-4 text-neutral-600 dark:text-neutral-400" />
+        )}
+      </button>
+    </div>
+  );
+}

--- a/apps/docs/src/mdx-components.tsx
+++ b/apps/docs/src/mdx-components.tsx
@@ -1,4 +1,5 @@
 import type { MDXComponents } from "mdx/types";
+import { CodeBlock } from "./components/code-block";
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
@@ -45,12 +46,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
         />
       );
     },
-    pre: (props) => (
-      <pre
-        className="mb-4 overflow-x-auto rounded-lg border border-neutral-200 bg-neutral-50 p-4 text-[13px] leading-relaxed dark:border-neutral-800 dark:bg-neutral-900"
-        {...props}
-      />
-    ),
+    pre: (props) => <CodeBlock {...props} />,
     blockquote: (props) => (
       <blockquote
         className="mb-4 border-l-2 border-neutral-200 pl-4 text-sm text-neutral-500 dark:border-neutral-800 dark:text-neutral-500"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       just-bash:
         specifier: ^2.10.2
         version: 2.10.2
+      lucide-react:
+        specifier: ^0.577.0
+        version: 0.577.0(react@19.2.4)
       next:
         specifier: ^16.1.6
         version: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.1)
@@ -5773,6 +5776,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@0.577.0:
+    resolution: {integrity: sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   magic-regexp@0.10.0:
     resolution: {integrity: sha512-Uly1Bu4lO1hwHUW0CQeSWuRtzCMNO00CmXtS8N6fyvB3B979GOEEeAkiTUDsmbYLAbvpUS/Kt5c4ibosAzVyVg==}
@@ -14152,6 +14160,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@0.577.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   magic-regexp@0.10.0:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -6,6 +6,7 @@
       "outputs": ["dist/**", ".next/**"]
     },
     "dev": {
+      "dependsOn": ["^build"],
       "cache": false,
       "persistent": true
     },


### PR DESCRIPTION
## Description

Adds a copy-to-clipboard button to code blocks in the docs. The button appears on hover in the top-right corner, improving UX when copying commands and snippets.

## Changes

- Created `apps/docs/src/components/code-block.tsx` with copy functionality
- Updated `apps/docs/src/mdx-components.tsx` to use the new component
- Added `lucide-react` for Copy and Check icons

## Features

- Shows copy button only on syntax-highlighted code blocks (not plain text)
- Visual feedback: checkmark icon for 2 seconds after copying
- Theme-aware styling matching the docs design
- Includes ARIA labels for accessibility

No changes needed to existing `.mdx` files - all code blocks automatically get the copy button.

