### PR TITLE
feat: add tunnel support (ngrok, Cloudflare Tunnel)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,34 @@ sudo portless trust
 
 On Linux, `portless trust` supports Debian/Ubuntu, Arch, Fedora/RHEL/CentOS, and openSUSE (via `update-ca-certificates` or `update-ca-trust`).
 
+## Tunnels (ngrok, Cloudflare Tunnel)
+
+Expose your local dev server to the internet using [ngrok](https://ngrok.com) or [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/).
+
+**Managed tunnel (recommended)** -- portless starts the tunnel for you:
+
+```bash
+portless myapp --tunnel ngrok next dev        # Starts app + ngrok tunnel
+portless run --tunnel cloudflare next dev     # Starts app + cloudflare tunnel
+```
+
+The child process receives `PORTLESS_TUNNEL_URL` with the public tunnel URL.
+
+**Single-app passthrough** -- with one app running, portless auto-routes tunnel traffic without any extra config:
+
+```bash
+portless myapp next dev       # Terminal 1: start app
+ngrok http 1355               # Terminal 2: start tunnel; auto-routed
+```
+
+**Multi-app with explicit mapping** -- when running multiple apps, map the tunnel hostname to a specific app:
+
+```bash
+portless tunnel map myapp abc123.ngrok-free.app
+portless tunnel unmap abc123.ngrok-free.app
+portless tunnel list
+```
+
 ## Commands
 
 ```bash
@@ -143,6 +171,9 @@ portless list                    # Show active routes
 portless trust                   # Add local CA to system trust store
 portless hosts sync              # Add routes to /etc/hosts (fixes Safari)
 portless hosts clean             # Remove portless entries from /etc/hosts
+portless tunnel map <name> <host>  # Map external tunnel hostname to an app
+portless tunnel unmap <host>     # Remove a tunnel hostname mapping
+portless tunnel list             # Show tunnel hostname mappings
 
 # Disable portless (run command directly)
 PORTLESS=0 pnpm dev              # Bypasses proxy, uses default port
@@ -166,6 +197,7 @@ portless proxy stop              # Stop the proxy
 --foreground                     Run proxy in foreground instead of daemon
 --tld <tld>                      Use a custom TLD instead of .localhost (e.g. test)
 --app-port <number>              Use a fixed port for the app (skip auto-assignment)
+--tunnel <provider>              Start a tunnel (ngrok, cloudflare)
 --force                          Override a route registered by another process
 --name <name>                    Use <name> as the app name
 ```
@@ -180,14 +212,16 @@ PORTLESS_HTTPS=1                 Always enable HTTPS
 PORTLESS_TLD=<tld>               Use a custom TLD (e.g. test; default: localhost)
 PORTLESS_SYNC_HOSTS=1            Auto-sync /etc/hosts (auto-enabled for custom TLDs)
 PORTLESS_STATE_DIR=<path>        Override the state directory
+PORTLESS_TUNNEL=<provider>       Start a tunnel automatically (ngrok, cloudflare)
 
 # Injected into child processes
 PORT                             Ephemeral port the child should listen on
 HOST                             Always 127.0.0.1
 PORTLESS_URL                     Public URL (e.g. https://myapp.localhost)
+PORTLESS_TUNNEL_URL              Tunnel URL when --tunnel is used
 ```
 
-> **Reserved names:** `run`, `alias`, `hosts`, `list`, `trust`, and `proxy` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name from your project, or `portless --name <name> <cmd>` to force any name including reserved ones.
+> **Reserved names:** `run`, `get`, `alias`, `tunnel`, `hosts`, `list`, `trust`, and `proxy` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name from your project, or `portless --name <name> <cmd>` to force any name including reserved ones.
 
 ## Safari / DNS
 

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -356,6 +356,53 @@ describe("CLI", () => {
     });
   });
 
+  describe("tunnel subcommand", () => {
+    it("prints help with --help", () => {
+      const { status, stdout } = run(["tunnel", "--help"]);
+      expect(status).toBe(0);
+      expect(stdout).toContain("portless tunnel");
+      expect(stdout).toContain("map");
+      expect(stdout).toContain("unmap");
+      expect(stdout).toContain("list");
+    });
+
+    it("prints help with -h", () => {
+      const { status, stdout } = run(["tunnel", "-h"]);
+      expect(status).toBe(0);
+      expect(stdout).toContain("portless tunnel");
+    });
+
+    it("exits 1 with usage when no subcommand given", () => {
+      const { status, stdout } = run(["tunnel"]);
+      expect(status).toBe(1);
+      expect(stdout).toContain("portless tunnel");
+    });
+
+    it("exits 1 for unknown tunnel subcommand", () => {
+      const { status, stderr } = run(["tunnel", "typo"]);
+      expect(status).toBe(1);
+      expect(stderr).toContain("Unknown tunnel subcommand");
+    });
+
+    it("exits 1 when map has missing arguments", () => {
+      const { status, stderr } = run(["tunnel", "map"]);
+      expect(status).toBe(1);
+      expect(stderr).toContain("Missing arguments");
+    });
+
+    it("exits 1 when map has only name but no hostname", () => {
+      const { status, stderr } = run(["tunnel", "map", "myapp"]);
+      expect(status).toBe(1);
+      expect(stderr).toContain("Missing arguments");
+    });
+
+    it("exits 1 when unmap has no hostname", () => {
+      const { status, stderr } = run(["tunnel", "unmap"]);
+      expect(status).toBe(1);
+      expect(stderr).toContain("No hostname provided");
+    });
+  });
+
   describe("proxy subcommand", () => {
     it("prints help with --help", () => {
       const { status, stdout } = run(["proxy", "--help"]);

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -12,6 +12,8 @@ import { fixOwnership, formatUrl, isErrnoException, parseHostname } from "./util
 import { syncHostsFile, cleanHostsFile } from "./hosts.js";
 import { FILE_MODE, RouteConflictError, RouteStore } from "./routes.js";
 import { inferProjectName, detectWorktreePrefix, sanitizeForHostname } from "./auto.js";
+import { getTunnelProvider, TUNNEL_PROVIDERS } from "./tunnel.js";
+import type { TunnelInstance } from "./tunnel.js";
 import {
   DEFAULT_TLD,
   PRIVILEGED_PORT_THRESHOLD,
@@ -79,7 +81,9 @@ function startProxyServer(
 
   // Cache routes in memory and reload on file change (debounced)
   let cachedRoutes = store.loadRoutes();
+  let cachedAliases = store.loadAliases();
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  let aliasDebounceTimer: ReturnType<typeof setTimeout> | null = null;
   let watcher: fs.FSWatcher | null = null;
   let pollingInterval: ReturnType<typeof setInterval> | null = null;
 
@@ -100,6 +104,14 @@ function startProxyServer(
     }
   };
 
+  const reloadAliases = () => {
+    try {
+      cachedAliases = store.loadAliases();
+    } catch {
+      // File may be mid-write; keep existing cached aliases
+    }
+  };
+
   try {
     watcher = fs.watch(routesPath, () => {
       if (debounceTimer) clearTimeout(debounceTimer);
@@ -111,12 +123,32 @@ function startProxyServer(
     pollingInterval = setInterval(reloadRoutes, POLL_INTERVAL_MS);
   }
 
+  // Watch aliases file. Use fs.watchFile (stat-based polling) instead of
+  // fs.watch because the file may not exist yet at proxy startup -- it is
+  // created on first `portless tunnel map` or `--tunnel` invocation.
+  const aliasesPath = store.getAliasesPath();
+  fs.watchFile(aliasesPath, { interval: POLL_INTERVAL_MS }, () => {
+    if (aliasDebounceTimer) clearTimeout(aliasDebounceTimer);
+    aliasDebounceTimer = setTimeout(reloadAliases, DEBOUNCE_MS);
+  });
+  if (pollingInterval) {
+    // Piggyback alias reloads on the existing polling interval (fs.watch
+    // was unavailable for routes, so we already fall back to polling)
+    const existingInterval = pollingInterval;
+    clearInterval(existingInterval);
+    pollingInterval = setInterval(() => {
+      reloadRoutes();
+      reloadAliases();
+    }, POLL_INTERVAL_MS);
+  }
+
   if (autoSyncHosts) {
     syncHostsFile(cachedRoutes.map((r) => r.hostname));
   }
 
   const server = createProxyServer({
     getRoutes: () => cachedRoutes,
+    getAliases: () => cachedAliases,
     proxyPort,
     tld,
     onError: (msg) => console.error(chalk.red(msg)),
@@ -160,10 +192,12 @@ function startProxyServer(
     if (exiting) return;
     exiting = true;
     if (debounceTimer) clearTimeout(debounceTimer);
+    if (aliasDebounceTimer) clearTimeout(aliasDebounceTimer);
     if (pollingInterval) clearInterval(pollingInterval);
     if (watcher) {
       watcher.close();
     }
+    fs.unwatchFile(aliasesPath);
     try {
       fs.unlinkSync(store.pidPath);
     } catch {
@@ -330,7 +364,8 @@ async function runApp(
   tld: string,
   force: boolean,
   autoInfo?: { nameSource: string; prefix?: string; prefixSource?: string },
-  desiredPort?: number
+  desiredPort?: number,
+  tunnelProviderName?: string
 ) {
   const hostname = parseHostname(name, tld);
 
@@ -463,27 +498,93 @@ async function runApp(
   }
 
   const finalUrl = formatUrl(hostname, proxyPort, tls);
-  console.log(chalk.cyan.bold(`\n  -> ${finalUrl}\n`));
+  console.log(chalk.cyan.bold(`\n  -> ${finalUrl}`));
+
+  // Start tunnel if requested
+  let tunnelInstance: TunnelInstance | undefined;
+  let tunnelUrl: string | undefined;
+  if (tunnelProviderName) {
+    const provider = getTunnelProvider(tunnelProviderName);
+    if (!provider) {
+      console.error(chalk.red(`Error: Unknown tunnel provider "${tunnelProviderName}".`));
+      process.exit(1);
+    }
+    if (!provider.isAvailable()) {
+      console.error(chalk.red(`Error: ${tunnelProviderName} is not installed.`));
+      console.error(chalk.blue(`Install it first:`));
+      if (tunnelProviderName === "ngrok") {
+        console.error(chalk.cyan("  https://ngrok.com/download"));
+      } else if (tunnelProviderName === "cloudflare") {
+        console.error(
+          chalk.cyan(
+            "  https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/"
+          )
+        );
+      }
+      process.exit(1);
+    }
+
+    console.log(chalk.gray(`\n-- Starting ${tunnelProviderName} tunnel...`));
+    try {
+      tunnelInstance = await provider.start(proxyPort);
+      tunnelUrl = tunnelInstance.url;
+
+      // Register alias so the proxy routes tunnel traffic correctly
+      const tunnelHostname = new URL(tunnelUrl).hostname;
+      store.addAlias(tunnelHostname, hostname);
+
+      console.log(chalk.cyan.bold(`  -> ${tunnelUrl} (tunnel)`));
+    } catch (err) {
+      console.error(chalk.red(`Error starting tunnel: ${(err as Error).message}`));
+      try {
+        store.removeRoute(hostname);
+      } catch {
+        // Non-fatal
+      }
+      process.exit(1);
+    }
+  }
+
+  console.log();
 
   // Inject --port for frameworks that ignore the PORT env var (e.g. Vite)
   injectFrameworkFlags(commandArgs, port);
 
+  // Build environment variables for the child process
+  const childEnv: Record<string, string> = {
+    ...(process.env as Record<string, string>),
+    PORT: port.toString(),
+    HOST: "127.0.0.1",
+    PORTLESS_URL: finalUrl,
+    __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: `.${tld}`,
+  };
+  if (tunnelUrl) {
+    childEnv.PORTLESS_TUNNEL_URL = tunnelUrl;
+  }
+
   // Run the command
+  const tunnelEnvStr = tunnelUrl ? ` PORTLESS_TUNNEL_URL=${tunnelUrl}` : "";
   console.log(
     chalk.gray(
-      `Running: PORT=${port} HOST=127.0.0.1 PORTLESS_URL=${finalUrl} ${commandArgs.join(" ")}\n`
+      `Running: PORT=${port} HOST=127.0.0.1 PORTLESS_URL=${finalUrl}${tunnelEnvStr} ${commandArgs.join(" ")}\n`
     )
   );
 
   spawnCommand(commandArgs, {
-    env: {
-      ...process.env,
-      PORT: port.toString(),
-      HOST: "127.0.0.1",
-      PORTLESS_URL: finalUrl,
-      __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: `.${tld}`,
-    },
+    env: childEnv,
     onCleanup: () => {
+      // Stop tunnel first
+      if (tunnelInstance) {
+        tunnelInstance.stop();
+        try {
+          if (tunnelUrl) {
+            const tunnelHostname = new URL(tunnelUrl).hostname;
+            store.removeAlias(tunnelHostname);
+          }
+        } catch {
+          // Non-fatal
+        }
+      }
       try {
         store.removeRoute(hostname);
       } catch {
@@ -498,11 +599,14 @@ async function runApp(
 // ---------------------------------------------------------------------------
 
 interface ParsedRunArgs {
+  /** Whether --force was specified. */
   force: boolean;
   /** Fixed app port (overrides automatic assignment). */
   appPort?: number;
   /** Override the inferred base name (from --name flag). */
   name?: string;
+  /** Tunnel provider name (e.g. "ngrok", "cloudflare"). */
+  tunnel?: string;
   /** The child command and its arguments, passed through untouched. */
   commandArgs: string[];
 }
@@ -536,6 +640,33 @@ function appPortFromEnv(): number | undefined {
   return port;
 }
 
+function parseTunnelArg(value: string | undefined): string {
+  if (!value || value.startsWith("-")) {
+    console.error(chalk.red("Error: --tunnel requires a provider name."));
+    console.error(chalk.blue(`Available providers: ${TUNNEL_PROVIDERS.join(", ")}`));
+    process.exit(1);
+  }
+  const provider = getTunnelProvider(value);
+  if (!provider) {
+    console.error(chalk.red(`Error: Unknown tunnel provider "${value}".`));
+    console.error(chalk.blue(`Available providers: ${TUNNEL_PROVIDERS.join(", ")}`));
+    process.exit(1);
+  }
+  return value;
+}
+
+function tunnelFromEnv(): string | undefined {
+  const envVal = process.env.PORTLESS_TUNNEL;
+  if (!envVal) return undefined;
+  const provider = getTunnelProvider(envVal);
+  if (!provider) {
+    console.error(chalk.red(`Error: Unknown PORTLESS_TUNNEL="${envVal}".`));
+    console.error(chalk.blue(`Available providers: ${TUNNEL_PROVIDERS.join(", ")}`));
+    process.exit(1);
+  }
+  return envVal;
+}
+
 /**
  * Parse `run` subcommand arguments: `[--name <name>] [--force] [--] <command...>`
  *
@@ -547,6 +678,7 @@ function parseRunArgs(args: string[]): ParsedRunArgs {
   let force = false;
   let appPort: number | undefined;
   let name: string | undefined;
+  let tunnel: string | undefined;
   let i = 0;
 
   while (i < args.length && args[i].startsWith("-")) {
@@ -564,6 +696,7 @@ ${chalk.bold("Options:")}
   --name <name>          Override the inferred base name (worktree prefix still applies)
   --force                Override an existing route registered by another process
   --app-port <number>    Use a fixed port for the app (skip auto-assignment)
+  --tunnel <provider>    Start a tunnel (ngrok, cloudflare)
   --help, -h             Show this help
 
 ${chalk.bold("Name inference (in order):")}
@@ -580,6 +713,7 @@ ${chalk.bold("Examples:")}
   portless run --name myapp next dev  # -> http://myapp.localhost:1355
   portless run vite dev               # -> http://<project>.localhost:1355
   portless run --app-port 3000 pnpm start
+  portless run --tunnel ngrok next dev
 `);
       process.exit(0);
     } else if (args[i] === "--force") {
@@ -587,6 +721,9 @@ ${chalk.bold("Examples:")}
     } else if (args[i] === "--app-port") {
       i++;
       appPort = parseAppPort(args[i]);
+    } else if (args[i] === "--tunnel") {
+      i++;
+      tunnel = parseTunnelArg(args[i]);
     } else if (args[i] === "--name") {
       i++;
       if (!args[i] || args[i].startsWith("-")) {
@@ -597,15 +734,16 @@ ${chalk.bold("Examples:")}
       name = args[i];
     } else {
       console.error(chalk.red(`Error: Unknown flag "${args[i]}".`));
-      console.error(chalk.blue("Known flags: --name, --force, --app-port, --help"));
+      console.error(chalk.blue("Known flags: --name, --force, --app-port, --tunnel, --help"));
       process.exit(1);
     }
     i++;
   }
 
   if (!appPort) appPort = appPortFromEnv();
