### PR TITLE
Fix TLS cert generation for long hostnames and proxy startup races

### DIFF
--- a/packages/portless/src/certs.test.ts
+++ b/packages/portless/src/certs.test.ts
@@ -250,6 +250,33 @@ describe("createSNICallback", () => {
     expect(cert.subjectAltName).toContain("DNS:chat.myapp.localhost");
   });
 
+  it("generates cert for a hostname longer than 64 characters (X.509 CN limit)", async () => {
+    // Construct a hostname that exceeds the 64-char CN limit:
+    // "inngest.ap.very-long-branch-name-that-exceeds-the-cn-limit.dev" = 63+ chars
+    const longPrefix = "a".repeat(55);
+    const longHostname = `service.${longPrefix}.localhost`;
+    expect(longHostname.length).toBeGreaterThan(64);
+
+    const sniCallback = createSNICallback(tmpDir, defaultCert, defaultKey);
+    const ctx = await new Promise<tls.SecureContext | undefined>((resolve, reject) => {
+      sniCallback(longHostname, (err, ctx) => {
+        if (err) reject(err);
+        else resolve(ctx);
+      });
+    });
+
+    expect(ctx).toBeDefined();
+
+    // Verify the generated cert uses the full hostname in the SAN (not CN).
+    // TLS validation relies on SAN, not CN, so the full hostname must be there.
+    const safeName = longHostname.replace(/\./g, "_");
+    const hostCertPath = path.join(tmpDir, "host-certs", `${safeName}.pem`);
+    expect(fs.existsSync(hostCertPath)).toBe(true);
+
+    const cert = new crypto.X509Certificate(fs.readFileSync(hostCertPath));
+    expect(cert.subjectAltName).toContain(`DNS:${longHostname}`);
+  });
+
   it("caches generated certs in memory on subsequent calls", async () => {
     const sniCallback = createSNICallback(tmpDir, defaultCert, defaultKey);
 

--- a/packages/portless/src/certs.ts
+++ b/packages/portless/src/certs.ts
@@ -469,6 +469,13 @@ function sanitizeHostForFilename(hostname: string): string {
 }
 
 /**
+ * Maximum length of the X.509 Common Name (CN) field, per RFC 5280 §4.1.2.6.
+ * Modern TLS uses Subject Alternative Names (SAN) for hostname matching, so
+ * truncating the CN is safe -- SANs always take precedence.
+ */
+const MAX_CN_LENGTH = 64;
+
+/**
  * Generate a certificate for a specific hostname, signed by the local CA.
  * Certs are cached on disk in the host-certs subdirectory.
  *
@@ -497,8 +504,11 @@ async function generateHostCertAsync(
   // Generate key
   await opensslAsync(["ecparam", "-genkey", "-name", "prime256v1", "-noout", "-out", keyPath]);
 
+  // The X.509 CN field has a 64-character limit (RFC 5280 §4.1.2.6).
+  // Truncate when necessary -- TLS validation uses SANs, not CN, so this is safe.
+  const cn = hostname.length > MAX_CN_LENGTH ? hostname.slice(0, MAX_CN_LENGTH) : hostname;
   // Generate CSR
-  await opensslAsync(["req", "-new", "-key", keyPath, "-out", csrPath, "-subj", `/CN=${hostname}`]);
+  await opensslAsync(["req", "-new", "-key", keyPath, "-out", csrPath, "-subj", `/CN=${cn}`]);
 
   // Build SAN list: include the exact hostname plus a wildcard at the same level
   // e.g., for "chat.json-render2.localhost" -> also add "*.json-render2.localhost"

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -431,10 +431,14 @@ async function runApp(
         timeout: SUDO_SPAWN_TIMEOUT_MS,
       });
       if (result.status !== 0) {
-        console.error(chalk.red("Failed to start proxy."));
-        console.error(chalk.blue("Try starting it manually:"));
-        console.error(chalk.cyan("  sudo portless proxy start"));
-        process.exit(1);
+        // A concurrent portless run may have already started the proxy.
+        // Check before failing -- if it is running, we can continue.
+        if (!(await isProxyRunning(proxyPort))) {
+          console.error(chalk.red("Failed to start proxy."));
+          console.error(chalk.blue("Try starting it manually:"));
+          console.error(chalk.cyan("  sudo portless proxy start"));
+          process.exit(1);
+        }
       }
     } else {
       // Non-privileged port -- auto-start silently, no prompt needed
@@ -447,10 +451,14 @@ async function runApp(
         timeout: SUDO_SPAWN_TIMEOUT_MS,
       });
       if (result.status !== 0) {
-        console.error(chalk.red("Failed to start proxy."));
-        console.error(chalk.blue("Try starting it manually:"));
-        console.error(chalk.cyan("  portless proxy start"));
-        process.exit(1);
+        // A concurrent portless run may have already started the proxy.
+        // Check before failing -- if it is running, we can continue.
+        if (!(await isProxyRunning(proxyPort))) {
+          console.error(chalk.red("Failed to start proxy."));
+          console.error(chalk.blue("Try starting it manually:"));
+          console.error(chalk.cyan("  portless proxy start"));
+          process.exit(1);
+        }
       }
     }
 


### PR DESCRIPTION
This PR addresses two critical issues that were causing teams to write complex shell wrappers:

**Problem 1: TLS Certificate Generation Failure**
When hostnames exceeded 64 characters, certificate generation would silently fail because the X.509 Common Name (CN) field has a strict 64-character limit per RFC 5280. This broke HTTPS for long branch names or service names.

**Problem 2: Proxy Startup Race Conditions**
When multiple `portless run` processes started concurrently (common with turbo/monorepos), they would race to start the proxy, causing some processes to exit with errors even though the proxy was successfully started by another process.

**Changes Made:**

1. **Certificate Generation Fix (`certs.ts`)**:
   - Truncate CN field to 64 characters when hostname is longer
   - TLS validation uses Subject Alternative Names (SAN), not CN, so truncation is safe
   - Full hostname is preserved in SAN for proper TLS validation
   - Added comprehensive test coverage for long hostnames

2. **Race Condition Fix (`cli.ts`)**:
   - Check if proxy is already running before exiting on startup failure
   - Allow continuation if proxy startup "fails" but proxy is actually running
   - Handles the common case where concurrent processes race to start the proxy

These fixes eliminate the need for complex shell wrappers while maintaining full functionality and security.

Fixes #148