### PR TITLE
Add GitHub Action to publish to npm

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["portless-monorepo", "@portless/docs", "google-oauth-example", "portless-e2e"]
+  "ignore": ["@portless/docs", "google-oauth-example", "portless-e2e"]
 }


### PR DESCRIPTION
## Summary

- Add changesets-based release workflow (`.github/workflows/release.yml`) to automatically publish the `portless` package to npm
- Install `@changesets/cli` and configure `.changeset/config.json` with public access
- Add `ci:version` and `ci:publish` scripts to root `package.json`

Modeled after the same release process used by `agent-browser`.