### PR TITLE
fix: handle ECONNRESET on TLS wrapper socket to prevent proxy crash

### DIFF
--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -358,6 +358,12 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
     // Wrap both in a net.Server that peeks at the first byte to decide
     // whether the connection is TLS (0x16 = ClientHello) or plain HTTP.
     const wrapper = net.createServer((socket) => {
+      // Absorb connection errors (ECONNRESET, EPIPE, etc.) from abrupt
+      // client disconnects (tab close, page reload, HMR) so they don't
+      // bubble up as uncaught exceptions and crash the proxy (#111).
+      socket.on("error", () => {
+        socket.destroy();
+      });
       socket.once("readable", () => {
         const buf: Buffer | null = socket.read(1);
         if (!buf) {


### PR DESCRIPTION
## Summary

Fixes #111 — the proxy no longer crashes when a client disconnects abruptly.

## Problem

The `net.createServer` TLS wrapper socket in `createProxyServer` had no `error` event handler. When a client disconnects abruptly (page reload, tab close, HMR), `ECONNRESET` bubbles up as an uncaught exception and kills the process:

```
Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20)
Emitted 'error' event on Socket instance at:
    ...
```

## Fix

Added an `error` handler on the wrapper socket that silently destroys the connection on errors like `ECONNRESET`, `EPIPE`, etc. This is standard practice for proxy/server sockets.

## Changes

- `packages/portless/src/proxy.ts`: Added `socket.on('error', ...)` in the `net.createServer` callback