### PR TITLE
fix(docs): add missing Expo and React Native to framework lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ portless myapp next dev
 # -> http://myapp.localhost:1355
 ```
 
-The proxy auto-starts when you run an app. A random port (4000--4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, Astro, React Router, Angular), portless auto-injects `--port` and `--host` flags.
+The proxy auto-starts when you run an app. A random port (4000--4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, Astro, React Router, Angular, Expo, React Native), portless auto-injects `--port` and `--host` flags.
 
 ## Use in package.json
 

--- a/apps/docs/src/app/configuration/page.mdx
+++ b/apps/docs/src/app/configuration/page.mdx
@@ -115,4 +115,4 @@ Override with `PORTLESS_STATE_DIR`.
 
 ## Port assignment
 
-Apps get a random port in the 4000--4999 range. Portless sets `PORT` and `HOST` before running your command. Most frameworks respect `PORT` automatically. For frameworks that ignore it (Vite, Astro, React Router, Angular), portless auto-injects `--port` and `--host` flags.
+Apps get a random port in the 4000--4999 range. Portless sets `PORT` and `HOST` before running your command. Most frameworks respect `PORT` automatically. For frameworks that ignore it (Vite, Astro, React Router, Angular, Expo, React Native), portless auto-injects `--port` and `--host` flags.

--- a/apps/docs/src/app/page.mdx
+++ b/apps/docs/src/app/page.mdx
@@ -29,7 +29,7 @@ portless myapp next dev
 # -> http://myapp.localhost:1355
 ```
 
-The proxy auto-starts when you run an app. A random port (4000--4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, Astro, React Router, Angular), portless auto-injects `--port` and `--host` flags.
+The proxy auto-starts when you run an app. A random port (4000--4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, Astro, React Router, Angular, Expo, React Native), portless auto-injects `--port` and `--host` flags.
 
 ## Use in package.json
 


### PR DESCRIPTION
## Summary

The documentation mentions four frameworks that need `--port`/`--host` flag injection (Vite, Astro, React Router, Angular), but the code supports six. Expo and React Native are missing from three docs locations.

**Evidence:**

- `FRAMEWORKS_NEEDING_PORT` in [`cli-utils.ts`](https://github.com/vercel-labs/portless/blob/main/packages/portless/src/cli-utils.ts#L551-L558) lists all six frameworks
- The `--help` output in [`cli.ts`](https://github.com/vercel-labs/portless/blob/main/packages/portless/src/cli.ts#L755-L756) also lists all six
- Expo and React Native were present in the README (added in #75 / v0.5.0) but dropped during the rewrite in #93

## Changes

Added "Expo, React Native" to the framework list in:
- `README.md` (line 32)
- `apps/docs/src/app/page.mdx` (line 32)
- `apps/docs/src/app/configuration/page.mdx` (line 118)

## Test plan

- [x] Verify `pnpm format:check` passes (docs-only change, no code affected)
- No changeset needed (`@portless/docs` is in the changeset ignore list)