### PR TITLE
Fix HTTPS proxy trust and stop on macOS with sudo

### DIFF
--- a/packages/portless/src/certs.ts
+++ b/packages/portless/src/certs.ts
@@ -301,27 +301,28 @@ export function isCATrusted(stateDir: string): boolean {
 
 function isCATrustedMacOS(caCertPath: string): boolean {
   try {
-    // Extract the SHA-1 fingerprint of our CA
-    const fingerprint = openssl(["x509", "-in", caCertPath, "-noout", "-fingerprint", "-sha1"])
-      .trim()
-      .replace(/^.*=/, "")
-      .replace(/:/g, "")
-      .toLowerCase();
+    const isRoot = (process.getuid?.() ?? -1) === 0;
+    const sudoUser = process.env.SUDO_USER;
 
-    // Check the login keychain first, then the system keychain
-    for (const keychain of [loginKeychainPath(), "/Library/Keychains/System.keychain"]) {
-      try {
-        const result = execFileSync("security", ["find-certificate", "-a", "-Z", keychain], {
-          encoding: "utf-8",
+    if (isRoot && sudoUser) {
+      // When running as root via sudo, check trust from the *browser user's*
+      // perspective. Root may have the CA in its own trust settings, but
+      // Chrome runs as the real user and won't see those.
+      execFileSync(
+        "sudo",
+        ["-u", sudoUser, "security", "verify-cert", "-c", caCertPath, "-L", "-p", "ssl"],
+        {
+          stdio: "pipe",
           timeout: 5000,
-          stdio: ["pipe", "pipe", "pipe"],
-        });
-        if (result.toLowerCase().includes(fingerprint)) return true;
-      } catch {
-        // Not found in this keychain, try next
-      }
+        }
+      );
+    } else {
+      execFileSync("security", ["verify-cert", "-c", caCertPath, "-L", "-p", "ssl"], {
+        stdio: "pipe",
+        timeout: 5000,
+      });
     }
-    return false;
+    return true;
   } catch {
     return false;
   }
@@ -655,12 +656,29 @@ export function trustCA(stateDir: string): { trusted: boolean; error?: string } 
 
   try {
     if (process.platform === "darwin") {
-      const keychain = loginKeychainPath();
-      execFileSync(
-        "security",
-        ["add-trusted-cert", "-r", "trustRoot", "-k", keychain, caCertPath],
-        { stdio: "pipe", timeout: 30_000 }
-      );
+      const isRoot = (process.getuid?.() ?? -1) === 0;
+      if (isRoot) {
+        execFileSync(
+          "security",
+          [
+            "add-trusted-cert",
+            "-d",
+            "-r",
+            "trustRoot",
+            "-k",
+            "/Library/Keychains/System.keychain",
+            caCertPath,
+          ],
+          { stdio: "pipe", timeout: 30_000 }
+        );
+      } else {
+        const keychain = loginKeychainPath();
+        execFileSync(
+          "security",
+          ["add-trusted-cert", "-r", "trustRoot", "-k", keychain, caCertPath],
+          { stdio: "pipe", timeout: 30_000 }
+        );
+      }
       return { trusted: true };
     } else if (process.platform === "linux") {
       const config = getLinuxCATrustConfig();

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -149,8 +149,11 @@ export async function discoverState(): Promise<{ dir: string; port: number; tls:
   // Check user-level state first (~/.portless)
   const userPort = readPortFromDir(USER_STATE_DIR);
   if (userPort !== null) {
-    const tls = readTlsMarker(USER_STATE_DIR);
-    if (await isProxyRunning(userPort, tls)) {
+    // Always use plain HTTP for the liveness check. The TLS-enabled proxy
+    // accepts plain HTTP via byte-peeking, so this works for both modes and
+    // avoids TLS handshake timeouts that can cause false negatives.
+    if (await isProxyRunning(userPort)) {
+      const tls = readTlsMarker(USER_STATE_DIR);
       return { dir: USER_STATE_DIR, port: userPort, tls };
     }
   }
@@ -158,14 +161,25 @@ export async function discoverState(): Promise<{ dir: string; port: number; tls:
   // Check system-level state (/tmp/portless)
   const systemPort = readPortFromDir(SYSTEM_STATE_DIR);
   if (systemPort !== null) {
-    const tls = readTlsMarker(SYSTEM_STATE_DIR);
-    if (await isProxyRunning(systemPort, tls)) {
+    if (await isProxyRunning(systemPort)) {
+      const tls = readTlsMarker(SYSTEM_STATE_DIR);
       return { dir: SYSTEM_STATE_DIR, port: systemPort, tls };
     }
   }
 
-  // Nothing running; fall back based on default port
+  // State files didn't help. Probe well-known ports as a last resort --
+  // privileged-port proxies store state in /tmp which macOS cleans on reboot,
+  // so the daemon may still be alive after the port file is gone.
   const defaultPort = getDefaultPort();
+  const probePorts = new Set([defaultPort, 443, 80]);
+  for (const port of probePorts) {
+    if (await isProxyRunning(port)) {
+      const dir = resolveStateDir(port);
+      const tls = readTlsMarker(dir);
+      return { dir, port, tls };
+    }
+  }
+
   return { dir: resolveStateDir(defaultPort), port: defaultPort, tls: false };
 }
 

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -178,14 +178,16 @@ function startProxyServer(
 // Commands
 // ---------------------------------------------------------------------------
 
-async function stopProxy(store: RouteStore, proxyPort: number, tls: boolean): Promise<void> {
+async function stopProxy(store: RouteStore, proxyPort: number, _tls: boolean): Promise<void> {
   const pidPath = store.pidPath;
   const needsSudo = proxyPort < PRIVILEGED_PORT_THRESHOLD;
   const sudoHint = needsSudo ? "sudo " : "";
 
   if (!fs.existsSync(pidPath)) {
-    // PID file is missing -- check whether something is still listening
-    if (await isProxyRunning(proxyPort, tls)) {
+    // PID file is missing -- check whether something is still listening.
+    // Use plain HTTP: the TLS proxy accepts it via byte-peeking, and this
+    // avoids false negatives from TLS handshake timeouts.
+    if (await isProxyRunning(proxyPort)) {
       console.log(chalk.yellow(`PID file is missing but port ${proxyPort} is still in use.`));
       const pid = findPidOnPort(proxyPort);
       if (pid !== null) {
@@ -249,7 +251,8 @@ async function stopProxy(store: RouteStore, proxyPort: number, tls: boolean): Pr
 
     // Verify the process is actually running a proxy on the expected port.
     // If the PID was recycled by an unrelated process, the port won't be listening.
-    if (!(await isProxyRunning(proxyPort, tls))) {
+    // Plain HTTP works for both TLS and non-TLS proxies (byte-peeking).
+    if (!(await isProxyRunning(proxyPort))) {
       console.log(
         chalk.yellow(
           `PID file exists but port ${proxyPort} is not listening. The PID may have been recycled.`
@@ -1045,8 +1048,13 @@ ${chalk.bold("Usage:")}
     }
     const needsSudo = proxyPort < PRIVILEGED_PORT_THRESHOLD;
     const sudoPrefix = needsSudo ? "sudo " : "";
+    const portFlag = proxyPort !== getDefaultPort() ? ` -p ${proxyPort}` : "";
     console.log(chalk.yellow(`Proxy is already running on port ${proxyPort}.`));
-    console.log(chalk.blue(`To restart: portless proxy stop && ${sudoPrefix}portless proxy start`));
+    console.log(
+      chalk.blue(
+        `To restart: ${sudoPrefix}portless proxy stop${portFlag} && ${sudoPrefix}portless proxy start${portFlag}`
+      )
+    );
     return;
   }
 


### PR DESCRIPTION
When running `sudo portless proxy start --https`, the CA was added to root's login keychain and trust store -- invisible to Chrome which runs as the regular user. Three fixes:

- trustCA: add CA to system keychain (/Library/Keychains/System.keychain) with -d flag when running as root, so all users see it
- isCATrustedMacOS: use `security verify-cert` (actual trust check, not just keychain presence) and run as the real user via sudo -u $SUDO_USER to avoid false positives from root's trust settings
- proxy stop: accept -p flag to target a specific port when state files are missing but the daemon is still alive; use plain HTTP for all liveness checks (TLS proxy accepts it via byte-peeking) to match proxy start behavior and avoid TLS handshake timeouts