+  if (!tunnel) tunnel = tunnelFromEnv();
 
-  return { force, appPort, name, commandArgs: args.slice(i) };
+  return { force, appPort, name, tunnel, commandArgs: args.slice(i) };
 }
 
 /**
@@ -618,6 +756,7 @@ ${chalk.bold("Examples:")}
 function parseAppArgs(args: string[]): ParsedAppArgs {
   let force = false;
   let appPort: number | undefined;
+  let tunnel: string | undefined;
   let i = 0;
 
   // Consume leading flags before name
@@ -630,9 +769,12 @@ function parseAppArgs(args: string[]): ParsedAppArgs {
     } else if (args[i] === "--app-port") {
       i++;
       appPort = parseAppPort(args[i]);
+    } else if (args[i] === "--tunnel") {
+      i++;
+      tunnel = parseTunnelArg(args[i]);
     } else {
       console.error(chalk.red(`Error: Unknown flag "${args[i]}".`));
-      console.error(chalk.blue("Known flags: --force, --app-port"));
+      console.error(chalk.blue("Known flags: --force, --app-port, --tunnel"));
       process.exit(1);
     }
     i++;
@@ -652,17 +794,21 @@ function parseAppArgs(args: string[]): ParsedAppArgs {
     } else if (args[i] === "--app-port") {
       i++;
       appPort = parseAppPort(args[i]);
+    } else if (args[i] === "--tunnel") {
+      i++;
+      tunnel = parseTunnelArg(args[i]);
     } else {
       console.error(chalk.red(`Error: Unknown flag "${args[i]}".`));
-      console.error(chalk.blue("Known flags: --force, --app-port"));
+      console.error(chalk.blue("Known flags: --force, --app-port, --tunnel"));
       process.exit(1);
     }
     i++;
   }
 
   if (!appPort) appPort = appPortFromEnv();
+  if (!tunnel) tunnel = tunnelFromEnv();
 
-  return { force, appPort, name, commandArgs: args.slice(i) };
+  return { force, appPort, tunnel, name, commandArgs: args.slice(i) };
 }
 
 // ---------------------------------------------------------------------------
@@ -692,6 +838,9 @@ ${chalk.bold("Usage:")}
   ${chalk.cyan("portless alias --remove <name>")}   Remove a static route
   ${chalk.cyan("portless list")}                    Show active routes
   ${chalk.cyan("portless trust")}                   Add local CA to system trust store
+  ${chalk.cyan("portless tunnel map <n> <host>")}   Map external tunnel hostname to an app
+  ${chalk.cyan("portless tunnel unmap <host>")}     Remove a tunnel hostname mapping
+  ${chalk.cyan("portless tunnel list")}             Show tunnel hostname mappings
   ${chalk.cyan("portless hosts sync")}              Add routes to /etc/hosts (fixes Safari)
   ${chalk.cyan("portless hosts clean")}             Remove portless entries from /etc/hosts
 
@@ -705,6 +854,13 @@ ${chalk.bold("Examples:")}
   portless run next dev               # in worktree -> http://<worktree>.<project>.localhost:1355
   portless get backend                 # -> http://backend.localhost:1355 (for cross-service refs)
   # Wildcard subdomains: tenant.myapp.localhost also routes to myapp
+
+${chalk.bold("Tunnels (ngrok, Cloudflare Tunnel):")}
+  portless myapp --tunnel ngrok next dev        # Starts app + ngrok tunnel
+  portless run --tunnel cloudflare next dev     # Starts app + cloudflare tunnel
+  # Single-app tunnel also works without --tunnel:
+  portless myapp next dev                       # Start app
+  ngrok http 1355                               # In another terminal; auto-routed
 
 ${chalk.bold("In package.json:")}
   {
@@ -739,6 +895,7 @@ ${chalk.bold("Options:")}
   --foreground                  Run proxy in foreground (for debugging)
   --tld <tld>                   Use a custom TLD instead of .localhost (e.g. test, dev)
   --app-port <number>           Use a fixed port for the app (skip auto-assignment)
+  --tunnel <provider>           Start a tunnel (ngrok, cloudflare)
   --force                       Override an existing route registered by another process
   --name <name>                 Use <name> as the app name (bypasses subcommand dispatch)
   --                            Stop flag parsing; everything after is passed to the child
@@ -750,12 +907,14 @@ ${chalk.bold("Environment variables:")}
   PORTLESS_TLD=<tld>            Use a custom TLD (e.g. test, dev; default: localhost)
   PORTLESS_SYNC_HOSTS=1         Auto-sync /etc/hosts (auto-enabled for custom TLDs)
   PORTLESS_STATE_DIR=<path>     Override the state directory
+  PORTLESS_TUNNEL=<provider>    Start a tunnel automatically (ngrok, cloudflare)
   PORTLESS=0                    Run command directly without proxy
 
 ${chalk.bold("Child process environment:")}
   PORT                          Ephemeral port the child should listen on
   HOST                          Always 127.0.0.1
   PORTLESS_URL                  Public URL of the app (e.g. http://myapp.localhost:1355)
+  PORTLESS_TUNNEL_URL           Tunnel URL when --tunnel is used (e.g. https://abc123.ngrok-free.app)
 
 ${chalk.bold("Safari / DNS:")}
   .localhost subdomains auto-resolve in Chrome, Firefox, and Edge.
@@ -770,7 +929,7 @@ ${chalk.bold("Skip portless:")}
   PORTLESS=0 pnpm dev           # Runs command directly without proxy
 
 ${chalk.bold("Reserved names:")}
-  run, get, alias, hosts, list, trust, proxy are subcommands and cannot
+  run, get, alias, tunnel, hosts, list, trust, proxy are subcommands and cannot
   be used as app names directly. Use "portless run" to infer the name,
   or "portless --name <name>" to force any name including reserved ones.
 `);
@@ -931,6 +1090,105 @@ ${chalk.bold("Examples:")}
   const force = args.includes("--force");
   store.addRoute(hostname, port, 0, force);
   console.log(chalk.green(`Alias registered: ${hostname} -> 127.0.0.1:${port}`));
+}
+
+async function handleTunnel(args: string[]): Promise<void> {
+  if (args[1] === "--help" || args[1] === "-h" || !args[1]) {
+    console.log(`
+${chalk.bold("portless tunnel")} - Map external tunnel hostnames to portless apps.
+
+${chalk.bold("Usage:")}
+  ${chalk.cyan("portless tunnel map <name> <hostname>")}    Map external hostname to a portless app
+  ${chalk.cyan("portless tunnel unmap <hostname>")}          Remove a hostname mapping
+  ${chalk.cyan("portless tunnel list")}                      Show all tunnel mappings
+
+${chalk.bold("Examples:")}
+  portless tunnel map myapp abc123.ngrok-free.app
+  portless tunnel map api.myapp mysite.trycloudflare.com
+  portless tunnel unmap abc123.ngrok-free.app
+  portless tunnel list
+
+${chalk.bold("How it works:")}
+  When a tunnel provider (ngrok, Cloudflare Tunnel, etc.) forwards traffic
+  to the portless proxy, the Host header is the tunnel's public hostname.
+  Tunnel mappings tell portless which app to route that traffic to.
+
+  Note: with a single app running, portless auto-routes tunnel traffic
+  without needing an explicit mapping.
+`);
+    process.exit(!args[1] ? 1 : 0);
+  }
+
+  const { dir, tld } = await discoverState();
+  const store = new RouteStore(dir, {
+    onWarning: (msg) => console.warn(chalk.yellow(msg)),
+  });
+
+  if (args[1] === "list") {
+    const aliases = store.loadAliases();
+    const entries = Object.entries(aliases);
+    if (entries.length === 0) {
+      console.log(chalk.gray("No tunnel mappings."));
+      return;
+    }
+    console.log(chalk.bold("\nTunnel mappings:\n"));
+    for (const [external, target] of entries) {
+      console.log(`  ${chalk.cyan(external)} -> ${chalk.green(target)}`);
+    }
+    console.log();
+    return;
+  }
+
+  if (args[1] === "map") {
+    const name = args[2];
+    const externalHostname = args[3];
+    if (!name || !externalHostname) {
+      console.error(chalk.red("Error: Missing arguments."));
+      console.error(chalk.blue("Usage:"));
+      console.error(chalk.cyan("  portless tunnel map <name> <hostname>"));
+      console.error(chalk.blue("Example:"));
+      console.error(chalk.cyan("  portless tunnel map myapp abc123.ngrok-free.app"));
+      process.exit(1);
+    }
+
+    const portlessHostname = parseHostname(name, tld);
+
+    // Validate that the target route exists
+    const routes = store.loadRoutes();
+    const routeExists = routes.some((r) => r.hostname === portlessHostname);
+    if (!routeExists) {
+      console.warn(
+        chalk.yellow(
+          `Warning: No active route for "${portlessHostname}". ` +
+            `The mapping will take effect when the app starts.`
+        )
+      );
+    }
+
+    store.addAlias(externalHostname, portlessHostname);
+    console.log(chalk.green(`Tunnel mapped: ${externalHostname} -> ${portlessHostname}`));
+    return;
+  }
+
+  if (args[1] === "unmap") {
+    const externalHostname = args[2];
+    if (!externalHostname) {
+      console.error(chalk.red("Error: No hostname provided."));
+      console.error(chalk.cyan("  portless tunnel unmap <hostname>"));
+      process.exit(1);
+    }
+    const removed = store.removeAlias(externalHostname);
+    if (!removed) {
+      console.error(chalk.red(`Error: No tunnel mapping found for "${externalHostname}".`));
+      process.exit(1);
+    }
+    console.log(chalk.green(`Tunnel mapping removed: ${externalHostname}`));
+    return;
+  }
+
+  console.error(chalk.red(`Unknown tunnel subcommand: ${args[1]}`));
+  console.error(chalk.cyan("  portless tunnel --help"));
+  process.exit(1);
 }
 
 async function handleHosts(args: string[]): Promise<void> {
@@ -1325,7 +1583,8 @@ async function handleRunMode(args: string[]): Promise<void> {
     tld,
     parsed.force,
     { nameSource, prefix: worktree?.prefix, prefixSource: worktree?.source },
-    parsed.appPort
+    parsed.appPort,
+    parsed.tunnel
   );
 }
 
@@ -1355,7 +1614,8 @@ async function handleNamedMode(args: string[]): Promise<void> {
     tld,
     parsed.force,
     undefined,
-    parsed.appPort
+    parsed.appPort,
+    parsed.tunnel
   );
 }
 
@@ -1390,7 +1650,7 @@ async function main() {
 
   // --name flag: treat the next arg as an explicit app name, bypassing
   // subcommand dispatch. Useful when the app name collides with a reserved
-  // subcommand (run, alias, hosts, list, trust, proxy).
+  // subcommand (run, get, alias, tunnel, hosts, list, trust, proxy).
   if (args[0] === "--name") {
     args.shift();
     if (!args[0]) {
@@ -1461,6 +1721,10 @@ async function main() {
     }
     if (args[0] === "alias") {
       await handleAlias(args);
+      return;
+    }
+    if (args[0] === "tunnel") {
+      await handleTunnel(args);
       return;
     }
     if (args[0] === "hosts") {

--- a/packages/portless/src/index.ts
+++ b/packages/portless/src/index.ts
@@ -3,3 +3,4 @@ export * from "./proxy.js";
 export * from "./routes.js";
 export * from "./utils.js";
 export * from "./hosts.js";
+export * from "./tunnel.js";

--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -244,6 +244,240 @@ describe("createProxyServer", () => {
     });
   });
 
+  describe("tunnel passthrough", () => {
+    it("routes non-portless hostname to single registered route", async () => {
+      const backend = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("tunnel passthrough");
+        })
+      );
+      await listen(backend);
+      const backendAddr = backend.address();
+      if (!backendAddr || typeof backendAddr === "string") throw new Error("no addr");
+
+      const routes: RouteInfo[] = [{ hostname: "myapp.localhost", port: backendAddr.port }];
+      const server = trackServer(
+        createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+      );
+      await listen(server);
+
+      // Simulate ngrok forwarding with its own Host header
+      const res = await request(server, { host: "abc123.ngrok-free.app" });
+      expect(res.status).toBe(200);
+      expect(res.body).toBe("tunnel passthrough");
+    });
+
+    it("returns 404 for non-portless hostname when multiple routes exist", async () => {
+      const routes: RouteInfo[] = [
+        { hostname: "app1.localhost", port: 4001 },
+        { hostname: "app2.localhost", port: 4002 },
+      ];
+      const server = trackServer(
+        createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "abc123.ngrok-free.app" });
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 404 for non-portless hostname when no routes exist", async () => {
+      const routes: RouteInfo[] = [];
+      const server = trackServer(
+        createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "abc123.ngrok-free.app" });
+      expect(res.status).toBe(404);
+    });
+
+    it("does not trigger tunnel passthrough for unregistered portless hostname", async () => {
+      const routes: RouteInfo[] = [{ hostname: "myapp.localhost", port: 4001 }];
+      const server = trackServer(
+        createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+      );
+      await listen(server);
+
+      // This is a .localhost hostname -- should NOT fall back to single route
+      const res = await request(server, { host: "other.localhost" });
+      expect(res.status).toBe(404);
+    });
+
+    it("does not trigger tunnel passthrough for bare TLD hostname", async () => {
+      const routes: RouteInfo[] = [{ hostname: "myapp.localhost", port: 4001 }];
+      const server = trackServer(
+        createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "localhost" });
+      expect(res.status).toBe(404);
+    });
+
+    it("works with cloudflare tunnel hostnames", async () => {
+      const backend = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("cloudflare tunnel");
+        })
+      );
+      await listen(backend);
+      const backendAddr = backend.address();
+      if (!backendAddr || typeof backendAddr === "string") throw new Error("no addr");
+
+      const routes: RouteInfo[] = [{ hostname: "myapp.localhost", port: backendAddr.port }];
+      const server = trackServer(
+        createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "random-words.trycloudflare.com" });
+      expect(res.status).toBe(200);
+      expect(res.body).toBe("cloudflare tunnel");
+    });
+  });
+
+  describe("alias routing", () => {
+    it("routes aliased hostname to correct backend", async () => {
+      const backend = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("via alias");
+        })
+      );
+      await listen(backend);
+      const backendAddr = backend.address();
+      if (!backendAddr || typeof backendAddr === "string") throw new Error("no addr");
+
+      const routes: RouteInfo[] = [{ hostname: "myapp.localhost", port: backendAddr.port }];
+      const aliases: Record<string, string> = {
+        "abc123.ngrok-free.app": "myapp.localhost",
+      };
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => routes,
+          getAliases: () => aliases,
+          proxyPort: TEST_PROXY_PORT,
+        })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "abc123.ngrok-free.app" });
+      expect(res.status).toBe(200);
+      expect(res.body).toBe("via alias");
+    });
+
+    it("routes to correct app in multi-app setup via alias", async () => {
+      const backend1 = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("app1");
+        })
+      );
+      await listen(backend1);
+      const addr1 = backend1.address();
+      if (!addr1 || typeof addr1 === "string") throw new Error("no addr");
+
+      const backend2 = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("app2");
+        })
+      );
+      await listen(backend2);
+      const addr2 = backend2.address();
+      if (!addr2 || typeof addr2 === "string") throw new Error("no addr");
+
+      const routes: RouteInfo[] = [
+        { hostname: "frontend.localhost", port: addr1.port },
+        { hostname: "api.localhost", port: addr2.port },
+      ];
+      const aliases: Record<string, string> = {
+        "my-tunnel.ngrok-free.app": "api.localhost",
+      };
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => routes,
+          getAliases: () => aliases,
+          proxyPort: TEST_PROXY_PORT,
+        })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "my-tunnel.ngrok-free.app" });
+      expect(res.status).toBe(200);
+      expect(res.body).toBe("app2");
+    });
+
+    it("returns 404 when alias points to non-existent route", async () => {
+      const routes: RouteInfo[] = [
+        { hostname: "app1.localhost", port: 4001 },
+        { hostname: "app2.localhost", port: 4002 },
+      ];
+      const aliases: Record<string, string> = {
+        "abc123.ngrok-free.app": "other.localhost",
+      };
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => routes,
+          getAliases: () => aliases,
+          proxyPort: TEST_PROXY_PORT,
+        })
+      );
+      await listen(server);
+
+      // Alias points to "other.localhost" which doesn't exist;
+      // multiple routes exist so tunnel passthrough does not apply
+      const res = await request(server, { host: "abc123.ngrok-free.app" });
+      expect(res.status).toBe(404);
+    });
+
+    it("prefers exact route match over alias", async () => {
+      const exactBackend = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("exact");
+        })
+      );
+      await listen(exactBackend);
+      const exactAddr = exactBackend.address();
+      if (!exactAddr || typeof exactAddr === "string") throw new Error("no addr");
+
+      const aliasBackend = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("aliased");
+        })
+      );
+      await listen(aliasBackend);
+      const aliasAddr = aliasBackend.address();
+      if (!aliasAddr || typeof aliasAddr === "string") throw new Error("no addr");
+
+      // The host is also a registered route -- exact match should win
+      const routes: RouteInfo[] = [
+        { hostname: "abc123.ngrok-free.app", port: exactAddr.port },
+        { hostname: "other.localhost", port: aliasAddr.port },
+      ];
+      const aliases: Record<string, string> = {
+        "abc123.ngrok-free.app": "other.localhost",
+      };
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => routes,
+          getAliases: () => aliases,
+          proxyPort: TEST_PROXY_PORT,
+        })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "abc123.ngrok-free.app" });
+      expect(res.status).toBe(200);
+      expect(res.body).toBe("exact");
+    });
+  });
+
   describe("missing Host header", () => {
     it("returns 400 when Host header is missing", async () => {
       const routes: RouteInfo[] = [];

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -72,14 +72,45 @@ const MAX_PROXY_HOPS = 5;
  * Find the route matching a given host. Matches exact hostname first, then
  * falls back to wildcard subdomain matching (e.g. tenant.myapp.localhost
  * matches a route registered for myapp.localhost).
+ *
+ * When the host is not a portless-managed hostname (i.e. it does not end with
+ * the configured TLD suffix) and exactly one route is registered, we return
+ * that route as a tunnel passthrough. This lets external tunnel providers
+ * (ngrok, Cloudflare Tunnel, etc.) forward traffic to the proxy without
+ * requiring explicit hostname mapping.
  */
 function findRoute(
   routes: { hostname: string; port: number }[],
-  host: string
+  host: string,
+  tldSuffix: string,
+  aliases?: Record<string, string>
 ): { hostname: string; port: number } | undefined {
-  return (
-    routes.find((r) => r.hostname === host) || routes.find((r) => host.endsWith("." + r.hostname))
-  );
+  // 1. Exact match
+  const exact = routes.find((r) => r.hostname === host);
+  if (exact) return exact;
+
+  // 2. Wildcard subdomain match
+  const wildcard = routes.find((r) => host.endsWith("." + r.hostname));
+  if (wildcard) return wildcard;
+
+  // 3. Alias lookup (e.g. "abc123.ngrok-free.app" -> "myapp.localhost")
+  if (aliases) {
+    const aliasTarget = aliases[host];
+    if (aliasTarget) {
+      const aliased = routes.find((r) => r.hostname === aliasTarget);
+      if (aliased) return aliased;
+    }
+  }
+
+  // 4. Tunnel passthrough: if the host is NOT a portless hostname and there
+  //    is exactly one registered route, assume traffic is arriving via an
+  //    external tunnel and route to the single app.
+  const isPortlessHost = host.endsWith(tldSuffix) || host === tldSuffix.slice(1);
+  if (!isPortlessHost && routes.length === 1) {
+    return routes[0];
+  }
+
+  return undefined;
 }
 
 /** Server type returned by createProxyServer (plain HTTP/1.1 or net.Server TLS wrapper). */
