### PR TITLE
fix: add Windows compatibility for hosts file management

### DIFF
--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -40,6 +40,12 @@ import {
 // Constants
 // ---------------------------------------------------------------------------
 
+/** Display-friendly hosts file path. */
+const HOSTS_DISPLAY = isWindows ? "hosts file" : "/etc/hosts";
+
+/** Prefix for commands that need elevated privileges. */
+const SUDO_PREFIX = isWindows ? "" : "sudo ";
+
 /** Debounce delay (ms) for reloading routes after a file change. */
 const DEBOUNCE_MS = 100;
 
@@ -719,8 +725,8 @@ ${chalk.bold("Usage:")}
   ${chalk.cyan("portless alias --remove <name>")}   Remove a static route
   ${chalk.cyan("portless list")}                    Show active routes
   ${chalk.cyan("portless trust")}                   Add local CA to system trust store
-  ${chalk.cyan("portless hosts sync")}              Add routes to /etc/hosts (fixes Safari)
-  ${chalk.cyan("portless hosts clean")}             Remove portless entries from /etc/hosts
+  ${chalk.cyan("portless hosts sync")}              Add routes to ${HOSTS_DISPLAY} (fixes Safari)
+  ${chalk.cyan("portless hosts clean")}             Remove portless entries from ${HOSTS_DISPLAY}
 
 ${chalk.bold("Examples:")}
   portless proxy start                # Start proxy on port 1355
@@ -775,7 +781,7 @@ ${chalk.bold("Environment variables:")}
   PORTLESS_APP_PORT=<number>    Use a fixed port for the app (same as --app-port)
   PORTLESS_HTTPS=1              Always enable HTTPS (set in .bashrc / .zshrc)
   PORTLESS_TLD=<tld>            Use a custom TLD (e.g. test, dev; default: localhost)
-  PORTLESS_SYNC_HOSTS=1         Auto-sync /etc/hosts (auto-enabled for custom TLDs)
+  PORTLESS_SYNC_HOSTS=1         Auto-sync ${HOSTS_DISPLAY} (auto-enabled for custom TLDs)
   PORTLESS_STATE_DIR=<path>     Override the state directory
   PORTLESS=0                    Run command directly without proxy
 
@@ -787,11 +793,11 @@ ${chalk.bold("Child process environment:")}
 ${chalk.bold("Safari / DNS:")}
   .localhost subdomains auto-resolve in Chrome, Firefox, and Edge.
   Safari relies on the system DNS resolver, which may not handle them.
-  Auto-syncs /etc/hosts for custom TLDs (e.g. --tld test). For .localhost,
+  Auto-syncs ${HOSTS_DISPLAY} for custom TLDs (e.g. --tld test). For .localhost,
   set PORTLESS_SYNC_HOSTS=1 to enable. To manually sync:
-    ${chalk.cyan("sudo portless hosts sync")}
+    ${chalk.cyan(`${SUDO_PREFIX}portless hosts sync`)}
   Clean up later with:
-    ${chalk.cyan("sudo portless hosts clean")}
+    ${chalk.cyan(`${SUDO_PREFIX}portless hosts clean`)}
 
 ${chalk.bold("Skip portless:")}
   PORTLESS=0 pnpm dev           # Runs command directly without proxy
@@ -963,14 +969,14 @@ ${chalk.bold("Examples:")}
 async function handleHosts(args: string[]): Promise<void> {
   if (args[1] === "--help" || args[1] === "-h") {
     console.log(`
-${chalk.bold("portless hosts")} - Manage /etc/hosts entries for .localhost subdomains.
+${chalk.bold("portless hosts")} - Manage ${HOSTS_DISPLAY} entries for .localhost subdomains.
 
 Safari relies on the system DNS resolver, which may not handle .localhost
-subdomains. This command adds entries to /etc/hosts as a workaround.
+subdomains. This command adds entries to ${HOSTS_DISPLAY} as a workaround.
 
 ${chalk.bold("Usage:")}
-  ${chalk.cyan("sudo portless hosts sync")}    Add current routes to /etc/hosts
-  ${chalk.cyan("sudo portless hosts clean")}   Remove portless entries from /etc/hosts
+  ${chalk.cyan(`${SUDO_PREFIX}portless hosts sync`)}    Add current routes to ${HOSTS_DISPLAY}
+  ${chalk.cyan(`${SUDO_PREFIX}portless hosts clean`)}   Remove portless entries from ${HOSTS_DISPLAY}
 
 ${chalk.bold("Auto-sync:")}
   Auto-enabled for custom TLDs (e.g. --tld test). For .localhost, set
@@ -981,10 +987,14 @@ ${chalk.bold("Auto-sync:")}
 
   if (args[1] === "clean") {
     if (cleanHostsFile()) {
-      console.log(chalk.green("Removed portless entries from /etc/hosts."));
+      console.log(chalk.green(`Removed portless entries from ${HOSTS_DISPLAY}.`));
     } else {
-      console.error(chalk.red("Failed to update /etc/hosts (requires sudo)."));
-      console.error(chalk.cyan("  sudo portless hosts clean"));
+      console.error(
+        chalk.red(
+          `Failed to update ${HOSTS_DISPLAY}${isWindows ? " (run as Administrator)." : " (requires sudo)."}`
+        )
+      );
+      console.error(chalk.cyan(`  ${SUDO_PREFIX}portless hosts clean`));
       process.exit(1);
     }
     return;
@@ -994,8 +1004,8 @@ ${chalk.bold("Auto-sync:")}
     console.log(`
 ${chalk.bold("Usage: portless hosts <command>")}
 
-  ${chalk.cyan("sudo portless hosts sync")}    Add current routes to /etc/hosts
-  ${chalk.cyan("sudo portless hosts clean")}   Remove portless entries from /etc/hosts
+  ${chalk.cyan(`${SUDO_PREFIX}portless hosts sync`)}    Add current routes to ${HOSTS_DISPLAY}
+  ${chalk.cyan(`${SUDO_PREFIX}portless hosts clean`)}   Remove portless entries from ${HOSTS_DISPLAY}
 `);
     process.exit(0);
   }
@@ -1003,8 +1013,10 @@ ${chalk.bold("Usage: portless hosts <command>")}
   if (args[1] !== "sync") {
     console.error(chalk.red(`Error: Unknown hosts subcommand "${args[1]}".`));
     console.error(chalk.blue("Usage:"));
-    console.error(chalk.cyan("  portless hosts sync    # Add routes to /etc/hosts"));
-    console.error(chalk.cyan("  portless hosts clean   # Remove portless entries"));
+    console.error(
+      chalk.cyan(`  ${SUDO_PREFIX}portless hosts sync    # Add routes to ${HOSTS_DISPLAY}`)
+    );
+    console.error(chalk.cyan(`  ${SUDO_PREFIX}portless hosts clean   # Remove portless entries`));
     process.exit(1);
   }
 
@@ -1020,13 +1032,17 @@ ${chalk.bold("Usage: portless hosts <command>")}
   }
   const hostnames = routes.map((r) => r.hostname);
   if (syncHostsFile(hostnames)) {
-    console.log(chalk.green(`Synced ${hostnames.length} hostname(s) to /etc/hosts:`));
+    console.log(chalk.green(`Synced ${hostnames.length} hostname(s) to ${HOSTS_DISPLAY}:`));
     for (const h of hostnames) {
       console.log(chalk.cyan(`  127.0.0.1 ${h}`));
     }
   } else {
-    console.error(chalk.red("Failed to update /etc/hosts (requires sudo)."));
-    console.error(chalk.cyan("  sudo portless hosts sync"));
+    console.error(
+      chalk.red(
+        `Failed to update ${HOSTS_DISPLAY}${isWindows ? " (run as Administrator)." : " (requires sudo)."}`
+      )
+    );
+    console.error(chalk.cyan(`  ${SUDO_PREFIX}portless hosts sync`));
     process.exit(1);
   }
 }
