### PR TITLE
feat: add TCP proxy support for database and cache aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ On Linux, `portless trust` supports Debian/Ubuntu, Arch, Fedora/RHEL/CentOS, and
 portless run [--name <name>] <cmd> [args...]  # Infer name (or override with --name), run through proxy
 portless <name> <cmd> [args...]  # Run app at http://<name>.localhost:1355
 portless alias <name> <port>     # Register a static route (e.g. for Docker)
+portless alias --tcp <name> <port>  # Register a TCP proxy route (e.g. PostgreSQL, Redis)
 portless alias <name> <port> --force  # Overwrite an existing route
 portless alias --remove <name>   # Remove a static route
 portless list                    # Show active routes
@@ -169,6 +170,7 @@ portless proxy stop              # Stop the proxy
 --wildcard                       Allow unregistered subdomains to fall back to parent route
 --app-port <number>              Use a fixed port for the app (skip auto-assignment)
 --force                          Override a route registered by another process
+--tcp                            Register a TCP proxy instead of HTTP (for alias command)
 --name <name>                    Use <name> as the app name
 ```
 
@@ -236,6 +238,26 @@ devServer: {
 ```
 
 Portless detects this misconfiguration and responds with `508 Loop Detected` along with a message pointing to this fix.
+
+## TCP Proxy
+
+Use `portless alias --tcp` when the target speaks a raw TCP protocol instead of HTTP. Each TCP alias gets its own local listen port in the `5500-5999` range and forwards traffic to the target port on `127.0.0.1`.
+
+```bash
+portless alias --tcp my-postgres 5432
+# -> Connect to: 127.0.0.1:5500
+
+psql -h 127.0.0.1 -p 5500
+
+portless alias --tcp mysql 3306
+mysql -h 127.0.0.1 -P 5501
+
+portless alias --tcp redis 6379
+redis-cli -h 127.0.0.1 -p 5502
+```
+
+`portless list` shows TCP aliases with their real connect address, `127.0.0.1:<listenPort>`, and includes the friendly alias name in parentheses.
+`portless get <name>` also returns `127.0.0.1:<listenPort>` for TCP aliases, so scripts can discover the correct client endpoint without special casing.
 
 ## Development
 

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -38,6 +38,12 @@ const MIN_APP_PORT = 4000;
 /** Maximum app port when finding a free port. */
 const MAX_APP_PORT = 4999;
 
+/** Minimum auto-assigned TCP proxy listen port. */
+export const MIN_TCP_PORT = 5500;
+
+/** Maximum auto-assigned TCP proxy listen port. */
+export const MAX_TCP_PORT = 5999;
+
 /** Number of random port attempts before sequential scan. */
 const RANDOM_PORT_ATTEMPTS = 50;
 

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -4,15 +4,17 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import { RouteStore } from "./routes.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_PATH = path.resolve(__dirname, "../dist/cli.js");
 
 /** Run the CLI with the given args and optional env overrides. */
