### PR TITLE
fix(windows): deduplicate PATH env vars in child process spawn

### DIFF
--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -479,7 +479,23 @@ export function spawnCommand(
     onCleanup?: () => void;
   }
 ): void {
-  const env = { ...(options?.env ?? process.env), PATH: augmentedPath(options?.env) };
+  const env: Record<string, string | undefined> = {
+    ...(options?.env ?? process.env),
+    PATH: augmentedPath(options?.env),
+  };
+
+  // On Windows, process.env is a case-insensitive Proxy, but spreading it into
+  // a plain object creates case-sensitive keys. The path variable may exist as
+  // "Path" (Windows convention) alongside the "PATH" we just set above. cmd.exe
+  // may read the wrong key, causing tools like bun to be missing from the child
+  // process PATH. Delete any residual casing variants so only our "PATH" remains.
+  if (isWindows) {
+    for (const key of Object.keys(env)) {
+      if (key !== "PATH" && key.toUpperCase() === "PATH") {
+        delete env[key];
+      }
+    }
+  }
 
   const child = isWindows
     ? spawn(commandArgs[0], commandArgs.slice(1), {


### PR DESCRIPTION
## Problem

On Windows, child processes spawned by portless couldn't find tools like Bun in their PATH, even when the tools were available in the parent process. This occurred because Windows `process.env` is a case-insensitive Proxy, but spreading it into a plain object creates case-sensitive keys. The environment could end up with both "Path" (Windows convention) and "PATH" keys, causing cmd.exe to potentially read the wrong one.

## Changes

- Added Windows-specific PATH deduplication logic in `spawnCommand()`
- After setting the augmented PATH, remove any other keys that uppercase to "PATH" (like "Path")
- This ensures only the canonical "PATH" key with the correct augmented value is passed to child processes

## Implementation Details

The fix is guarded by `if (isWindows)` and only affects Windows environments. It preserves all other environment variables while ensuring PATH consistency for child process inheritance.

Fixes #153