### PR TITLE
Reserve app ports and validate fixed app-port inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ portless myapp next dev
 # -> http://myapp.localhost:1355
 ```
 
-The proxy auto-starts when you run an app. A random port (4000--4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, Astro, React Router, Angular, Expo, React Native), portless auto-injects `--port` and `--host` flags.
+The proxy auto-starts when you run an app. A random port (4000--4999, excluding reserved app ports) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, Astro, React Router, Angular, Expo, React Native), portless auto-injects `--port` and `--host` flags.
 
 ## Use in package.json
 
@@ -165,7 +165,7 @@ portless proxy stop              # Stop the proxy
 --no-tls                         Disable HTTPS (overrides PORTLESS_HTTPS)
 --foreground                     Run proxy in foreground instead of daemon
 --tld <tld>                      Use a custom TLD instead of .localhost (e.g. test)
---app-port <number>              Use a fixed port for the app (skip auto-assignment)
+--app-port <number>              Use a fixed port for the app (skip auto-assignment; must not be a reserved app port)
 --force                          Override a route registered by another process
 --name <name>                    Use <name> as the app name
 ```
@@ -175,7 +175,7 @@ portless proxy stop              # Stop the proxy
 ```
 # Configuration
 PORTLESS_PORT=<number>           Override the default proxy port
-PORTLESS_APP_PORT=<number>       Use a fixed port for the app (same as --app-port)
+PORTLESS_APP_PORT=<number>       Use a fixed port for the app (same as --app-port; must not be a reserved app port)
 PORTLESS_HTTPS=1                 Always enable HTTPS
 PORTLESS_TLD=<tld>               Use a custom TLD (e.g. test; default: localhost)
 PORTLESS_SYNC_HOSTS=1            Auto-sync /etc/hosts (auto-enabled for custom TLDs)

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -7,6 +7,7 @@ import * as path from "node:path";
 import {
   DEFAULT_PROXY_PORT,
   DEFAULT_TLD,
+  RESERVED_APP_PORTS,
   PRIVILEGED_PORT_THRESHOLD,
   RISKY_TLDS,
   SYSTEM_STATE_DIR,
@@ -59,6 +60,15 @@ describe("findFreePort", () => {
 
   it("throws when minPort > maxPort", async () => {
     await expect(findFreePort(5000, 4000)).rejects.toThrow("minPort");
+  });
+
+  it("skips reserved app ports", async () => {
+    expect(RESERVED_APP_PORTS.has(4045)).toBe(true);
+    await expect(findFreePort(4045, 4045)).rejects.toThrow("No free port found");
+    await expect(findFreePort(4190, 4190)).rejects.toThrow("No free port found");
+
+    const port = await findFreePort(4045, 4046);
+    expect(port).toBe(4046);
   });
 });
 

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -38,6 +38,23 @@ const MIN_APP_PORT = 4000;
 /** Maximum app port when finding a free port. */
 const MAX_APP_PORT = 4999;
 
+/**
+ * App ports reserved by portless to avoid known bad-port runtime failures.
+ * Source: https://fetch.spec.whatwg.org/#port-blocking
+ */
+export const RESERVED_APP_PORTS = new Set([
+  0, 1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 69, 77, 79, 87, 95, 101, 102,
+  103, 104, 109, 110, 111, 113, 115, 117, 119, 123, 135, 137, 139, 143, 161, 179, 389, 427, 465,
+  512, 513, 514, 515, 526, 530, 531, 532, 540, 548, 554, 556, 563, 587, 601, 631, 636, 989, 990,
+  993, 995, 1719, 1720, 1723, 2049, 3659, 4045, 4190, 5060, 5061, 6000, 6566, 6665, 6666, 6667,
+  6668, 6669, 6679, 6697, 10080,
+]);
+
+/** Return true when the port is reserved for app usage. */
+export function isReservedAppPort(port: number): boolean {
+  return RESERVED_APP_PORTS.has(port);
+}
+
 /** Number of random port attempts before sequential scan. */
 const RANDOM_PORT_ATTEMPTS = 50;
 
@@ -292,6 +309,9 @@ export async function findFreePort(
   }
 
   const tryPort = (port: number): Promise<boolean> => {
+    if (isReservedAppPort(port)) {
+      return Promise.resolve(false);
+    }
     return new Promise((resolve) => {
       const server = net.createServer();
       server.listen(port, () => {

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -286,6 +286,22 @@ describe("CLI", () => {
       expect(status).toBe(0);
       expect(stdout.trim()).toBe("ok");
     });
+
+    it("rejects reserved --app-port values", () => {
+      const { status, stderr } = run(["run", "--app-port", "4045", "echo", "ok"], {
+        env: { PORTLESS: "0" },
+      });
+      expect(status).toBe(1);
+      expect(stderr).toContain("app port is reserved");
+    });
+
+    it("rejects reserved PORTLESS_APP_PORT values", () => {
+      const { status, stderr } = run(["run", "echo", "ok"], {
+        env: { PORTLESS: "0", PORTLESS_APP_PORT: "4045" },
+      });
+      expect(status).toBe(1);
+      expect(stderr).toContain("app port is reserved");
+    });
   });
 
   describe("alias subcommand", () => {

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -24,6 +24,7 @@ import {
   injectFrameworkFlags,
   isHttpsEnvEnabled,
   isProxyRunning,
+  isReservedAppPort,
   isWindows,
   prompt,
   readTldFromDir,
@@ -563,6 +564,13 @@ function parseAppPort(value: string | undefined): number {
     console.error(chalk.red(`Error: Invalid app port "${value}". Must be 1-65535.`));
     process.exit(1);
   }
+  if (isReservedAppPort(port)) {
+    console.error(chalk.red(`Error: Invalid app port "${value}". This app port is reserved.`));
+    console.error(
+      chalk.blue("Choose a different port, or omit --app-port for automatic assignment.")
+    );
+    process.exit(1);
+  }
   return port;
 }
 
@@ -572,6 +580,15 @@ function appPortFromEnv(): number | undefined {
   const port = parseInt(envVal, 10);
   if (isNaN(port) || port < 1 || port > 65535) {
     console.error(chalk.red(`Error: Invalid PORTLESS_APP_PORT="${envVal}". Must be 1-65535.`));
+    process.exit(1);
+  }
+  if (isReservedAppPort(port)) {
+    console.error(
+      chalk.red(`Error: Invalid PORTLESS_APP_PORT="${envVal}". This app port is reserved.`)
+    );
+    console.error(
+      chalk.blue("Set a different port, or unset PORTLESS_APP_PORT for auto-assignment.")
+    );
     process.exit(1);
   }
   return port;
@@ -605,6 +622,7 @@ ${chalk.bold("Options:")}
   --name <name>          Override the inferred base name (worktree prefix still applies)
   --force                Override an existing route registered by another process
   --app-port <number>    Use a fixed port for the app (skip auto-assignment)
+                          Must not be a reserved app port
   --help, -h             Show this help
 
 ${chalk.bold("Name inference (in order):")}
@@ -757,7 +775,7 @@ ${chalk.bold("In package.json:")}
 ${chalk.bold("How it works:")}
   1. Start the proxy once (listens on port 1355 by default, no sudo needed)
   2. Run your apps - they auto-start the proxy and register automatically
-     (apps get a random port in the 4000-4999 range via PORT)
+     (apps get a random port in the 4000-4999 range via PORT, excluding reserved app ports)
   3. Access via http://<name>.localhost:1355
   4. .localhost domains auto-resolve to 127.0.0.1
   5. Frameworks that ignore PORT (Vite, Astro, React Router, Angular,
@@ -780,6 +798,7 @@ ${chalk.bold("Options:")}
   --foreground                  Run proxy in foreground (for debugging)
   --tld <tld>                   Use a custom TLD instead of .localhost (e.g. test, dev)
   --app-port <number>           Use a fixed port for the app (skip auto-assignment)
+                                Must not be a reserved app port
   --force                       Override an existing route registered by another process
   --name <name>                 Use <name> as the app name (bypasses subcommand dispatch)
   --                            Stop flag parsing; everything after is passed to the child
@@ -787,6 +806,7 @@ ${chalk.bold("Options:")}
 ${chalk.bold("Environment variables:")}
   PORTLESS_PORT=<number>        Override the default proxy port (e.g. in .bashrc)
   PORTLESS_APP_PORT=<number>    Use a fixed port for the app (same as --app-port)
+                                Must not be a reserved app port
   PORTLESS_HTTPS=1              Always enable HTTPS (set in .bashrc / .zshrc)
   PORTLESS_TLD=<tld>            Use a custom TLD (e.g. test, dev; default: localhost)
   PORTLESS_SYNC_HOSTS=1         Auto-sync ${HOSTS_DISPLAY} (auto-enabled for custom TLDs)

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -98,7 +98,7 @@ PORTLESS=0 pnpm dev   # Bypasses proxy, uses default port
 ## How It Works
 
 1. `portless proxy start` starts an HTTP reverse proxy on port 1355 as a background daemon (configurable with `-p` / `--port` or the `PORTLESS_PORT` env var). The proxy also auto-starts when you run an app.
-2. `portless <name> <cmd>` assigns a random free port (4000-4999) via the `PORT` env var and registers the app with the proxy
+2. `portless <name> <cmd>` assigns a random free port (4000-4999, excluding reserved app ports) via the `PORT` env var and registers the app with the proxy
 3. The browser hits `http://<name>.localhost:1355` on the proxy port; the proxy forwards to the app's assigned port
 
 `.localhost` domains resolve to `127.0.0.1` natively in Chrome, Firefox, and Edge. Safari relies on the system DNS resolver, which may not handle `.localhost` subdomains on all configurations. Run `sudo portless hosts sync` to add entries to `/etc/hosts` if needed.