-function run(args: string[], options?: { env?: Record<string, string | undefined> }) {
+function run(args: string[], options?: { env?: Record<string, string | undefined>; cwd?: string }) {
   const result = spawnSync(process.execPath, [CLI_PATH, ...args], {
     encoding: "utf-8",
     timeout: 10_000,
+    cwd: options?.cwd,
     env: { ...process.env, ...options?.env, NO_COLOR: "1" },
   });
   return {
@@ -81,6 +83,32 @@ describe("CLI", () => {
       // it doesn't crash and returns 0.
       const { status } = run(["list"]);
       expect(status).toBe(0);
+    });
+
+    it("shows TCP aliases with tcp:// URLs and listen ports", () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-cli-list-test-"));
+      try {
+        fs.writeFileSync(
+          path.join(tmpDir, "routes.json"),
+          JSON.stringify([
+            {
+              hostname: "redis.localhost",
+              port: 6379,
+              pid: 0,
+              type: "tcp",
+              listenPort: 5501,
+            },
+          ])
+        );
+
+        const { status, stdout } = run(["list"], { env: { PORTLESS_STATE_DIR: tmpDir } });
+        expect(status).toBe(0);
+        expect(stdout).toContain("127.0.0.1:5501");
+        expect(stdout).toContain("(redis.localhost)");
+        expect(stdout).toContain("localhost:6379");
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
     });
   });
 
@@ -289,11 +317,24 @@ describe("CLI", () => {
   });
 
   describe("alias subcommand", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-cli-alias-test-"));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    const getEnv = () => ({ PORTLESS_STATE_DIR: tmpDir });
+
     it("prints help with --help", () => {
       const { status, stdout } = run(["alias", "--help"]);
       expect(status).toBe(0);
       expect(stdout).toContain("portless alias");
       expect(stdout).toContain("--remove");
+      expect(stdout).toContain("--tcp");
     });
 
     it("prints help with -h", () => {
@@ -324,6 +365,55 @@ describe("CLI", () => {
       const { status, stderr } = run(["alias", "--remove"]);
       expect(status).toBe(1);
       expect(stderr).toContain("No alias name");
+    });
+
+    it("registers a TCP alias with a listen port", () => {
+      const { status, stdout } = run(["alias", "--tcp", "mydb", "5432"], { env: getEnv() });
+      expect(status).toBe(0);
+      expect(stdout).toContain("TCP alias registered");
+      expect(stdout).toContain("TCP listener will be available after starting the proxy daemon.");
+      expect(stdout).toContain("Start it with: portless proxy start");
+      expect(stdout).not.toContain("Connect to:");
+
+      const routesPath = path.join(tmpDir, "routes.json");
+      const routes = JSON.parse(fs.readFileSync(routesPath, "utf-8"));
+      expect(routes).toHaveLength(1);
+      expect(routes[0].hostname).toBe("mydb.localhost");
+      expect(routes[0].port).toBe(5432);
+      expect(routes[0].pid).toBe(0);
+      expect(routes[0].type).toBe("tcp");
+      expect(routes[0].listenPort).toBeGreaterThanOrEqual(5500);
+      expect(routes[0].listenPort).toBeLessThanOrEqual(5999);
+    });
+
+    it("does not reuse a stored TCP listen port when the proxy is stopped", () => {
+      const first = run(["alias", "--tcp", "db1", "5432"], { env: getEnv() });
+      const second = run(["alias", "--tcp", "db2", "5433"], { env: getEnv() });
+
+      expect(first.status).toBe(0);
+      expect(second.status).toBe(0);
+
+      const routesPath = path.join(tmpDir, "routes.json");
+      const routes = JSON.parse(fs.readFileSync(routesPath, "utf-8"));
+      expect(routes).toHaveLength(2);
+      expect(routes[0].listenPort).not.toBe(routes[1].listenPort);
+    });
+
+    it("reuses the existing listen port when replacing a TCP alias", () => {
+      const first = run(["alias", "--tcp", "db", "5432"], { env: getEnv() });
+      expect(first.status).toBe(0);
+
+      const routesPath = path.join(tmpDir, "routes.json");
+      const before = JSON.parse(fs.readFileSync(routesPath, "utf-8"));
+      const originalListenPort = before[0].listenPort;
+
+      const second = run(["alias", "--tcp", "db", "5433"], { env: getEnv() });
+      expect(second.status).toBe(0);
+
+      const after = JSON.parse(fs.readFileSync(routesPath, "utf-8"));
+      expect(after).toHaveLength(1);
+      expect(after[0].port).toBe(5433);
+      expect(after[0].listenPort).toBe(originalListenPort);
     });
   });
 
@@ -426,6 +516,57 @@ describe("CLI", () => {
       const { status, stdout } = run(["get", "api.backend"], { env: getEnv() });
       expect(status).toBe(0);
       expect(stdout.trim()).toMatch(/^https?:\/\/api\.backend\.localhost(:\d+)?$/);
+    });
+
+    it("prints the localhost endpoint for a TCP alias", async () => {
+      const store = new RouteStore(tmpDir);
+      await store.addTcpRoute("db.localhost", 5432, 0, false, {
+        minListenPort: 5500,
+        maxListenPort: 5505,
+      });
+
+      const { status, stdout } = run(["get", "db"], { env: getEnv() });
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe("127.0.0.1:5500");
+    });
+
+    it("falls back to the unprefixed TCP alias inside a git worktree", async () => {
+      const store = new RouteStore(tmpDir);
+      await store.addTcpRoute("db.localhost", 5432, 0, false, {
+        minListenPort: 5500,
+        maxListenPort: 5505,
+      });
+
+      const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-get-worktree-repo-"));
+      const worktreeDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-get-worktree-linked-"));
+
+      try {
+        const git = (gitArgs: string[], cwd: string) =>
+          spawnSync("git", gitArgs, {
+            cwd,
+            encoding: "utf-8",
+            env: { ...process.env, NO_COLOR: "1" },
+          });
+
+        fs.writeFileSync(path.join(repoDir, "package.json"), JSON.stringify({ name: "repo" }));
+        expect(git(["init", "-b", "main"], repoDir).status).toBe(0);
+        expect(git(["config", "user.name", "Test User"], repoDir).status).toBe(0);
+        expect(git(["config", "user.email", "test@example.com"], repoDir).status).toBe(0);
+        expect(git(["add", "package.json"], repoDir).status).toBe(0);
+        expect(git(["commit", "-m", "init"], repoDir).status).toBe(0);
+        expect(git(["branch", "feature/db"], repoDir).status).toBe(0);
+        expect(git(["worktree", "add", worktreeDir, "feature/db"], repoDir).status).toBe(0);
+
+        const { status, stdout } = run(["get", "db"], {
+          cwd: worktreeDir,
+          env: getEnv(),
+        });
+        expect(status).toBe(0);
+        expect(stdout.trim()).toBe("127.0.0.1:5500");
+      } finally {
+        fs.rmSync(worktreeDir, { recursive: true, force: true });
+        fs.rmSync(repoDir, { recursive: true, force: true });
+      }
     });
 
     it("rejects unknown flags", () => {

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -4,18 +4,22 @@ declare const __VERSION__: string;
 
 import chalk from "chalk";
 import * as fs from "node:fs";
+import * as net from "node:net";
 import * as path from "node:path";
 import { spawn, spawnSync } from "node:child_process";
 import { createSNICallback, ensureCerts, isCATrusted, trustCA } from "./certs.js";
+import { MAX_TCP_PORT, MIN_TCP_PORT } from "./cli-utils.js";
 import { createProxyServer } from "./proxy.js";
 import { fixOwnership, formatUrl, isErrnoException, parseHostname } from "./utils.js";
 import { syncHostsFile, cleanHostsFile } from "./hosts.js";
-import { FILE_MODE, RouteConflictError, RouteStore } from "./routes.js";
+import { FILE_MODE, RouteConflictError, RouteStore, SYSTEM_FILE_MODE } from "./routes.js";
+import { createTcpProxy } from "./tcp-proxy.js";
 import { inferProjectName, detectWorktreePrefix, truncateLabel } from "./auto.js";
 import {
   DEFAULT_TLD,
   PRIVILEGED_PORT_THRESHOLD,
   RISKY_TLDS,
+  SYSTEM_STATE_DIR,
   discoverState,
   findFreePort,
   findPidOnPort,
@@ -59,6 +63,12 @@ const EXIT_TIMEOUT_MS = 2000;
 /** Timeout (ms) for the sudo spawn when auto-starting the proxy. */
 const SUDO_SPAWN_TIMEOUT_MS = 30_000;
 
+/** Max time (ms) to wait for a TCP alias listener to become active. */
+const TCP_ALIAS_READY_TIMEOUT_MS = 1000;
+
+/** Poll interval (ms) while waiting for a TCP alias listener to become active. */
+const TCP_ALIAS_READY_POLL_MS = 100;
+
 // ---------------------------------------------------------------------------
 // Proxy server lifecycle
 // ---------------------------------------------------------------------------
@@ -86,11 +96,177 @@ function startProxyServer(
   }
   fixOwnership(routesPath);
 
+  const filterHttpRoutes = <T extends { type?: "http" | "tcp" }>(routes: T[]): T[] =>
+    routes.filter((route) => route.type !== "tcp");
+
   // Cache routes in memory and reload on file change (debounced)
-  let cachedRoutes = store.loadRoutes();
+  let cachedRoutes = filterHttpRoutes(store.loadRoutes());
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
   let watcher: fs.FSWatcher | null = null;
   let pollingInterval: ReturnType<typeof setInterval> | null = null;
+  let exiting = false;
+  const tcpProxies = new Map<string, net.Server>();
+  const startingTcpProxies = new Map<string, net.Server>();
+  const tcpProxySockets = new Map<string, Set<net.Socket>>();
+  const tcpProxyConfigs = new Map<string, string>();
+  const closingTcpProxies = new Set<string>();
+  const closingTcpProxyConfigs = new Map<string, string>();
+  const pendingTcpRoutes = new Map<
+    string,
+    { hostname: string; listenPort: number; port: number }
+  >();
+
+  const startTcpProxy = (route: { hostname: string; listenPort: number; port: number }) => {
+    const config = `${route.listenPort}:${route.port}`;
+    if (
+      tcpProxies.has(route.hostname) ||
+      startingTcpProxies.has(route.hostname) ||
+      closingTcpProxies.has(route.hostname)
+    ) {
+      if (closingTcpProxies.has(route.hostname)) {
+        pendingTcpRoutes.set(route.hostname, route);
+      }
+      return;
+    }
+
+    const server = createTcpProxy({
+      listenPort: route.listenPort,
+      targetPort: route.port,
+      onError: (msg) => console.error(chalk.red(msg)),
+    });
+    const sockets = new Set<net.Socket>();
+
+    server.on("connection", (socket) => {
+      sockets.add(socket);
+      socket.on("close", () => {
+        sockets.delete(socket);
+      });
+    });
+
+    server.on("error", (err: NodeJS.ErrnoException) => {
+      startingTcpProxies.delete(route.hostname);
+      tcpProxies.delete(route.hostname);
+      tcpProxySockets.delete(route.hostname);
+      tcpProxyConfigs.delete(route.hostname);
+      closingTcpProxyConfigs.delete(route.hostname);
+      persistActiveTcpListeners();
+      if (err.code === "EADDRINUSE") {
+        console.error(chalk.yellow(`TCP port ${route.listenPort} in use for ${route.hostname}`));
+        void (async () => {
+          const currentRoute = store
+            .loadRoutes()
+            .find(
+              (candidate) =>
+                candidate.hostname === route.hostname &&
+                candidate.type === "tcp" &&
+                candidate.listenPort === route.listenPort &&
+                candidate.port === route.port
+            );
+          if (!currentRoute) return;
+
+          try {
+            const reassignedPort = await store.addTcpRoute(route.hostname, route.port, 0, true, {
+              minListenPort: MIN_TCP_PORT,
+              maxListenPort: MAX_TCP_PORT,
+            });
+            if (reassignedPort !== route.listenPort) {
+              console.error(
+                chalk.yellow(
+                  `Reassigned ${route.hostname} to TCP port ${reassignedPort} after bind conflict`
+                )
+              );
+            }
+          } catch (reassignErr) {
+            console.error(
+              chalk.red(
+                `Failed to reassign TCP alias ${route.hostname}: ${(reassignErr as Error).message}`
+              )
+            );
+          }
+        })();
+      } else {
+        console.error(chalk.red(`TCP proxy error for ${route.hostname}: ${err.message}`));
+      }
+    });
+
+    server.listen(route.listenPort, "127.0.0.1", () => {
+      startingTcpProxies.delete(route.hostname);
+      tcpProxies.set(route.hostname, server);
+      closingTcpProxyConfigs.delete(route.hostname);
+      persistActiveTcpListeners();
+      console.log(
+        chalk.green(
+          `TCP proxy: port ${route.listenPort} -> localhost:${route.port} (${route.hostname})`
+        )
+      );
+    });
+
+    startingTcpProxies.set(route.hostname, server);
+    tcpProxySockets.set(route.hostname, sockets);
+    tcpProxyConfigs.set(route.hostname, config);
+  };
+
+  const stopTcpProxy = (
+    hostname: string,
+    server: net.Server,
+    nextRoute?: { hostname: string; listenPort: number; port: number }
+  ) => {
+    closingTcpProxies.add(hostname);
+    if (nextRoute) {
+      pendingTcpRoutes.set(hostname, nextRoute);
+    } else {
+      pendingTcpRoutes.delete(hostname);
+    }
+    const config = tcpProxyConfigs.get(hostname);
+    if (config) {
+      closingTcpProxyConfigs.set(hostname, config);
+    }
+    persistActiveTcpListeners();
+    for (const socket of tcpProxySockets.get(hostname) ?? []) {
+      socket.destroy();
+    }
+    server.close(() => {
+      startingTcpProxies.delete(hostname);
+      tcpProxies.delete(hostname);
+      tcpProxySockets.delete(hostname);
+      tcpProxyConfigs.delete(hostname);
+      closingTcpProxyConfigs.delete(hostname);
+      closingTcpProxies.delete(hostname);
+      persistActiveTcpListeners();
+      const latestRoute = pendingTcpRoutes.get(hostname);
+      pendingTcpRoutes.delete(hostname);
+      if (!exiting && latestRoute) startTcpProxy(latestRoute);
+    });
+  };
+
+  const persistActiveTcpListeners = () => {
+    const parseListener = (
+      hostname: string,
+      config: string | undefined,
+      status: "active" | "closing"
+    ) => {
+      const [listenPortRaw, targetPortRaw] = config?.split(":") ?? [];
+      const listenPort = listenPortRaw ? parseInt(listenPortRaw, 10) : NaN;
+      const targetPort = targetPortRaw ? parseInt(targetPortRaw, 10) : NaN;
+      return { hostname, listenPort, targetPort, status };
+    };
+
+    const listeners = [
+      ...Array.from(tcpProxies.keys()).map((hostname) =>
+        parseListener(hostname, tcpProxyConfigs.get(hostname), "active")
+      ),
+      ...Array.from(closingTcpProxyConfigs.keys()).map((hostname) =>
+        parseListener(hostname, closingTcpProxyConfigs.get(hostname), "closing")
+      ),
+    ].filter(
+      (listener) => !Number.isNaN(listener.listenPort) && !Number.isNaN(listener.targetPort)
+    );
+
+    fs.writeFileSync(store.tcpListenersPath, JSON.stringify(listeners, null, 2), {
+      mode: store.dir === SYSTEM_STATE_DIR ? SYSTEM_FILE_MODE : FILE_MODE,
+    });
+    fixOwnership(store.tcpListenersPath);
+  };
 
   const syncVal = process.env.PORTLESS_SYNC_HOSTS;
   const autoSyncHosts =
@@ -100,7 +276,37 @@ function startProxyServer(
 
   const reloadRoutes = () => {
     try {
-      cachedRoutes = store.loadRoutes();
+      const routes = store.loadRoutes();
+      cachedRoutes = filterHttpRoutes(routes);
+
+      const tcpRoutes = routes.filter(
+        (route) => route.type === "tcp" && route.listenPort !== undefined
+      );
+      const activeTcpRoutes = new Map(
+        tcpRoutes.map((route) => [
+          route.hostname,
+          { hostname: route.hostname, listenPort: route.listenPort as number, port: route.port },
+        ])
+      );
+
+      const managedTcpServers = new Map([
+        ...Array.from(tcpProxies.entries()),
+        ...Array.from(startingTcpProxies.entries()),
+      ]);
+
+      for (const [hostname, server] of managedTcpServers) {
+        const nextRoute = activeTcpRoutes.get(hostname);
+        const nextConfig = nextRoute ? `${nextRoute.listenPort}:${nextRoute.port}` : null;
+        if (!nextConfig || tcpProxyConfigs.get(hostname) !== nextConfig) {
+          stopTcpProxy(hostname, server, nextRoute);
+        }
+      }
+
+      for (const route of tcpRoutes) {
+        if (route.listenPort === undefined) continue;
+        startTcpProxy({ hostname: route.hostname, listenPort: route.listenPort, port: route.port });
+      }
+
       if (autoSyncHosts) {
         syncHostsFile(cachedRoutes.map((r) => r.hostname));
       }
@@ -123,6 +329,7 @@ function startProxyServer(
   if (autoSyncHosts) {
     syncHostsFile(cachedRoutes.map((r) => r.hostname));
   }
+  reloadRoutes();
 
   const server = createProxyServer({
     getRoutes: () => cachedRoutes,
@@ -172,7 +379,6 @@ function startProxyServer(
   });
 
   // Cleanup on exit
-  let exiting = false;
   const cleanup = () => {
     if (exiting) return;
     exiting = true;
@@ -180,6 +386,28 @@ function startProxyServer(
     if (pollingInterval) clearInterval(pollingInterval);
     if (watcher) {
       watcher.close();
+    }
+    for (const [hostname, sockets] of tcpProxySockets) {
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      tcpProxySockets.set(hostname, new Set());
+    }
+    for (const [, tcpServer] of new Map([
+      ...Array.from(tcpProxies.entries()),
+      ...Array.from(startingTcpProxies.entries()),
+    ])) {
+      tcpServer.close();
+    }
+    startingTcpProxies.clear();
+    tcpProxies.clear();
+    tcpProxySockets.clear();
+    tcpProxyConfigs.clear();
+    closingTcpProxyConfigs.clear();
+    try {
+      fs.unlinkSync(store.tcpListenersPath);
+    } catch {
+      // Listener file may already be absent; non-fatal
     }
     try {
       fs.unlinkSync(store.pidPath);
@@ -350,8 +578,15 @@ function listRoutes(store: RouteStore, proxyPort: number, tls: boolean): void {
 
   console.log(chalk.blue.bold("\nActive routes:\n"));
   for (const route of routes) {
-    const url = formatUrl(route.hostname, proxyPort, tls);
     const label = route.pid === 0 ? "(alias)" : `(pid ${route.pid})`;
+    if (route.type === "tcp" && route.listenPort) {
+      console.log(
+        `  ${chalk.cyan(`127.0.0.1:${route.listenPort}`)}  ${chalk.gray(`(${route.hostname})`)}  ${chalk.gray("->")}  ${chalk.white(`localhost:${route.port}`)}  ${chalk.gray(label)}`
+      );
+      continue;
+    }
+
+    const url = formatUrl(route.hostname, proxyPort, tls);
     console.log(
       `  ${chalk.cyan(url)}  ${chalk.gray("->")}  ${chalk.white(`localhost:${route.port}`)}  ${chalk.gray(label)}`
     );
@@ -736,6 +971,7 @@ ${chalk.bold("Usage:")}
   ${chalk.cyan("portless run <cmd>")}               Infer name from project, run through proxy
   ${chalk.cyan("portless get <name>")}              Print URL for a service (for cross-service refs)
   ${chalk.cyan("portless alias <name> <port>")}     Register a static route (e.g. for Docker)
+  ${chalk.cyan("portless alias --tcp <name> <port>")} Register a TCP proxy route (e.g. for databases)
   ${chalk.cyan("portless alias --remove <name>")}   Remove a static route
   ${chalk.cyan("portless list")}                    Show active routes
   ${chalk.cyan("portless trust")}                   Add local CA to system trust store
@@ -750,7 +986,9 @@ ${chalk.bold("Examples:")}
   portless api.myapp pnpm start       # -> http://api.myapp.localhost:1355
   portless run next dev               # -> http://<project>.localhost:1355
   portless run next dev               # in worktree -> http://<worktree>.<project>.localhost:1355
-  portless get backend                 # -> http://backend.localhost:1355 (for cross-service refs)
+  portless get backend                # -> http://backend.localhost:1355 (for cross-service refs)
+  portless alias --tcp my-db 5432     # TCP proxy -> localhost:5432 (for psql, etc.)
+  portless list                       # TCP aliases show 127.0.0.1:<port> connect addresses
   # Wildcard subdomains: tenant.myapp.localhost also routes to myapp
 
 ${chalk.bold("In package.json:")}
@@ -788,6 +1026,7 @@ ${chalk.bold("Options:")}
   --wildcard                    Allow unregistered subdomains to fall back to parent route
   --app-port <number>           Use a fixed port for the app (skip auto-assignment)
   --force                       Override an existing route registered by another process
+  --tcp                         Register a TCP proxy instead of HTTP (for alias command)
   --name <name>                 Use <name> as the app name (bypasses subcommand dispatch)
   --                            Stop flag parsing; everything after is passed to the child
 
@@ -831,6 +1070,47 @@ function printVersion(): void {
   process.exit(0);
 }
 
+async function waitForTcpAliasReady(
+  store: RouteStore,
+  hostname: string,
+  listenPort: number,
+  targetPort: number,
+  timeoutMs = TCP_ALIAS_READY_TIMEOUT_MS
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const active = store
+      .loadActiveTcpListeners()
+      .some(
+        (listener) =>
+          listener.hostname === hostname &&
+          listener.listenPort === listenPort &&
+          listener.targetPort === targetPort &&
+          listener.status === "active"
+      );
+    if (active) return true;
+    await new Promise((resolve) => setTimeout(resolve, TCP_ALIAS_READY_POLL_MS));
+  }
+  return false;
+}
+
+function findCurrentTcpRoute(
+  store: RouteStore,
+  hostname: string,
+  targetPort: number
+): { listenPort: number } | null {
+  const route = store
+    .loadRoutes()
+    .find(
+      (candidate) =>
+        candidate.hostname === hostname &&
+        candidate.type === "tcp" &&
+        candidate.port === targetPort &&
+        candidate.listenPort !== undefined
+    );
+  return route?.listenPort !== undefined ? { listenPort: route.listenPort } : null;
+}
+
 async function handleTrust(): Promise<void> {
   const { dir } = await discoverState();
   const result = trustCA(dir);
@@ -858,14 +1138,15 @@ async function handleList(): Promise<void> {
 async function handleGet(args: string[]): Promise<void> {
   if (args[1] === "--help" || args[1] === "-h") {
     console.log(`
-${chalk.bold("portless get")} - Print the URL for a service.
+${chalk.bold("portless get")} - Print the connect endpoint for a service.
 
 ${chalk.bold("Usage:")}
   ${chalk.cyan("portless get <name>")}
 
-Constructs the URL using the same hostname and worktree logic as
-"portless run", then prints it to stdout. Useful for wiring services
-together:
+Constructs the endpoint using the same hostname and worktree logic as
+"portless run", then prints it to stdout. HTTP routes return a URL,
+while TCP aliases return 127.0.0.1:<listenPort>. Useful for wiring
+services together:
 
   BACKEND_URL=$(portless get backend)
 
@@ -877,6 +1158,7 @@ ${chalk.bold("Examples:")}
   portless get backend                  # -> http://backend.localhost:1355
   portless get backend                  # in worktree -> http://auth.backend.localhost:1355
   portless get backend --no-worktree    # -> http://backend.localhost:1355 (skip worktree)
+  portless get my-postgres              # -> 127.0.0.1:5500 (for TCP aliases)
 `);
     process.exit(0);
   }
@@ -909,10 +1191,24 @@ ${chalk.bold("Examples:")}
   const worktree = skipWorktree ? null : detectWorktreePrefix();
   const effectiveName = worktree ? `${worktree.prefix}.${name}` : name;
 
-  const { port, tls, tld } = await discoverState();
+  const { dir, port, tls, tld } = await discoverState();
   const hostname = parseHostname(effectiveName, tld);
+  const unprefixedHostname = worktree && !skipWorktree ? parseHostname(name, tld) : hostname;
+  const store = new RouteStore(dir, {
+    onWarning: (msg) => console.warn(chalk.yellow(msg)),
+  });
+  const routes = store.loadRoutes();
+  const route =
+    routes.find((entry) => entry.hostname === hostname) ??
+    routes.find((entry) => entry.type === "tcp" && entry.hostname === unprefixedHostname);
+
+  if (route?.type === "tcp" && route.listenPort) {
+    process.stdout.write(`127.0.0.1:${route.listenPort}\n`);
+    return;
+  }
+
   const url = formatUrl(hostname, port, tls);
-  // Print bare URL to stdout so it works in $(portless get <name>)
+  // Print bare endpoint to stdout so it works in $(portless get <name>)
   process.stdout.write(url + "\n");
 }
 
@@ -923,21 +1219,24 @@ ${chalk.bold("portless alias")} - Register a static route for services not manag
 
 ${chalk.bold("Usage:")}
   ${chalk.cyan("portless alias <name> <port>")}        Register a route
+  ${chalk.cyan("portless alias --tcp <name> <port>")}  Register a TCP proxy route
   ${chalk.cyan("portless alias --remove <name>")}      Remove a route
   ${chalk.cyan("portless alias <name> <port> --force")} Override existing route
 
 ${chalk.bold("Examples:")}
   portless alias my-postgres 5432     # -> http://my-postgres.localhost:1355
+  portless alias --tcp my-postgres 5432 # -> 127.0.0.1:5500
   portless alias redis 6379           # -> http://redis.localhost:1355
   portless alias --remove my-postgres # Remove the alias
 `);
     process.exit(0);
   }
 
-  const { dir, tld } = await discoverState();
+  const { dir, port: proxyPort, tls, tld } = await discoverState();
   const store = new RouteStore(dir, {
     onWarning: (msg) => console.warn(chalk.yellow(msg)),
   });
+  const proxyRunning = await isProxyRunning(proxyPort, tls);
 
   if (args[1] === "--remove") {
     const aliasName = args[2];
@@ -958,12 +1257,14 @@ ${chalk.bold("Examples:")}
     return;
   }
 
-  const aliasName = args[1];
-  const aliasPort = args[2];
+  const positional = args.slice(1).filter((arg) => arg !== "--tcp" && arg !== "--force");
+  const aliasName = positional[0];
+  const aliasPort = positional[1];
   if (!aliasName || !aliasPort) {
     console.error(chalk.red("Error: Missing arguments."));
     console.error(chalk.blue("Usage:"));
     console.error(chalk.cyan("  portless alias <name> <port>"));
+    console.error(chalk.cyan("  portless alias --tcp <name> <port>"));
     console.error(chalk.cyan("  portless alias --remove <name>"));
     console.error(chalk.blue("Example:"));
     console.error(chalk.cyan("  portless alias my-postgres 5432"));
@@ -978,6 +1279,50 @@ ${chalk.bold("Examples:")}
   }
 
   const force = args.includes("--force");
+  const isTcp = args.includes("--tcp");
+
+  if (isTcp) {
+    let listenPort: number;
+    try {
+      listenPort = await store.addTcpRoute(hostname, port, 0, force, {
+        minListenPort: MIN_TCP_PORT,
+        maxListenPort: MAX_TCP_PORT,
+      });
+    } catch (err) {
+      console.error(chalk.red(`Error: ${(err as Error).message}`));
+      process.exit(1);
+    }
+    console.log(
+      chalk.green(
+        `TCP alias registered: 127.0.0.1:${listenPort} (${hostname}) -> 127.0.0.1:${port}`
+      )
+    );
+    if (proxyRunning) {
+      if (await waitForTcpAliasReady(store, hostname, listenPort, port)) {
+        console.log(chalk.cyan(`Connect to: 127.0.0.1:${listenPort}`));
+      } else {
+        const currentRoute = findCurrentTcpRoute(store, hostname, port);
+        const currentListenPort = currentRoute?.listenPort ?? listenPort;
+        if (
+          currentListenPort !== listenPort &&
+          (await waitForTcpAliasReady(store, hostname, currentListenPort, port))
+        ) {
+          console.log(chalk.yellow(`TCP listener was reassigned by the proxy daemon.`));
+          console.log(chalk.cyan(`Connect to: 127.0.0.1:${currentListenPort}`));
+        } else {
+          console.log(chalk.yellow(`TCP listener is being activated by the proxy daemon.`));
+          console.log(
+            chalk.gray(`If connection is refused, retry 127.0.0.1:${currentListenPort} shortly.`)
+          );
+        }
+      }
+    } else {
+      console.log(chalk.yellow(`TCP listener will be available after starting the proxy daemon.`));
+      console.log(chalk.cyan("Start it with: portless proxy start"));
+    }
+    return;
+  }
+
   store.addRoute(hostname, port, 0, force);
   console.log(chalk.green(`Alias registered: ${hostname} -> 127.0.0.1:${port}`));
 }
@@ -1041,7 +1386,7 @@ ${chalk.bold("Usage: portless hosts <command>")}
     onWarning: (msg) => console.warn(chalk.yellow(msg)),
   });
 
-  const routes = store.loadRoutes();
+  const routes = store.loadRoutes().filter((route) => route.type !== "tcp");
   if (routes.length === 0) {
     console.log(chalk.yellow("No active routes to sync."));
     return;

--- a/packages/portless/src/routes.test.ts
+++ b/packages/portless/src/routes.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
+import * as net from "node:net";
 import * as path from "node:path";
 import * as os from "node:os";
 import { RouteStore } from "./routes.js";
@@ -91,6 +92,23 @@ describe("RouteStore", () => {
       expect(loaded[0].port).toBe(4001);
     });
 
+    it("loads TCP routes with listen ports from file", () => {
+      const routes = [
+        {
+          hostname: "postgres.localhost",
+          port: 5432,
+          pid: 0,
+          type: "tcp",
+          listenPort: 5500,
+        },
+      ];
+      store.ensureDir();
+      fs.writeFileSync(store.getRoutesPath(), JSON.stringify(routes));
+      const loaded = store.loadRoutes();
+      expect(loaded).toHaveLength(1);
+      expect(loaded[0]).toEqual(routes[0]);
+    });
+
     it("filters out routes with dead PIDs", () => {
       // Use a PID that is guaranteed not to exist
       const deadPid = 999999;
@@ -103,6 +121,15 @@ describe("RouteStore", () => {
       const loaded = store.loadRoutes();
       expect(loaded).toHaveLength(1);
       expect(loaded[0].hostname).toBe("alive.localhost");
+    });
+
+    it("keeps legacy routes without explicit type for backward compatibility", () => {
+      const routes = [{ hostname: "legacy.localhost", port: 4001, pid: process.pid }];
+      store.ensureDir();
+      fs.writeFileSync(store.getRoutesPath(), JSON.stringify(routes));
+      const loaded = store.loadRoutes();
+      expect(loaded).toHaveLength(1);
+      expect(loaded[0].type).toBeUndefined();
     });
 
     it("does not persist cleanup when persistCleanup is false (default)", () => {
@@ -167,6 +194,19 @@ describe("RouteStore", () => {
       });
     });
 
+    it("adds a TCP route with listen port metadata", () => {
+      store.addRoute("postgres.localhost", 5432, 0, false, { type: "tcp", listenPort: 5500 });
+      const routes = store.loadRoutes();
+      expect(routes).toHaveLength(1);
+      expect(routes[0]).toEqual({
+        hostname: "postgres.localhost",
+        port: 5432,
+        pid: 0,
+        type: "tcp",
+        listenPort: 5500,
+      });
+    });
+
     it("replaces existing route with same hostname", () => {
       store.addRoute("myapp.localhost", 4001, process.pid);
       store.addRoute("myapp.localhost", 4002, process.pid);
@@ -182,6 +222,123 @@ describe("RouteStore", () => {
       expect(routes).toHaveLength(2);
       const hostnames = routes.map((r) => r.hostname).sort();
       expect(hostnames).toEqual(["app1.localhost", "app2.localhost"]);
+    });
+  });
+
+  describe("addTcpRoute", () => {
+    it("allocates distinct listen ports for distinct TCP aliases", async () => {
+      const first = await store.addTcpRoute("db1.localhost", 5432, 0, false, {
+        minListenPort: 5500,
+        maxListenPort: 5510,
+      });
+      const second = await store.addTcpRoute("db2.localhost", 5433, 0, false, {
+        minListenPort: 5500,
+        maxListenPort: 5510,
+      });
+
+      expect(first).not.toBe(second);
+      const routes = store.loadRoutes();
+      expect(routes).toHaveLength(2);
+      expect(routes[0].listenPort).not.toBe(routes[1].listenPort);
+    });
+
+    it("reuses the existing listen port when replacing a TCP alias", async () => {
+      const first = await store.addTcpRoute("db.localhost", 5432, 0, false, {
+        minListenPort: 5500,
+        maxListenPort: 5510,
+      });
+      const second = await store.addTcpRoute("db.localhost", 5433, 0, false, {
+        minListenPort: 5500,
+        maxListenPort: 5510,
+      });
+
+      expect(second).toBe(first);
+      const routes = store.loadRoutes();
+      expect(routes).toHaveLength(1);
+      expect(routes[0].port).toBe(5433);
+      expect(routes[0].listenPort).toBe(first);
+    });
+
+    it("allocates a new listen port when the saved one is no longer bindable", async () => {
+      const first = await store.addTcpRoute("db.localhost", 5432, 0, false, {
+        minListenPort: 5500,
+        maxListenPort: 5510,
+      });
+
+      const blocker = net.createServer();
+      await new Promise<void>((resolve, reject) => {
+        blocker.once("error", reject);
+        blocker.listen(first, "127.0.0.1", () => resolve());
+      });
+
+      try {
+        const second = await store.addTcpRoute("db.localhost", 5433, 0, false, {
+          minListenPort: 5500,
+          maxListenPort: 5510,
+        });
+
+        expect(second).not.toBe(first);
+        const routes = store.loadRoutes();
+        expect(routes).toHaveLength(1);
+        expect(routes[0].port).toBe(5433);
+        expect(routes[0].listenPort).toBe(second);
+      } finally {
+        await new Promise<void>((resolve) => blocker.close(() => resolve()));
+      }
+    });
+
+    it("preserves the existing listen port while the proxy daemon is running", async () => {
+      const first = await store.addTcpRoute("db.localhost", 5432, 0, false, {
+        minListenPort: 5500,
+        maxListenPort: 5510,
+      });
+
+      fs.writeFileSync(store.pidPath, process.pid.toString());
+      fs.writeFileSync(
+        store.tcpListenersPath,
+        JSON.stringify([{ hostname: "db.localhost", listenPort: first }], null, 2)
+      );
+
+      const second = await store.addTcpRoute("db.localhost", 5433, 0, false, {
+        minListenPort: 5500,
+        maxListenPort: 5510,
+      });
+
+      expect(second).toBe(first);
+      const routes = store.loadRoutes();
+      expect(routes).toHaveLength(1);
+      expect(routes[0].port).toBe(5433);
+      expect(routes[0].listenPort).toBe(first);
+    });
+
+    it("allocates a new listen port when the daemon is running but the listener is not active", async () => {
+      const first = await store.addTcpRoute("db.localhost", 5432, 0, false, {
+        minListenPort: 5500,
+        maxListenPort: 5510,
+      });
+
+      fs.writeFileSync(store.pidPath, process.pid.toString());
+
+      const blocker = net.createServer();
+      await new Promise<void>((resolve, reject) => {
+        blocker.once("error", reject);
+        blocker.listen(first, "127.0.0.1", () => resolve());
+      });
+
+      try {
+        const second = await store.addTcpRoute("db.localhost", 5433, 0, false, {
+          minListenPort: 5500,
+          maxListenPort: 5510,
+        });
+
+        expect(second).not.toBe(first);
+        const routes = store.loadRoutes();
+        expect(routes).toHaveLength(1);
+        expect(routes[0].port).toBe(5433);
+        expect(routes[0].listenPort).toBe(second);
+      } finally {
+        await new Promise<void>((resolve) => blocker.close(() => resolve()));
+      }
     });
   });
 

--- a/packages/portless/src/routes.ts
+++ b/packages/portless/src/routes.ts
@@ -1,8 +1,9 @@
 import * as fs from "node:fs";
+import * as net from "node:net";
 import * as path from "node:path";
 import type { RouteInfo } from "./types.js";
-import { fixOwnership, isErrnoException } from "./utils.js";
 import { SYSTEM_STATE_DIR } from "./cli-utils.js";
+import { fixOwnership, isErrnoException } from "./utils.js";
 
 /** How long (ms) before a lock directory is considered stale and forcibly removed. */
 const STALE_LOCK_THRESHOLD_MS = 10_000;
@@ -29,14 +30,34 @@ export interface RouteMapping extends RouteInfo {
   pid: number;
 }
 
+interface ActiveTcpListener {
+  hostname: string;
+  listenPort: number;
+  targetPort: number;
+  status: "active" | "closing";
+}
+
+async function canListenOnLocalhost(port: number): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const server = net.createServer();
+    server.listen(port, "127.0.0.1", () => {
+      server.close(() => resolve(true));
+    });
+    server.on("error", () => resolve(false));
+  });
+}
+
 /** Runtime check that a parsed JSON value is a valid RouteMapping. */
 function isValidRoute(value: unknown): value is RouteMapping {
+  const route = value as RouteMapping;
   return (
     typeof value === "object" &&
     value !== null &&
-    typeof (value as RouteMapping).hostname === "string" &&
-    typeof (value as RouteMapping).port === "number" &&
-    typeof (value as RouteMapping).pid === "number"
+    typeof route.hostname === "string" &&
+    typeof route.port === "number" &&
+    typeof route.pid === "number" &&
+    (route.type === undefined || route.type === "http" || route.type === "tcp") &&
+    (route.listenPort === undefined || typeof route.listenPort === "number")
   );
 }
 
@@ -70,6 +91,7 @@ export class RouteStore {
   private readonly lockPath: string;
   readonly pidPath: string;
   readonly portFilePath: string;
+  readonly tcpListenersPath: string;
   private readonly onWarning: ((message: string) => void) | undefined;
 
   constructor(dir: string, options?: { onWarning?: (message: string) => void }) {
@@ -78,6 +100,7 @@ export class RouteStore {
     this.lockPath = path.join(dir, "routes.lock");
     this.pidPath = path.join(dir, "proxy.pid");
     this.portFilePath = path.join(dir, "proxy.port");
+    this.tcpListenersPath = path.join(dir, "tcp-listeners.json");
     this.onWarning = options?.onWarning;
   }
 
@@ -161,8 +184,44 @@ export class RouteStore {
     try {
       process.kill(pid, 0);
       return true;
+    } catch (err: unknown) {
+      if (isErrnoException(err) && err.code === "EPERM") {
+        return true;
+      }
+      return false;
+    }
+  }
+
+  private isProxyDaemonAlive(): boolean {
+    try {
+      const pid = parseInt(fs.readFileSync(this.pidPath, "utf-8"), 10);
+      return !isNaN(pid) && this.isProcessAlive(pid);
     } catch {
       return false;
+    }
+  }
+
+  loadActiveTcpListeners(): ActiveTcpListener[] {
+    if (!this.isProxyDaemonAlive()) return [];
+    if (!fs.existsSync(this.tcpListenersPath)) return [];
+
+    try {
+      const raw = fs.readFileSync(this.tcpListenersPath, "utf-8");
+      const parsed: unknown = JSON.parse(raw);
+      if (!Array.isArray(parsed)) return [];
+
+      return parsed.filter(
+        (listener): listener is ActiveTcpListener =>
+          typeof listener === "object" &&
+          listener !== null &&
+          typeof (listener as ActiveTcpListener).hostname === "string" &&
+          typeof (listener as ActiveTcpListener).listenPort === "number" &&
+          typeof (listener as ActiveTcpListener).targetPort === "number" &&
+          ((listener as ActiveTcpListener).status === "active" ||
+            (listener as ActiveTcpListener).status === "closing")
+      );
+    } catch {
+      return [];
     }
   }
 
@@ -214,7 +273,13 @@ export class RouteStore {
     fixOwnership(this.routesPath);
   }
 
-  addRoute(hostname: string, port: number, pid: number, force = false): void {
+  addRoute(
+    hostname: string,
+    port: number,
+    pid: number,
+    force = false,
+    extra?: { type?: "tcp"; listenPort?: number }
+  ): void {
     this.ensureDir();
     if (!this.acquireLock()) {
       throw new Error("Failed to acquire route lock");
@@ -226,11 +291,137 @@ export class RouteStore {
         throw new RouteConflictError(hostname, existing.pid);
       }
       const filtered = routes.filter((r) => r.hostname !== hostname);
-      filtered.push({ hostname, port, pid });
+      filtered.push({
+        hostname,
+        port,
+        pid,
+        type: extra?.type,
+        listenPort: extra?.listenPort,
+      });
       this.saveRoutes(filtered);
     } finally {
       this.releaseLock();
     }
+  }
+
+  async addTcpRoute(
+    hostname: string,
+    port: number,
+    pid: number,
+    force = false,
+    options: { minListenPort: number; maxListenPort: number }
+  ): Promise<number> {
+    this.ensureDir();
+    for (let attempt = 0; attempt < 5; attempt++) {
+      let candidatePorts: number[] = [];
+
+      // We need one lock pass to derive candidate ports from the latest route
+      // table, then release it before async bind probes, and finally re-lock
+      // before saving to avoid holding the directory lock across async I/O.
+      if (!this.acquireLock()) {
+        throw new Error("Failed to acquire route lock");
+      }
+      try {
+        const routes = this.loadRoutes(true);
+        const existing = routes.find((r) => r.hostname === hostname);
+        if (existing && existing.pid !== pid && this.isProcessAlive(existing.pid) && !force) {
+          throw new RouteConflictError(hostname, existing.pid);
+        }
+
+        const filtered = routes.filter((r) => r.hostname !== hostname);
+
+        if (existing?.type === "tcp" && existing.listenPort !== undefined) {
+          const activeListeners = this.loadActiveTcpListeners();
+          const existingListenerActive = activeListeners.some(
+            (listener) =>
+              listener.hostname === hostname && listener.listenPort === existing.listenPort
+          );
+
+          if (existingListenerActive) {
+            filtered.push({
+              hostname,
+              port,
+              pid,
+              type: "tcp",
+              listenPort: existing.listenPort,
+            });
+            this.saveRoutes(filtered);
+            return existing.listenPort;
+          }
+
+          candidatePorts.push(existing.listenPort);
+        }
+
+        const usedListenPorts = new Set(
+          filtered
+            .filter((route) => route.type === "tcp" && route.listenPort !== undefined)
+            .map((route) => route.listenPort as number)
+        );
+
+        candidatePorts = candidatePorts.filter((candidate) => !usedListenPorts.has(candidate));
+        for (
+          let candidate = options.minListenPort;
+          candidate <= options.maxListenPort;
+          candidate++
+        ) {
+          if (usedListenPorts.has(candidate) || candidatePorts.includes(candidate)) continue;
+          candidatePorts.push(candidate);
+        }
+      } finally {
+        this.releaseLock();
+      }
+
+      let selectedPort: number | null = null;
+      for (const candidate of candidatePorts) {
+        if (await canListenOnLocalhost(candidate)) {
+          selectedPort = candidate;
+          break;
+        }
+      }
+      if (selectedPort === null) {
+        throw new Error(
+          `No free TCP proxy port found in range ${options.minListenPort}-${options.maxListenPort}.`
+        );
+      }
+
+      if (!this.acquireLock()) {
+        throw new Error("Failed to acquire route lock");
+      }
+      try {
+        const routes = this.loadRoutes(true);
+        const existing = routes.find((r) => r.hostname === hostname);
+        if (existing && existing.pid !== pid && this.isProcessAlive(existing.pid) && !force) {
+          throw new RouteConflictError(hostname, existing.pid);
+        }
+
+        const filtered = routes.filter((r) => r.hostname !== hostname);
+        const usedListenPorts = new Set(
+          filtered
+            .filter((route) => route.type === "tcp" && route.listenPort !== undefined)
+            .map((route) => route.listenPort as number)
+        );
+        // There is still a small TOCTOU window between the bind probe above and
+        // the daemon actually listening on the selected port. We re-check
+        // route-level ownership here to avoid duplicate assignments, and the
+        // daemon's EADDRINUSE handling covers the remaining race with external
+        // processes.
+        if (usedListenPorts.has(selectedPort)) continue;
+
+        filtered.push({
+          hostname,
+          port,
+          pid,
+          type: "tcp",
+          listenPort: selectedPort,
+        });
+        this.saveRoutes(filtered);
+        return selectedPort;
+      } finally {
+        this.releaseLock();
+      }
+    }
+
+    throw new Error("Failed to allocate TCP proxy port due to concurrent route updates.");
   }
 
   removeRoute(hostname: string): void {

--- a/packages/portless/src/tcp-proxy.test.ts
+++ b/packages/portless/src/tcp-proxy.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it } from "vitest";
+import * as net from "node:net";
+import { once } from "node:events";
+import { findFreePort } from "./cli-utils.js";
+import { createTcpProxy } from "./tcp-proxy.js";
+
+const serversToClose: net.Server[] = [];
+
+async function closeServer(server: net.Server): Promise<void> {
+  if (!server.listening) return;
+  server.close();
+  await once(server, "close");
+}
+
+async function listen(server: net.Server, port: number): Promise<void> {
+  server.listen(port);
+  await once(server, "listening");
+}
+
+describe("createTcpProxy", () => {
+  afterEach(async () => {
+    while (serversToClose.length > 0) {
+      const server = serversToClose.pop();
+      if (server) await closeServer(server);
+    }
+  });
+
+  it("forwards data bidirectionally", async () => {
+    const targetPort = await findFreePort(6100, 6199);
+    const proxyPort = await findFreePort(6200, 6299);
+
+    const targetServer = net.createServer((socket) => {
+      socket.on("data", (chunk) => {
+        socket.write(Buffer.from(`echo:${chunk.toString()}`));
+      });
+    });
+    serversToClose.push(targetServer);
+    await listen(targetServer, targetPort);
+
+    const proxyServer = createTcpProxy({ listenPort: proxyPort, targetPort });
+    serversToClose.push(proxyServer);
+    await listen(proxyServer, proxyPort);
+
+    const client = net.connect(proxyPort, "127.0.0.1");
+    await once(client, "connect");
+
+    const response = new Promise<string>((resolve) => {
+      client.once("data", (chunk) => resolve(chunk.toString()));
+    });
+
+    client.write("hello");
+    await expect(response).resolves.toBe("echo:hello");
+
+    client.end();
+    await once(client, "close");
+  });
+
+  it("closes the upstream socket when the client disconnects", async () => {
+    const targetPort = await findFreePort(6300, 6399);
+    const proxyPort = await findFreePort(6400, 6499);
+
+    let resolveAccepted: (() => void) | null = null;
+    const targetAccepted = new Promise<void>((resolve) => {
+      resolveAccepted = resolve;
+    });
+    let resolveTargetClosed: (() => void) | null = null;
+    const targetClosed = new Promise<void>((resolve) => {
+      resolveTargetClosed = resolve;
+    });
+
+    const targetServer = net.createServer((socket) => {
+      socket.resume();
+      resolveAccepted?.();
+      socket.once("close", () => resolveTargetClosed?.());
+    });
+    serversToClose.push(targetServer);
+    await listen(targetServer, targetPort);
+
+    const proxyServer = createTcpProxy({ listenPort: proxyPort, targetPort });
+    serversToClose.push(proxyServer);
+    await listen(proxyServer, proxyPort);
+
+    const client = net.connect(proxyPort, "127.0.0.1");
+    await once(client, "connect");
+    client.write("ping");
+    await targetAccepted;
+    client.end();
+    await once(client, "close");
+
+    await expect(targetClosed).resolves.toBeUndefined();
+  });
+
+  it("reports errors when the target is unreachable", async () => {
+    const proxyPort = await findFreePort(6500, 6599);
+    const targetPort = await findFreePort(6600, 6699);
+    const errors: string[] = [];
+
+    const proxyServer = createTcpProxy({
+      listenPort: proxyPort,
+      targetPort,
+      onError: (message) => errors.push(message),
+    });
+    serversToClose.push(proxyServer);
+    await listen(proxyServer, proxyPort);
+
+    const client = net.connect(proxyPort, "127.0.0.1");
+    await once(client, "connect");
+    client.write("ping");
+    await once(client, "close");
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain(`port ${proxyPort} -> ${targetPort}`);
+  });
+});

--- a/packages/portless/src/tcp-proxy.ts
+++ b/packages/portless/src/tcp-proxy.ts
@@ -1,0 +1,33 @@
+import * as net from "node:net";
+
+export interface TcpProxyOptions {
+  /** Used only for error messages; the caller is responsible for listen(). */
+  listenPort: number;
+  targetPort: number;
+  targetHost?: string;
+  onError?: (message: string) => void;
+}
+
+export function createTcpProxy(options: TcpProxyOptions): net.Server {
+  const { listenPort, targetPort, targetHost = "127.0.0.1", onError } = options;
+
+  return net.createServer((clientSocket) => {
+    clientSocket.pause();
+    clientSocket.on("error", () => clientSocket.destroy());
+
+    const targetSocket = net.connect(targetPort, targetHost, () => {
+      clientSocket.pipe(targetSocket);
+      targetSocket.pipe(clientSocket);
+      clientSocket.resume();
+    });
+
+    targetSocket.on("error", (err) => {
+      onError?.(`TCP proxy error (port ${listenPort} -> ${targetPort}): ${err.message}`);
+      clientSocket.destroy();
+      targetSocket.destroy();
+    });
+
+    clientSocket.on("close", () => targetSocket.destroy());
+    targetSocket.on("close", () => clientSocket.destroy());
+  });
+}

--- a/packages/portless/src/types.ts
+++ b/packages/portless/src/types.ts
@@ -2,6 +2,8 @@
 export interface RouteInfo {
   hostname: string;
   port: number;
+  type?: "http" | "tcp";
+  listenPort?: number;
 }
 
 export interface ProxyServerOptions {

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -149,8 +149,8 @@ On Linux, `portless trust` supports Debian/Ubuntu, Arch, Fedora/RHEL/CentOS, and
 | `portless run <cmd> [args...]`         | Infer name from project, run through proxy (auto-starts)      |
 | `portless run --name <name> <cmd>`     | Override inferred base name (worktree prefix still applies)   |
 | `portless <name> <cmd> [args...]`      | Run app at `http://<name>.localhost:1355` (auto-starts proxy) |
-| `portless get <name>`                  | Print URL for a service (for cross-service wiring)            |
-| `portless get <name> --no-worktree`    | Print URL without worktree prefix                             |
+| `portless get <name>`                  | Print a service endpoint (HTTP URL or TCP `127.0.0.1:<port>`) |
+| `portless get <name> --no-worktree`    | Print endpoint without worktree prefix                        |
 | `portless list`                        | Show active routes                                            |
 | `portless trust`                       | Add local CA to system trust store (for HTTPS)                |
 | `portless proxy start`                 | Start the proxy as a daemon (port 1355, no sudo)              |
@@ -161,6 +161,7 @@ On Linux, `portless trust` supports Debian/Ubuntu, Arch, Fedora/RHEL/CentOS, and
 | `portless proxy start --wildcard`      | Allow unregistered subdomains to fall back to parent route    |
 | `portless proxy stop`                  | Stop the proxy                                                |
 | `portless alias <name> <port>`         | Register a static route (e.g. for Docker containers)          |
+| `portless alias --tcp <name> <port>`   | Register a TCP proxy route (e.g. PostgreSQL, MySQL, Redis)    |
 | `portless alias <name> <port> --force` | Overwrite an existing route                                   |
 | `portless alias --remove <name>`       | Remove a static route                                         |
 | `portless hosts sync`                  | Add routes to /etc/hosts (fixes Safari)                       |
@@ -174,6 +175,20 @@ On Linux, `portless trust` supports Debian/Ubuntu, Arch, Fedora/RHEL/CentOS, and
 | `portless --version` / `-v`            | Show version                                                  |
 
 **Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `trust`, and `proxy` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name, or `portless --name <name> <cmd>` to force any name including reserved ones.
+
+## TCP services
+
+Use `portless alias --tcp` for local services that speak raw TCP instead of HTTP. Portless assigns a listen port in the `5500-5999` range and forwards it to the target on `127.0.0.1`.
+
+```bash
+portless alias --tcp my-postgres 5432
+# -> Connect with: psql -h 127.0.0.1 -p 5500
+
+portless alias --tcp redis 6379
+# -> Connect with: redis-cli -h 127.0.0.1 -p 5501
+```
+
+`portless list` shows these entries with the real connect address, `127.0.0.1:<listenPort>`, and includes the alias name in parentheses.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Portless only supported HTTP/HTTPS routing by hostname, so raw TCP services (PostgreSQL, MySQL, Redis, etc.) couldn't be exposed through aliases. This PR adds `portless alias --tcp <name> <port>`, which assigns a dedicated listen port in the `5500-5999` range and proxies traffic to the target. Each alias gets its own port because raw TCP has no `Host` header for multiplexing.

## Changes

- **CLI**: `portless alias --tcp <name> <port>` to register TCP aliases; `portless list` and `portless get` return the connect address `127.0.0.1:<listenPort>`
- **TCP proxy** (`tcp-proxy.ts`): minimal bidirectional `net` module proxy between the listen port and the target
- **Route model**: extended `routes.json` with optional `type` and `listenPort` fields; existing HTTP entries are unaffected
- **Port allocation**: `addTcpRoute()` uses two-phase locking to avoid holding the file lock during async bind probes, and tracks active listeners in `tcp-listeners.json` to preserve daemon-held ports across alias updates
- **Daemon**: TCP listeners start/stop alongside HTTP routes, bind to `127.0.0.1` only, and are excluded from HTTP routing and hosts sync

## Test plan

- [x] `pnpm --filter portless build`
- [x] `pnpm --filter portless test`
- [x] `pnpm lint && pnpm typecheck && pnpm format:check`
- [x] Manual end-to-end with Docker: PostgreSQL (`psql`), MySQL (`mysql`), Redis (`redis-cli`) all connect through assigned proxy ports