@@ -1139,10 +1155,12 @@ ${chalk.bold("Usage:")}
     process.env.PORTLESS_SYNC_HOSTS === "0" || process.env.PORTLESS_SYNC_HOSTS === "false";
   if (tld !== DEFAULT_TLD && syncDisabled) {
     console.warn(
-      chalk.yellow(`Warning: .${tld} domains require /etc/hosts entries to resolve to 127.0.0.1.`)
+      chalk.yellow(
+        `Warning: .${tld} domains require ${HOSTS_DISPLAY} entries to resolve to 127.0.0.1.`
+      )
     );
     console.warn(chalk.yellow("Hosts sync is disabled. To add entries manually, run:"));
-    console.warn(chalk.cyan("  sudo portless hosts sync"));
+    console.warn(chalk.cyan(`  ${SUDO_PREFIX}portless hosts sync`));
   }
 
   // Custom cert/key implies HTTPS

--- a/packages/portless/src/hosts.ts
+++ b/packages/portless/src/hosts.ts
@@ -1,7 +1,12 @@
 import * as fs from "node:fs";
 import * as dns from "node:dns";
+import * as path from "node:path";
 
-const HOSTS_PATH = "/etc/hosts";
+const isWindows = process.platform === "win32";
+
+const HOSTS_PATH = isWindows
+  ? path.join(process.env.SystemRoot ?? "C:\\Windows", "System32", "drivers", "etc", "hosts")
+  : "/etc/hosts";
 const MARKER_START = "# portless-start";
 const MARKER_END = "# portless-end";
 