@@ -117,15 +117,15 @@ Override with the `PORTLESS_STATE_DIR` environment variable.
 
 ### Environment variables
 
-| Variable              | Description                                                       |
-| --------------------- | ----------------------------------------------------------------- |
-| `PORTLESS_PORT`       | Override the default proxy port (default: 1355)                   |
-| `PORTLESS_APP_PORT`   | Use a fixed port for the app (skip auto-assignment)               |
-| `PORTLESS_HTTPS`      | Set to `1` to always enable HTTPS/HTTP/2                          |
-| `PORTLESS_TLD`        | Use a custom TLD instead of localhost (e.g. test)                 |
-| `PORTLESS_SYNC_HOSTS` | Set to `1` to auto-sync /etc/hosts (auto-enabled for custom TLDs) |
-| `PORTLESS_STATE_DIR`  | Override the state directory                                      |
-| `PORTLESS=0`          | Bypass the proxy, run the command directly                        |
+| Variable              | Description                                                                  |
+| --------------------- | ---------------------------------------------------------------------------- |
+| `PORTLESS_PORT`       | Override the default proxy port (default: 1355)                              |
+| `PORTLESS_APP_PORT`   | Use a fixed port for the app (skip auto-assignment; not a reserved app port) |
+| `PORTLESS_HTTPS`      | Set to `1` to always enable HTTPS/HTTP/2                                     |
+| `PORTLESS_TLD`        | Use a custom TLD instead of localhost (e.g. test)                            |
+| `PORTLESS_SYNC_HOSTS` | Set to `1` to auto-sync /etc/hosts (auto-enabled for custom TLDs)            |
+| `PORTLESS_STATE_DIR`  | Override the state directory                                                 |
+| `PORTLESS=0`          | Bypass the proxy, run the command directly                                   |
 
 ### HTTP/2 + HTTPS
 