@@ -102,6 +133,7 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
     proxyPort,
     tld = "localhost",
     onError = (msg: string) => console.error(msg),
+    getAliases,
     tls,
   } = options;
   const tldSuffix = `.${tld}`;
@@ -143,7 +175,7 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
       return;
     }
 
-    const route = findRoute(routes, host);
+    const route = findRoute(routes, host, tldSuffix, getAliases?.());
 
     if (!route) {
       const safeHost = escapeHtml(host);
@@ -260,7 +292,7 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
 
     const routes = getRoutes();
     const host = getRequestHost(req).split(":")[0];
-    const route = findRoute(routes, host);
+    const route = findRoute(routes, host, tldSuffix, getAliases?.());
 
     if (!route) {
       socket.destroy();

--- a/packages/portless/src/routes.test.ts
+++ b/packages/portless/src/routes.test.ts
@@ -226,4 +226,83 @@ describe("RouteStore", () => {
       expect(routes[0].hostname).toBe("test.localhost");
     });
   });
+
+  describe("aliases", () => {
+    it("returns empty object when aliases file does not exist", () => {
+      expect(store.loadAliases()).toEqual({});
+    });
+
+    it("returns empty object for invalid JSON", () => {
+      store.ensureDir();
+      fs.writeFileSync(store.getAliasesPath(), "not json");
+      expect(store.loadAliases()).toEqual({});
+    });
+
+    it("returns empty object for non-object JSON", () => {
+      store.ensureDir();
+      fs.writeFileSync(store.getAliasesPath(), "[]");
+      expect(store.loadAliases()).toEqual({});
+    });
+
+    it("adds and loads an alias", () => {
+      store.addAlias("abc123.ngrok-free.app", "myapp.localhost");
+      const aliases = store.loadAliases();
+      expect(aliases).toEqual({ "abc123.ngrok-free.app": "myapp.localhost" });
+    });
+
+    it("overwrites existing alias", () => {
+      store.addAlias("abc123.ngrok-free.app", "app1.localhost");
+      store.addAlias("abc123.ngrok-free.app", "app2.localhost");
+      const aliases = store.loadAliases();
+      expect(aliases["abc123.ngrok-free.app"]).toBe("app2.localhost");
+    });
+
+    it("stores multiple aliases", () => {
+      store.addAlias("tunnel1.ngrok-free.app", "frontend.localhost");
+      store.addAlias("tunnel2.trycloudflare.com", "api.localhost");
+      const aliases = store.loadAliases();
+      expect(Object.keys(aliases)).toHaveLength(2);
+      expect(aliases["tunnel1.ngrok-free.app"]).toBe("frontend.localhost");
+      expect(aliases["tunnel2.trycloudflare.com"]).toBe("api.localhost");
+    });
+
+    it("removes an alias", () => {
+      store.addAlias("abc123.ngrok-free.app", "myapp.localhost");
+      const removed = store.removeAlias("abc123.ngrok-free.app");
+      expect(removed).toBe(true);
+      expect(store.loadAliases()).toEqual({});
+    });
+
+    it("returns false when removing non-existent alias", () => {
+      const removed = store.removeAlias("nonexistent.example.com");
+      expect(removed).toBe(false);
+    });
+
+    it("removes all aliases for a route", () => {
+      store.addAlias("tunnel1.ngrok-free.app", "myapp.localhost");
+      store.addAlias("tunnel2.ngrok-free.app", "myapp.localhost");
+      store.addAlias("other.trycloudflare.com", "api.localhost");
+      store.removeAliasesForRoute("myapp.localhost");
+      const aliases = store.loadAliases();
+      expect(Object.keys(aliases)).toHaveLength(1);
+      expect(aliases["other.trycloudflare.com"]).toBe("api.localhost");
+    });
+
+    it("does nothing when removing aliases for route with no aliases", () => {
+      store.addAlias("abc123.ngrok-free.app", "myapp.localhost");
+      store.removeAliasesForRoute("other.localhost");
+      const aliases = store.loadAliases();
+      expect(Object.keys(aliases)).toHaveLength(1);
+    });
+
+    it("filters out non-string values from aliases file", () => {
+      store.ensureDir();
+      fs.writeFileSync(
+        store.getAliasesPath(),
+        JSON.stringify({ valid: "myapp.localhost", invalid: 123, nullish: null })
+      );
+      const aliases = store.loadAliases();
+      expect(aliases).toEqual({ valid: "myapp.localhost" });
+    });
+  });
 });

