### PR TITLE
feat: make docs chat LLM provider configurable, add MiniMax support (M3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,25 @@ pnpm typecheck        # Type-check all packages
 pnpm format           # Format all files with Prettier
 ```
 
+## Docs Chat LLM
+
+The documentation site at [portless.dev](https://portless.dev) includes an AI chatbot. By default it uses Anthropic Claude Haiku, but you can configure a different provider via environment variables when self-hosting:
+
+```
+DOCS_CHAT_MODEL=anthropic/claude-haiku-4.5    # Default (Anthropic)
+DOCS_CHAT_MODEL=openai/gpt-4o-mini            # OpenAI
+DOCS_CHAT_MODEL=minimax/MiniMax-M2.5          # MiniMax
+```
+
+For MiniMax, set the API key:
+
+```
+MINIMAX_API_KEY=<your-key>
+MINIMAX_BASE_URL=https://api.minimax.io/v1    # Default (global); use https://api.minimaxi.com/v1 for China
+```
+
+Available MiniMax models: `MiniMax-M2.5` (default, 204K context) and `MiniMax-M2.5-highspeed` (faster).
+
 ## Requirements
 
 - Node.js 20+

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ The documentation site at [portless.dev](https://portless.dev) includes an AI ch
 ```
 DOCS_CHAT_MODEL=anthropic/claude-haiku-4.5    # Default (Anthropic)
 DOCS_CHAT_MODEL=openai/gpt-4o-mini            # OpenAI
-DOCS_CHAT_MODEL=minimax/MiniMax-M2.5          # MiniMax
+DOCS_CHAT_MODEL=minimax/MiniMax-M2.7          # MiniMax
 ```
 
 For MiniMax, set the API key:
@@ -265,7 +265,7 @@ MINIMAX_API_KEY=<your-key>
 MINIMAX_BASE_URL=https://api.minimax.io/v1    # Default (global); use https://api.minimaxi.com/v1 for China
 ```
 
-Available MiniMax models: `MiniMax-M2.5` (default, 204K context) and `MiniMax-M2.5-highspeed` (faster).
+Available MiniMax models: `MiniMax-M2.7` (default, latest flagship with enhanced reasoning and coding), `MiniMax-M2.7-highspeed` (high-speed version for low-latency scenarios), `MiniMax-M2.5` (204K context), and `MiniMax-M2.5-highspeed` (faster).
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ The documentation site at [portless.dev](https://portless.dev) includes an AI ch
 ```
 DOCS_CHAT_MODEL=anthropic/claude-haiku-4.5    # Default (Anthropic)
 DOCS_CHAT_MODEL=openai/gpt-4o-mini            # OpenAI
-DOCS_CHAT_MODEL=minimax/MiniMax-M2.7          # MiniMax
+DOCS_CHAT_MODEL=minimax/MiniMax-M3             # MiniMax
 ```
 
 For MiniMax, set the API key:
@@ -265,7 +265,7 @@ MINIMAX_API_KEY=<your-key>
 MINIMAX_BASE_URL=https://api.minimax.io/v1    # Default (global); use https://api.minimaxi.com/v1 for China
 ```
 
-Available MiniMax models: `MiniMax-M2.7` (default, latest flagship with enhanced reasoning and coding), `MiniMax-M2.7-highspeed` (high-speed version for low-latency scenarios), `MiniMax-M2.5` (204K context), and `MiniMax-M2.5-highspeed` (faster).
+Available MiniMax models: `MiniMax-M3` (default, 512K context, up to 128K output, supports image input), `MiniMax-M2.7` (previous flagship), and `MiniMax-M2.7-highspeed` (high-speed version for low-latency scenarios).
 
 ## Requirements
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -9,6 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@ai-sdk/openai": "^3.0.45",
     "@ai-sdk/react": "^3.0.96",
     "@mdx-js/loader": "^3",
     "@mdx-js/react": "^3",

--- a/apps/docs/src/app/api/docs-chat/route.ts
+++ b/apps/docs/src/app/api/docs-chat/route.ts
@@ -2,6 +2,7 @@ import { readFile } from "fs/promises";
 import { join } from "path";
 import { convertToModelMessages, stepCountIs, streamText } from "ai";
 import type { ModelMessage, UIMessage } from "ai";
+import { createOpenAI } from "@ai-sdk/openai";
 import { createBashTool } from "bash-tool";
 import { headers } from "next/headers";
 import { allDocsPages } from "@/lib/docs-navigation";
@@ -10,7 +11,24 @@ import { minuteRateLimit, dailyRateLimit } from "@/lib/rate-limit";
 
 export const maxDuration = 60;
 
-const DEFAULT_MODEL = "anthropic/claude-haiku-4.5";
+const DOCS_CHAT_MODEL = process.env.DOCS_CHAT_MODEL || "anthropic/claude-haiku-4.5";
+
+function createModel() {
+  // MiniMax models use the OpenAI-compatible API
+  if (DOCS_CHAT_MODEL.startsWith("minimax/")) {
+    const minimax = createOpenAI({
+      apiKey: process.env.MINIMAX_API_KEY,
+      baseURL: process.env.MINIMAX_BASE_URL || "https://api.minimax.io/v1",
+    });
+    return minimax(DOCS_CHAT_MODEL.slice("minimax/".length));
+  }
+
+  // For other providers (anthropic, openai, etc.), use AI SDK model string
+  return DOCS_CHAT_MODEL;
+}
+
+const model = createModel();
+const isAnthropic = DOCS_CHAT_MODEL.startsWith("anthropic/");
 
 const SYSTEM_PROMPT = `You are a helpful documentation assistant for portless, a CLI tool that replaces port numbers with stable, named .localhost URLs.
 
@@ -105,14 +123,18 @@ export async function POST(req: Request) {
   } = await createBashTool({ files: docsFiles });
 
   const result = streamText({
-    model: DEFAULT_MODEL,
+    model,
     system: SYSTEM_PROMPT,
     messages: await convertToModelMessages(messages),
     stopWhen: stepCountIs(5),
     tools: { bash, readFile: readFileTool },
-    prepareStep: ({ messages: stepMessages }) => ({
-      messages: addCacheControl(stepMessages),
-    }),
+    ...(isAnthropic
+      ? {
+          prepareStep: ({ messages: stepMessages }) => ({
+            messages: addCacheControl(stepMessages),
+          }),
+        }
+      : {}),
   });
 
   return result.toUIMessageStreamResponse();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
 
   apps/docs:
     dependencies:
+      '@ai-sdk/openai':
+        specifier: ^3.0.45
+        version: 3.0.45(zod@4.3.5)
       '@ai-sdk/react':
         specifier: ^3.0.96
         version: 3.0.96(react@19.2.4)(zod@4.3.5)
@@ -305,8 +308,20 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/openai@3.0.45':
+    resolution: {integrity: sha512-bHOw3E73pxo4D/dZUXk7zwmlofq2nURYlK1dSAy/CI+t6btVhr/BXbElAR7yst6P8Ukqy5GfFlFfsru5p6YSig==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@4.0.15':
     resolution: {integrity: sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.20':
+    resolution: {integrity: sha512-gpUIj9uDhIGbuo9afKEgQ074BWmhvK4THJAAeBjRnroTy2yQYo6rbtGD7pQDMZM8ouXPYmT/SCdkWVJ0KcpX8A==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -9061,7 +9076,20 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 4.3.5
 
+  '@ai-sdk/openai@3.0.45(zod@4.3.5)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.20(zod@4.3.5)
+      zod: 4.3.5
+
   '@ai-sdk/provider-utils@4.0.15(zod@4.3.5)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.3.5
+
+  '@ai-sdk/provider-utils@4.0.20(zod@4.3.5)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0


### PR DESCRIPTION
## Summary
- Make the docs chat LLM provider configurable via `DOCS_CHAT_MODEL` environment variable
- Add MiniMax as an alternative LLM provider using the OpenAI-compatible API
- Default MiniMax model: `MiniMax-M3` (latest flagship: 512K context, up to 128K output, supports image input)

## Changes
- Add `createModel()` function in docs-chat route to support provider-specific configuration
- Support `minimax/` prefix for MiniMax models via `@ai-sdk/openai` compatible SDK
- Document available providers and MiniMax configuration in README
- Available MiniMax models: M3 (default), M2.7, M2.7-highspeed

## Why
Allows self-hosters to choose their preferred LLM provider. `MiniMax-M3` is the latest flagship model, with a 512K context window, up to 128K output, and image input support.

## Testing
- Verified MiniMax provider routing works with OpenAI-compatible API
- Existing providers (Anthropic, OpenAI) continue to work unchanged