@@ -143,33 +143,33 @@ On Linux, `portless trust` supports Debian/Ubuntu, Arch, Fedora/RHEL/CentOS, and
 
 ## CLI Reference
 
-| Command                                | Description                                                   |
-| -------------------------------------- | ------------------------------------------------------------- |
-| `portless run <cmd> [args...]`         | Infer name from project, run through proxy (auto-starts)      |
-| `portless run --name <name> <cmd>`     | Override inferred base name (worktree prefix still applies)   |
-| `portless <name> <cmd> [args...]`      | Run app at `http://<name>.localhost:1355` (auto-starts proxy) |
-| `portless get <name>`                  | Print URL for a service (for cross-service wiring)            |
-| `portless get <name> --no-worktree`    | Print URL without worktree prefix                             |
-| `portless list`                        | Show active routes                                            |
-| `portless trust`                       | Add local CA to system trust store (for HTTPS)                |
-| `portless proxy start`                 | Start the proxy as a daemon (port 1355, no sudo)              |
-| `portless proxy start --https`         | Start with HTTP/2 + TLS (auto-generates certs)                |
-| `portless proxy start -p <number>`     | Start the proxy on a custom port                              |
-| `portless proxy start --tld test`      | Use .test instead of .localhost (requires /etc/hosts sync)    |
-| `portless proxy start --foreground`    | Start the proxy in foreground (for debugging)                 |
-| `portless proxy stop`                  | Stop the proxy                                                |
-| `portless alias <name> <port>`         | Register a static route (e.g. for Docker containers)          |
-| `portless alias <name> <port> --force` | Overwrite an existing route                                   |
-| `portless alias --remove <name>`       | Remove a static route                                         |
-| `portless hosts sync`                  | Add routes to /etc/hosts (fixes Safari)                       |
-| `portless hosts clean`                 | Remove portless entries from /etc/hosts                       |
-| `portless <name> --app-port <n> <cmd>` | Use a fixed port for the app instead of auto-assignment       |
-| `portless <name> --force <cmd>`        | Override an existing route registered by another process      |
-| `portless --name <name> <cmd>`         | Force `<name>` as app name (bypasses subcommand dispatch)     |
-| `portless <name> -- <cmd> [args...]`   | Stop flag parsing; everything after `--` is passed to child   |
-| `portless --help` / `-h`               | Show help                                                     |
-| `portless run --help`                  | Show help for a subcommand (also: alias, hosts)               |
-| `portless --version` / `-v`            | Show version                                                  |
+| Command                                | Description                                                                       |
+| -------------------------------------- | --------------------------------------------------------------------------------- |
+| `portless run <cmd> [args...]`         | Infer name from project, run through proxy (auto-starts)                          |
+| `portless run --name <name> <cmd>`     | Override inferred base name (worktree prefix still applies)                       |
+| `portless <name> <cmd> [args...]`      | Run app at `http://<name>.localhost:1355` (auto-starts proxy)                     |
+| `portless get <name>`                  | Print URL for a service (for cross-service wiring)                                |
+| `portless get <name> --no-worktree`    | Print URL without worktree prefix                                                 |
+| `portless list`                        | Show active routes                                                                |
+| `portless trust`                       | Add local CA to system trust store (for HTTPS)                                    |
+| `portless proxy start`                 | Start the proxy as a daemon (port 1355, no sudo)                                  |
+| `portless proxy start --https`         | Start with HTTP/2 + TLS (auto-generates certs)                                    |
+| `portless proxy start -p <number>`     | Start the proxy on a custom port                                                  |
+| `portless proxy start --tld test`      | Use .test instead of .localhost (requires /etc/hosts sync)                        |
+| `portless proxy start --foreground`    | Start the proxy in foreground (for debugging)                                     |
+| `portless proxy stop`                  | Stop the proxy                                                                    |
+| `portless alias <name> <port>`         | Register a static route (e.g. for Docker containers)                              |
+| `portless alias <name> <port> --force` | Overwrite an existing route                                                       |
+| `portless alias --remove <name>`       | Remove a static route                                                             |
+| `portless hosts sync`                  | Add routes to /etc/hosts (fixes Safari)                                           |
+| `portless hosts clean`                 | Remove portless entries from /etc/hosts                                           |
+| `portless <name> --app-port <n> <cmd>` | Use a fixed port for the app instead of auto-assignment (not a reserved app port) |
+| `portless <name> --force <cmd>`        | Override an existing route registered by another process                          |
+| `portless --name <name> <cmd>`         | Force `<name>` as app name (bypasses subcommand dispatch)                         |
+| `portless <name> -- <cmd> [args...]`   | Stop flag parsing; everything after `--` is passed to child                       |
+| `portless --help` / `-h`               | Show help                                                                         |
+| `portless run --help`                  | Show help for a subcommand (also: alias, hosts)                                   |
+| `portless --version` / `-v`            | Show version                                                                      |
 
 **Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `trust`, and `proxy` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name, or `portless --name <name> <cmd>` to force any name including reserved ones.
 


### PR DESCRIPTION
## Summary

I ran into this Next.js reserved-port issue:
https://nextjs.org/docs/messages/reserved-port

From there, I used the Fetch bad-port list it links to:
https://fetch.spec.whatwg.org/#port-blocking

This PR makes `portless` treat those as reserved app ports, so we stop assigning or accepting ports that will fail at runtime.

## What I changed

- Added reserved app ports from the Fetch bad-port list.
- Updated auto port selection to skip reserved app ports.
- Updated fixed app-port input validation (`--app-port` and `PORTLESS_APP_PORT`) to reject reserved app ports early.
- Added tests for both auto-selection and fixed-port validation.
- Updated CLI help, README, and `skills/portless/SKILL.md` to document the new behavior.

## Result

`portless` now consistently avoids reserved app ports across both automatic and fixed port flows.

### AI disclaimer

I used OpenAI GPT-5.3 Codex (high reasoning mode) to help with implementation and test updates. 