### PR TITLE
fix: resolve 'node not recognized' on Windows in portless run

### DIFF
--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -454,9 +454,16 @@ function collectBinPaths(cwd: string): string[] {
  * Build a PATH string with `node_modules/.bin` directories prepended.
  */
 function augmentedPath(env: NodeJS.ProcessEnv | undefined): string {
-  const base = (env ?? process.env).PATH ?? "";
+  const source = env ?? process.env;
+  // On Windows, the PATH variable may be stored as "Path" (case-insensitive in
+  // process.env but case-sensitive in plain objects created via spread).
+  const base = source.PATH ?? source.Path ?? "";
   const bins = collectBinPaths(process.cwd());
-  return bins.length > 0 ? bins.join(path.delimiter) + path.delimiter + base : base;
+  // Ensure node's own directory is in PATH so .cmd wrappers in node_modules/.bin
+  // can locate the node executable (fixes Windows "node not recognized" errors).
+  const nodeBin = path.dirname(process.execPath);
+  const allBins = [...bins, nodeBin];
+  return allBins.join(path.delimiter) + path.delimiter + base;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #121 — `portless run vite` fails on Windows with "'node' is not recognized as an internal or external command".

## Root Cause

`augmentedPath()` reads `env.PATH` but on Windows the environment variable key is `Path` (capital P, lowercase ath). When `process.env` is spread into a plain object (as done in the `run` command's custom env), the case-insensitive behavior of `process.env` is lost. The plain object has `Path` but `augmentedPath` looked for `PATH`, getting `undefined` and losing the entire system PATH.

## Fix

1. Check both `env.PATH` and `env.Path` to handle Windows casing
2. Always prepend `path.dirname(process.execPath)` so `.cmd` wrappers in `node_modules/.bin` can locate the `node` executable

## Changes

- `packages/portless/src/cli-utils.ts`: Updated `augmentedPath()` function