### PR TITLE
fix(docs): add Windows to docs requirements

### DIFF
--- a/apps/docs/src/app/page.mdx
+++ b/apps/docs/src/app/page.mdx
@@ -98,4 +98,4 @@ Browser (myapp.localhost:1355) -> proxy (port 1355) -> App (random port)
 ## Requirements
 
 - Node.js 20+
-- macOS or Linux
+- macOS, Linux, or Windows


### PR DESCRIPTION
Fix the docs homepage requirements list to match the README by adding Windows support.