--- a/packages/portless/src/routes.ts
+++ b/packages/portless/src/routes.ts
@@ -67,6 +67,7 @@ export class RouteStore {
   /** The state directory path. */
   readonly dir: string;
   private readonly routesPath: string;
+  private readonly aliasesPath: string;
   private readonly lockPath: string;
   readonly pidPath: string;
   readonly portFilePath: string;
@@ -75,6 +76,7 @@ export class RouteStore {
   constructor(dir: string, options?: { onWarning?: (message: string) => void }) {
     this.dir = dir;
     this.routesPath = path.join(dir, "routes.json");
+    this.aliasesPath = path.join(dir, "aliases.json");
     this.lockPath = path.join(dir, "routes.lock");
     this.pidPath = path.join(dir, "proxy.pid");
     this.portFilePath = path.join(dir, "proxy.port");
@@ -241,6 +243,112 @@ export class RouteStore {
     try {
       const routes = this.loadRoutes(true).filter((r) => r.hostname !== hostname);
       this.saveRoutes(routes);
+    } finally {
+      this.releaseLock();
+    }
+  }
+
+  // -- Alias I/O -------------------------------------------------------------
+
+  getAliasesPath(): string {
+    return this.aliasesPath;
+  }
+
+  /**
+   * Load hostname aliases from disk.
+   * Returns a map of external hostname -> portless hostname.
+   */
+  loadAliases(): Record<string, string> {
+    if (!fs.existsSync(this.aliasesPath)) {
+      return {};
+    }
+    try {
+      const raw = fs.readFileSync(this.aliasesPath, "utf-8");
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        this.onWarning?.(`Corrupted aliases file (invalid JSON): ${this.aliasesPath}`);
+        return {};
+      }
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        this.onWarning?.(`Corrupted aliases file (expected object): ${this.aliasesPath}`);
+        return {};
+      }
+      // Validate that all values are strings
+      const aliases: Record<string, string> = {};
+      for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+        if (typeof value === "string") {
+          aliases[key] = value;
+        }
+      }
+      return aliases;
+    } catch {
+      return {};
+    }
+  }
+
+  private saveAliases(aliases: Record<string, string>): void {
+    fs.writeFileSync(this.aliasesPath, JSON.stringify(aliases, null, 2), { mode: this.fileMode });
+    fixOwnership(this.aliasesPath);
+  }
+
+  /**
+   * Map an external hostname (e.g. ngrok URL) to a portless route hostname.
+   */
+  addAlias(externalHostname: string, portlessHostname: string): void {
+    this.ensureDir();
+    if (!this.acquireLock()) {
+      throw new Error("Failed to acquire route lock");
+    }
+    try {
+      const aliases = this.loadAliases();
+      aliases[externalHostname] = portlessHostname;
+      this.saveAliases(aliases);
+    } finally {
+      this.releaseLock();
+    }
+  }
+
+  /**
+   * Remove a specific alias by its external hostname.
+   */
+  removeAlias(externalHostname: string): boolean {
+    this.ensureDir();
+    if (!this.acquireLock()) {
+      throw new Error("Failed to acquire route lock");
+    }
+    try {
+      const aliases = this.loadAliases();
+      if (!(externalHostname in aliases)) return false;
+      delete aliases[externalHostname];
+      this.saveAliases(aliases);
+      return true;
+    } finally {
+      this.releaseLock();
+    }
+  }
+
+  /**
+   * Remove all aliases pointing at a given portless hostname.
+   */
+  removeAliasesForRoute(portlessHostname: string): void {
+    this.ensureDir();
+    if (!this.acquireLock()) {
+      throw new Error("Failed to acquire route lock");
+    }
+    try {
+      const aliases = this.loadAliases();
+      let changed = false;
+      for (const [ext, target] of Object.entries(aliases)) {
+        if (target === portlessHostname) {
+          delete aliases[ext];
+          changed = true;
+        }
+      }
+      if (changed) {
+        this.saveAliases(aliases);
+      }
     } finally {
       this.releaseLock();
     }

--- a/packages/portless/src/tunnel.test.ts
+++ b/packages/portless/src/tunnel.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { getTunnelProvider, TUNNEL_PROVIDERS } from "./tunnel.js";
+
+describe("tunnel providers", () => {
+  it("exposes ngrok and cloudflare as known providers", () => {
+    expect(TUNNEL_PROVIDERS).toContain("ngrok");
+    expect(TUNNEL_PROVIDERS).toContain("cloudflare");
+  });
+
+  it("returns ngrok provider by name", () => {
+    const provider = getTunnelProvider("ngrok");
+    expect(provider).toBeDefined();
+    expect(provider!.name).toBe("ngrok");
+  });
+
+  it("returns cloudflare provider by name", () => {
+    const provider = getTunnelProvider("cloudflare");
+    expect(provider).toBeDefined();
+    expect(provider!.name).toBe("cloudflare");
+  });
+
+  it("returns undefined for unknown provider", () => {
+    expect(getTunnelProvider("localtunnel")).toBeUndefined();
+    expect(getTunnelProvider("")).toBeUndefined();
+  });
+
+  describe("ngrok provider", () => {
+    it("has isAvailable method", () => {
+      const provider = getTunnelProvider("ngrok")!;
+      expect(typeof provider.isAvailable).toBe("function");
+      // isAvailable returns a boolean (may or may not be installed)
+      const result = provider.isAvailable();
+      expect(typeof result).toBe("boolean");
+    });
+
+    it("has start method", () => {
+      const provider = getTunnelProvider("ngrok")!;
+      expect(typeof provider.start).toBe("function");
+    });
+  });
+
+  describe("cloudflare provider", () => {
+    it("has isAvailable method", () => {
+      const provider = getTunnelProvider("cloudflare")!;
+      expect(typeof provider.isAvailable).toBe("function");
+      const result = provider.isAvailable();
+      expect(typeof result).toBe("boolean");
+    });
+
+    it("has start method", () => {
+      const provider = getTunnelProvider("cloudflare")!;
+      expect(typeof provider.start).toBe("function");
+    });
+  });
+});

--- a/packages/portless/src/tunnel.ts
+++ b/packages/portless/src/tunnel.ts
@@ -1,0 +1,219 @@
+import { type ChildProcess, spawn, execFileSync } from "node:child_process";
+
+/** Timeout (ms) waiting for a tunnel URL to become available. */
+const TUNNEL_URL_TIMEOUT_MS = 30_000;
+
+/** Polling interval (ms) when checking ngrok's local API for the tunnel URL. */
+const NGROK_POLL_INTERVAL_MS = 500;
+
+export interface TunnelProvider {
+  /** Display name of the provider (e.g. "ngrok", "cloudflare"). */
+  readonly name: string;
+
+  /** Check if the tunnel CLI binary is installed and accessible. */
+  isAvailable(): boolean;
+
+  /**
+   * Start a tunnel pointing at the given local port.
+   * Resolves once the public URL is known.
+   */
+  start(localPort: number): Promise<TunnelInstance>;
+}
+
+export interface TunnelInstance {
+  /** The public tunnel URL (e.g. https://abc123.ngrok-free.app). */
+  url: string;
+
+  /** The tunnel's child process. */
+  process: ChildProcess;
+
+  /** Gracefully stop the tunnel. */
+  stop(): void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isCommandAvailable(command: string): boolean {
+  try {
+    execFileSync("which", [command], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function waitForOutput(
+  proc: ChildProcess,
+  pattern: RegExp,
+  stream: "stdout" | "stderr",
+  timeoutMs: number
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Timed out waiting for tunnel URL (${timeoutMs}ms)`));
+    }, timeoutMs);
+
+    const source = stream === "stdout" ? proc.stdout : proc.stderr;
+    if (!source) {
+      clearTimeout(timer);
+      reject(new Error(`No ${stream} stream on tunnel process`));
+      return;
+    }
+
+    let buffer = "";
+    const onData = (chunk: Buffer) => {
+      buffer += chunk.toString();
+      const match = pattern.exec(buffer);
+      if (match) {
+        clearTimeout(timer);
+        source.removeListener("data", onData);
+        resolve(match[1] || match[0]);
+      }
+    };
+    source.on("data", onData);
+
+    proc.on("exit", (code) => {
+      clearTimeout(timer);
+      source.removeListener("data", onData);
+      reject(new Error(`Tunnel process exited with code ${code} before URL was available`));
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// ngrok provider
+// ---------------------------------------------------------------------------
+
+/**
+ * ngrok tunnel provider.
+ *
+ * Starts `ngrok http <port>` and discovers the public URL by polling ngrok's
+ * local management API at http://127.0.0.1:4040/api/tunnels.
+ */
+export const ngrokProvider: TunnelProvider = {
+  name: "ngrok",
+
+  isAvailable(): boolean {
+    return isCommandAvailable("ngrok");
+  },
+
+  async start(localPort: number): Promise<TunnelInstance> {
+    const proc = spawn("ngrok", ["http", String(localPort), "--log=stdout", "--log-format=json"], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    // ngrok exposes a local API -- poll it for the tunnel URL
+    const url = await pollNgrokApi(proc, TUNNEL_URL_TIMEOUT_MS);
+
+    return {
+      url,
+      process: proc,
+      stop() {
+        if (!proc.killed) {
+          proc.kill("SIGTERM");
+        }
+      },
+    };
+  },
+};
+
+async function pollNgrokApi(proc: ChildProcess, timeoutMs: number): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    // Check if process died
+    if (proc.exitCode !== null) {
+      throw new Error(`ngrok exited with code ${proc.exitCode} before tunnel was ready`);
+    }
+
+    try {
+      const res = await fetch("http://127.0.0.1:4040/api/tunnels");
+      if (res.ok) {
+        const data = (await res.json()) as {
+          tunnels: Array<{ public_url: string; proto: string }>;
+        };
+        // Prefer HTTPS tunnel
+        const httpsTunnel = data.tunnels.find((t) => t.proto === "https");
+        const tunnel = httpsTunnel || data.tunnels[0];
+        if (tunnel?.public_url) {
+          return tunnel.public_url;
+        }
+      }
+    } catch {
+      // API not ready yet; retry
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, NGROK_POLL_INTERVAL_MS));
+  }
+
+  throw new Error(`Timed out waiting for ngrok tunnel URL (${timeoutMs}ms)`);
+}
+
+// ---------------------------------------------------------------------------
+// Cloudflare Tunnel provider
+// ---------------------------------------------------------------------------
+
+/**
+ * Cloudflare Tunnel (cloudflared) provider.
+ *
+ * Starts `cloudflared tunnel --url http://localhost:<port>` and parses the
+ * public URL from stderr output (cloudflared prints it during startup).
+ */
+export const cloudflareProvider: TunnelProvider = {
+  name: "cloudflare",
+
+  isAvailable(): boolean {
+    return isCommandAvailable("cloudflared");
+  },
+
+  async start(localPort: number): Promise<TunnelInstance> {
+    const proc = spawn("cloudflared", ["tunnel", "--url", `http://localhost:${localPort}`], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    // cloudflared prints the URL to stderr like:
+    //   ... | INF +-----------------------------------------------------------+
+    //   ... | INF |  Your quick Tunnel has been created! Visit it at (it may   |
+    //   ... | INF |  take some time to be reachable):                          |
+    //   ... | INF |  https://random-words.trycloudflare.com                    |
+    //   ... | INF +-----------------------------------------------------------+
+    const url = await waitForOutput(
+      proc,
+      /https:\/\/[a-z0-9-]+\.trycloudflare\.com/,
+      "stderr",
+      TUNNEL_URL_TIMEOUT_MS
+    );
+
+    return {
+      url,
+      process: proc,
+      stop() {
+        if (!proc.killed) {
+          proc.kill("SIGTERM");
+        }
+      },
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Provider registry
+// ---------------------------------------------------------------------------
+
+const providers: Record<string, TunnelProvider> = {
+  ngrok: ngrokProvider,
+  cloudflare: cloudflareProvider,
+};
+
+/** Known provider names. */
+export const TUNNEL_PROVIDERS = Object.keys(providers);
+
+/**
+ * Get a tunnel provider by name.
+ * Returns undefined if the provider is not known.
+ */
+export function getTunnelProvider(name: string): TunnelProvider | undefined {
+  return providers[name];
+}

--- a/packages/portless/src/types.ts
+++ b/packages/portless/src/types.ts
@@ -13,6 +13,11 @@ export interface ProxyServerOptions {
   tld?: string;
   /** Optional error logger; defaults to console.error. */
   onError?: (message: string) => void;
+  /**
+   * Called on each request to get current hostname aliases.
+   * Maps external hostnames (e.g. ngrok URLs) to portless route hostnames.
+   */
+  getAliases?: () => Record<string, string>;
   /** When provided, enables HTTP/2 over TLS (HTTPS). */
   tls?: {
     cert: Buffer;

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -95,6 +95,34 @@ Set `PORTLESS=0` to run the command directly without the proxy:
 PORTLESS=0 pnpm dev   # Bypasses proxy, uses default port
 ```
 
+### Tunnels (ngrok, Cloudflare Tunnel)
+
+Expose your local dev server to the internet using ngrok or Cloudflare Tunnel.
+
+**Managed tunnel** -- portless starts the tunnel for you:
+
+```bash
+portless myapp --tunnel ngrok next dev        # Starts app + ngrok tunnel
+portless run --tunnel cloudflare next dev     # Starts app + cloudflare tunnel
+```
+
+The child process receives `PORTLESS_TUNNEL_URL` with the public tunnel URL. Requires `ngrok` or `cloudflared` to be installed.
+
+**Single-app passthrough** -- with one app running, portless auto-routes tunnel traffic:
+
+```bash
+portless myapp next dev       # Terminal 1
+ngrok http 1355               # Terminal 2; auto-routed to the single app
+```
+
+**Multi-app with explicit mapping:**
+
+```bash
+portless tunnel map myapp abc123.ngrok-free.app    # Map tunnel hostname
+portless tunnel unmap abc123.ngrok-free.app        # Remove mapping
+portless tunnel list                                # Show all mappings
+```
+
 ## How It Works
 
 1. `portless proxy start` starts an HTTP reverse proxy on port 1355 as a background daemon (configurable with `-p` / `--port` or the `PORTLESS_PORT` env var). The proxy also auto-starts when you run an app.
@@ -124,6 +152,7 @@ Override with the `PORTLESS_STATE_DIR` environment variable.
 | `PORTLESS_TLD`        | Use a custom TLD instead of localhost (e.g. test)                 |
 | `PORTLESS_SYNC_HOSTS` | Set to `1` to auto-sync /etc/hosts (auto-enabled for custom TLDs) |
 | `PORTLESS_STATE_DIR`  | Override the state directory                                      |
+| `PORTLESS_TUNNEL`     | Start a tunnel automatically (ngrok, cloudflare)                  |
 | `PORTLESS=0`          | Bypass the proxy, run the command directly                        |
 
 ### HTTP/2 + HTTPS
@@ -142,33 +171,37 @@ On Linux, `portless trust` supports Debian/Ubuntu, Arch, Fedora/RHEL/CentOS, and
 
 ## CLI Reference
 
-| Command                                | Description                                                   |
-| -------------------------------------- | ------------------------------------------------------------- |
-| `portless run <cmd> [args...]`         | Infer name from project, run through proxy (auto-starts)      |
-| `portless run --name <name> <cmd>`     | Override inferred base name (worktree prefix still applies)   |
-| `portless <name> <cmd> [args...]`      | Run app at `http://<name>.localhost:1355` (auto-starts proxy) |
-| `portless list`                        | Show active routes                                            |
-| `portless trust`                       | Add local CA to system trust store (for HTTPS)                |
-| `portless proxy start`                 | Start the proxy as a daemon (port 1355, no sudo)              |
-| `portless proxy start --https`         | Start with HTTP/2 + TLS (auto-generates certs)                |
-| `portless proxy start -p <number>`     | Start the proxy on a custom port                              |
-| `portless proxy start --tld test`      | Use .test instead of .localhost (requires /etc/hosts sync)    |
-| `portless proxy start --foreground`    | Start the proxy in foreground (for debugging)                 |
-| `portless proxy stop`                  | Stop the proxy                                                |
-| `portless alias <name> <port>`         | Register a static route (e.g. for Docker containers)          |
-| `portless alias <name> <port> --force` | Overwrite an existing route                                   |
-| `portless alias --remove <name>`       | Remove a static route                                         |
-| `portless hosts sync`                  | Add routes to /etc/hosts (fixes Safari)                       |
-| `portless hosts clean`                 | Remove portless entries from /etc/hosts                       |
-| `portless <name> --app-port <n> <cmd>` | Use a fixed port for the app instead of auto-assignment       |
-| `portless <name> --force <cmd>`        | Override an existing route registered by another process      |
-| `portless --name <name> <cmd>`         | Force `<name>` as app name (bypasses subcommand dispatch)     |
-| `portless <name> -- <cmd> [args...]`   | Stop flag parsing; everything after `--` is passed to child   |
-| `portless --help` / `-h`               | Show help                                                     |
-| `portless run --help`                  | Show help for a subcommand (also: alias, hosts)               |
-| `portless --version` / `-v`            | Show version                                                  |
+| Command                                 | Description                                                   |
+| --------------------------------------- | ------------------------------------------------------------- |
+| `portless run <cmd> [args...]`          | Infer name from project, run through proxy (auto-starts)      |
+| `portless run --name <name> <cmd>`      | Override inferred base name (worktree prefix still applies)   |
+| `portless <name> <cmd> [args...]`       | Run app at `http://<name>.localhost:1355` (auto-starts proxy) |
+| `portless list`                         | Show active routes                                            |
+| `portless trust`                        | Add local CA to system trust store (for HTTPS)                |
+| `portless proxy start`                  | Start the proxy as a daemon (port 1355, no sudo)              |
+| `portless proxy start --https`          | Start with HTTP/2 + TLS (auto-generates certs)                |
+| `portless proxy start -p <number>`      | Start the proxy on a custom port                              |
+| `portless proxy start --tld test`       | Use .test instead of .localhost (requires /etc/hosts sync)    |
+| `portless proxy start --foreground`     | Start the proxy in foreground (for debugging)                 |
+| `portless proxy stop`                   | Stop the proxy                                                |
+| `portless alias <name> <port>`          | Register a static route (e.g. for Docker containers)          |
+| `portless alias <name> <port> --force`  | Overwrite an existing route                                   |
+| `portless alias --remove <name>`        | Remove a static route                                         |
+| `portless hosts sync`                   | Add routes to /etc/hosts (fixes Safari)                       |
+| `portless hosts clean`                  | Remove portless entries from /etc/hosts                       |
+| `portless <name> --tunnel <prov> <cmd>` | Start app with a tunnel (ngrok, cloudflare)                   |
+| `portless tunnel map <name> <host>`     | Map external tunnel hostname to a portless app                |
+| `portless tunnel unmap <host>`          | Remove a tunnel hostname mapping                              |
+| `portless tunnel list`                  | Show all tunnel hostname mappings                             |
+| `portless <name> --app-port <n> <cmd>`  | Use a fixed port for the app instead of auto-assignment       |
+| `portless <name> --force <cmd>`         | Override an existing route registered by another process      |
+| `portless --name <name> <cmd>`          | Force `<name>` as app name (bypasses subcommand dispatch)     |
+| `portless <name> -- <cmd> [args...]`    | Stop flag parsing; everything after `--` is passed to child   |
+| `portless --help` / `-h`                | Show help                                                     |
+| `portless run --help`                   | Show help for a subcommand (also: alias, tunnel, hosts)       |
+| `portless --version` / `-v`             | Show version                                                  |
 
-**Reserved names:** `run`, `alias`, `hosts`, `list`, `trust`, and `proxy` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name, or `portless --name <name> <cmd>` to force any name including reserved ones.
+**Reserved names:** `run`, `get`, `alias`, `tunnel`, `hosts`, `list`, `trust`, and `proxy` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name, or `portless --name <name> <cmd>` to force any name including reserved ones.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Adds support for external tunnel providers (ngrok, Cloudflare Tunnel) to expose local dev servers to the internet. Closes #43.

**Session trace**: https://www.traces.com/s/jn7c9rx9wqywxp9a77b265qtg582p96p

## What changed

Three levels of integration, each independently useful:

### 1. Single-app passthrough (zero config)

When one app is running and a request arrives with a non-`.localhost` Host header (e.g. from ngrok forwarding), portless auto-routes it to the single registered app. This means the simplest tunnel workflow just works:

```bash
portless myapp next dev       # Terminal 1
ngrok http 1355               # Terminal 2 -- auto-routed
```

### 2. Hostname aliasing (`portless tunnel map/unmap/list`)

For multi-app setups, explicitly map an external tunnel hostname to a portless route:

```bash
portless tunnel map myapp abc123.ngrok-free.app
portless tunnel unmap abc123.ngrok-free.app
portless tunnel list
```

Aliases are stored in `aliases.json` in the state directory and watched for changes by the proxy.

### 3. Managed tunnels (`--tunnel` flag)

Portless can start the tunnel for you, auto-register the alias, and pass the tunnel URL to the child process:

```bash
portless myapp --tunnel ngrok next dev
portless run --tunnel cloudflare next dev
```

The child process receives `PORTLESS_TUNNEL_URL` alongside the existing `PORTLESS_URL`. Tunnel cleanup (process kill + alias removal) happens automatically on exit.

## Files changed

| File | Changes |
|------|---------|
| `proxy.ts` | `findRoute()` extended with alias lookup + tunnel passthrough fallback |
| `types.ts` | Added `getAliases` to `ProxyServerOptions` |
| `routes.ts` | Alias storage: `loadAliases`, `addAlias`, `removeAlias`, `removeAliasesForRoute` |
| `tunnel.ts` | **New**: `TunnelProvider`/`TunnelInstance` interfaces, ngrok + cloudflare providers |
| `cli.ts` | `--tunnel` flag, `PORTLESS_TUNNEL` env var, `handleTunnel` command, alias watching in proxy startup |
| `index.ts` | Re-exports `tunnel.ts` |
| `README.md` | New "Tunnels" section, updated commands/options/env vars |
| `SKILL.md` | Tunnel docs, updated CLI reference and env vars tables |
| Tests | 36 new tests across `proxy.test.ts`, `routes.test.ts`, `tunnel.test.ts`, `cli.test.ts` |

## Testing

- 323 tests passing (36 new)
- Typecheck clean
- Lint clean
- Zero new runtime dependencies