### PR TITLE
release: v0.6.0

### DIFF
--- a/packages/portless/package.json
+++ b/packages/portless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portless",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Replace port numbers with stable, named .localhost URLs. For humans and agents.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Bump version to 0.6.0 in `packages/portless/package.json`

Follows the changelog and docs updates merged in #99.