### PR TITLE
fix: proxy detection behind pf redirects

### DIFF
--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -22,6 +22,7 @@ import {
   validateTld,
   writeTldFile,
 } from "./cli-utils.js";
+import { PORTLESS_HEADER, PORTLESS_LISTENER_PORT_HEADER } from "./proxy.js";
 
 describe("findFreePort", () => {
   it("returns a port in the default range", async () => {
@@ -78,13 +79,15 @@ describe("isProxyRunning", () => {
   });
 
   it("returns true when a portless proxy is listening", async () => {
+    let listenerPort = 0;
     const server = http.createServer((_req, res) => {
-      res.setHeader("X-Portless", "1");
+      res.setHeader(PORTLESS_HEADER, "1");
+      res.setHeader(PORTLESS_LISTENER_PORT_HEADER, String(listenerPort));
       res.end("ok");
     });
     servers.push(server);
 
-    const port = await new Promise<number>((resolve) => {
+    listenerPort = await new Promise<number>((resolve) => {
       server.listen(0, "127.0.0.1", () => {
         const addr = server.address();
         if (addr && typeof addr !== "string") {
@@ -93,7 +96,7 @@ describe("isProxyRunning", () => {
       });
     });
 
-    const result = await isProxyRunning(port);
+    const result = await isProxyRunning(listenerPort);
     expect(result).toBe(true);
   });
 
@@ -113,6 +116,28 @@ describe("isProxyRunning", () => {
     });
 
     const result = await isProxyRunning(port);
+    expect(result).toBe(false);
+  });
+
+  it("returns false when a portless response reports a different listener port", async () => {
+    let listenerPort = 0;
+    const server = http.createServer((_req, res) => {
+      res.setHeader(PORTLESS_HEADER, "1");
+      res.setHeader(PORTLESS_LISTENER_PORT_HEADER, String(listenerPort + 1));
+      res.end("redirected");
+    });
+    servers.push(server);
+
+    listenerPort = await new Promise<number>((resolve) => {
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address();
+        if (addr && typeof addr !== "string") {
+          resolve(addr.port);
+        }
+      });
+    });
+
+    const result = await isProxyRunning(listenerPort);
     expect(result).toBe(false);
   });
 });

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -6,7 +6,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import * as readline from "node:readline";
 import { execSync, spawn } from "node:child_process";
-import { PORTLESS_HEADER } from "./proxy.js";
+import { PORTLESS_HEADER, PORTLESS_LISTENER_PORT_HEADER } from "./proxy.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -322,7 +322,9 @@ export async function findFreePort(
 /**
  * Check if a portless proxy is listening on the given port at 127.0.0.1.
  * Makes an HTTP(S) request and verifies the X-Portless response header to
- * distinguish the portless proxy from unrelated services.
+ * distinguish the portless proxy from unrelated services. Also verifies the
+ * proxy reports that it is actually bound to the probed port, which avoids
+ * false positives when pf/NAT redirects a different local port here.
  *
  * When `tls` is true, uses HTTPS with certificate verification disabled
  * (the proxy may use a self-signed or locally-trusted CA cert).
@@ -341,7 +343,24 @@ export function isProxyRunning(port: number, tls = false): Promise<boolean> {
       },
       (res) => {
         res.resume();
-        resolve(res.headers[PORTLESS_HEADER.toLowerCase()] === "1");
+        if (res.headers[PORTLESS_HEADER.toLowerCase()] !== "1") {
+          resolve(false);
+          return;
+        }
+
+        const reportedPort = res.headers[PORTLESS_LISTENER_PORT_HEADER.toLowerCase()];
+        if (typeof reportedPort === "string") {
+          resolve(parseInt(reportedPort, 10) === port);
+          return;
+        }
+        if (Array.isArray(reportedPort) && reportedPort.length > 0) {
+          resolve(parseInt(reportedPort[0], 10) === port);
+          return;
+        }
+
+        // Older proxies do not report their listener port, so fall back to
+        // the legacy header-only check for compatibility.
+        resolve(true);
       }
     );
     req.on("error", () => resolve(false));

--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -6,7 +6,7 @@ import * as https from "node:https";
 import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
-import { createProxyServer, PORTLESS_HEADER } from "./proxy.js";
+import { createProxyServer, PORTLESS_HEADER, PORTLESS_LISTENER_PORT_HEADER } from "./proxy.js";
 import type { ProxyServer } from "./proxy.js";
 import type { RouteInfo } from "./types.js";
 import { ensureCerts } from "./certs.js";
@@ -299,9 +299,12 @@ describe("createProxyServer", () => {
         createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
       );
       await listen(server);
+      const addr = server.address();
+      if (!addr || typeof addr === "string") throw new Error("no addr");
 
       const res = await request(server, { host: "unknown.localhost" });
       expect(res.headers[PORTLESS_HEADER.toLowerCase()]).toBe("1");
+      expect(res.headers[PORTLESS_LISTENER_PORT_HEADER.toLowerCase()]).toBe(String(addr.port));
     });
 
     it("includes X-Portless header on 400 responses", async () => {
@@ -310,9 +313,12 @@ describe("createProxyServer", () => {
         createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
       );
       await listen(server);
+      const addr = server.address();
+      if (!addr || typeof addr === "string") throw new Error("no addr");
 
       const res = await request(server, { host: "" });
       expect(res.headers[PORTLESS_HEADER.toLowerCase()]).toBe("1");
+      expect(res.headers[PORTLESS_LISTENER_PORT_HEADER.toLowerCase()]).toBe(String(addr.port));
     });
   });
 
@@ -953,9 +959,12 @@ describe("createProxyServer with TLS (HTTP/2)", () => {
       })
     );
     await listen(server);
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("no addr");
 
     const res = await httpsRequest(server, { host: "unknown.localhost" });
     expect(res.headers[PORTLESS_HEADER.toLowerCase()]).toBe("1");
+    expect(res.headers[PORTLESS_LISTENER_PORT_HEADER.toLowerCase()]).toBe(String(addr.port));
   });
 
   it("proxies HTTPS request to matching route", async () => {

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -9,6 +9,13 @@ import { ARROW_SVG, renderPage } from "./pages.js";
 export const PORTLESS_HEADER = "X-Portless";
 
 /**
+ * Response header reporting the actual local TCP port that accepted the
+ * request. This lets health checks distinguish a proxy bound to the probed
+ * port from traffic redirected there by pf/NAT rules.
+ */
+export const PORTLESS_LISTENER_PORT_HEADER = "X-Portless-Listener-Port";
+
+/**
  * HTTP/1.1 hop-by-hop headers that are forbidden in HTTP/2 responses.
  * These must be stripped when proxying an HTTP/1.1 backend response
  * back to an HTTP/2 client.
@@ -30,6 +37,12 @@ function getRequestHost(req: http.IncomingMessage): string {
   const authority = req.headers[":authority"];
   if (typeof authority === "string" && authority) return authority;
   return req.headers.host || "";
+}
+
+/** Return the local TCP port that accepted this request. */
+function getListenerPort(req: http.IncomingMessage, fallbackPort: number): string {
+  const port = req.socket.localPort;
+  return typeof port === "number" && port > 0 ? String(port) : String(fallbackPort);
 }
 
 /**
@@ -110,6 +123,7 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
 
   const handleRequest = (req: http.IncomingMessage, res: http.ServerResponse) => {
     res.setHeader(PORTLESS_HEADER, "1");
+    res.setHeader(PORTLESS_LISTENER_PORT_HEADER, getListenerPort(req, proxyPort));
 
     const routes = getRoutes();
     const host = getRequestHost(req).split(":")[0];


### PR DESCRIPTION
## Summary

Fixes a false positive existing proxy check when `/etc/pf.conf` is modified.

## Background

I wanted to access my sites without any port numbers, so I modifed my `/etc/pf.conf` and added this line

```sh
rdr pass on lo0 inet proto tcp from any to 127.0.0.1 port 80 -> 127.0.0.1 port 1355
```

After modifying it, I enabled `pfctl` so that I can access at my app at `http://myapp.localhost`, which gets routed to `http://myapp.localhost:1355`:

```
sudo pfctl -e
```

This worked fine. But after I stopped the portless proxy server, I could not start it again, and I get this error "Proxy failed to start (timed out)".

Things recovered after disabling `pfctl`:

```
sudo pfctl -d
```

I could start `portless` again like before.

My changes to `/etc/pf.conf` led `portless` to think that the proxy server is running when it isn't. I think this is a bug in `portless`.

## Fix

- Add a listener-port response header so health checks can tell which local port actually accepted the request
- Tighten `isProxyRunning()` to reject PF/NAT redirect false positives when the probed port differs from the actual listener port
- Add regression coverage for redirected-port detection and proxy response headers

## Testing

- `pnpm --filter portless test`
- `pnpm --filter portless typecheck`
- `pnpm --filter portless build`