--- a/tests/e2e/src/harness.ts
+++ b/tests/e2e/src/harness.ts
@@ -14,25 +14,54 @@ const VENV_DIR = path.resolve(__dirname, "../.venv");
 // collisions. Current allocation: 19001-19011. Pick the next unused port
 // when adding a new test.
 
+const isWindows = process.platform === "win32";
+
 /** Path to the Python binary inside the e2e venv. */
-export const PYTHON_BIN = path.join(VENV_DIR, "bin", "python3");
+export const PYTHON_BIN = isWindows
+  ? path.join(VENV_DIR, "Scripts", "python.exe")
+  : path.join(VENV_DIR, "bin", "python3");
 
 /** Kill any process listening on the given TCP port (skips our own PID). */
 function killPort(port: number): void {
   try {
-    const pids = execSync(`lsof -ti tcp:${port}`, {
-      encoding: "utf-8",
-      timeout: 5000,
-    }).trim();
-    if (pids) {
+    if (isWindows) {
+      const output = execSync("netstat -ano -p tcp", {
+        encoding: "utf-8",
+        timeout: 5000,
+      });
       const myPid = process.pid;
-      for (const raw of pids.split("\n")) {
-        const pid = parseInt(raw, 10);
-        if (isNaN(pid) || pid === myPid) continue;
+      for (const line of output.split(/\r?\n/)) {
+        if (!line.includes("LISTENING")) continue;
+        const parts = line.trim().split(/\s+/);
+        if (parts.length < 5) continue;
+        const localAddr = parts[1];
+        const lastColon = localAddr.lastIndexOf(":");
+        if (lastColon === -1) continue;
+        const addrPort = parseInt(localAddr.substring(lastColon + 1), 10);
+        if (addrPort !== port) continue;
+        const pid = parseInt(parts[parts.length - 1], 10);
+        if (isNaN(pid) || pid <= 0 || pid === myPid) continue;
         try {
           process.kill(pid, "SIGTERM");
         } catch {
           // already dead
+        }
+      }
+    } else {
+      const pids = execSync(`lsof -ti tcp:${port}`, {
+        encoding: "utf-8",
+        timeout: 5000,
+      }).trim();
+      if (pids) {
+        const myPid = process.pid;
+        for (const raw of pids.split("\n")) {
+          const pid = parseInt(raw, 10);
+          if (isNaN(pid) || pid === myPid) continue;
+          try {
+            process.kill(pid, "SIGTERM");
+          } catch {
+            // already dead
+          }
         }
       }
     }


### PR DESCRIPTION
This PR adds Windows compatibility for hosts file management functionality in portless.

## Problem
The CLI was hardcoded to use Unix-style paths and commands for hosts file operations (`/etc/hosts`, `sudo`), making it incompatible with Windows systems.

## Changes
- Added Windows detection and proper hosts file path resolution (`C:\Windows\System32\drivers\etc\hosts`)
- Updated all CLI help text and error messages to use platform-appropriate file paths and commands
- Replaced hardcoded `/etc/hosts` references with dynamic `HOSTS_DISPLAY` variable
- Replaced `sudo` prefix with platform-aware `SUDO_PREFIX` (empty on Windows, "sudo " on Unix)
- Updated error messages to suggest "run as Administrator" on Windows vs "requires sudo" on Unix

## Implementation Details
- Added `isWindows` platform detection using `process.platform`
- Created display-friendly constants for consistent messaging across all commands
- Updated hosts file path resolution in `hosts.ts` to use `SystemRoot` environment variable with fallback

Fixes #112