### PR TITLE
feat: add {PORT}, {HOST}, {PORTLESS_URL} placeholders for command args

### DIFF
--- a/.changeset/placeholder-args.md
+++ b/.changeset/placeholder-args.md
@@ -1,0 +1,5 @@
+---
+"portless": minor
+---
+
+Add `{PORT}`, `{HOST}`, and `{PORTLESS_URL}` placeholders for command args. Tools that ignore the `PORT` env var can now receive the assigned port directly via CLI flags: `portless run my-server --port {PORT}`. When placeholders are present, automatic `--port`/`--host` injection is skipped.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ portless myapp next dev
 
 The proxy auto-starts when you run an app. A random port (4000--4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, Astro, React Router, Angular, Expo, React Native), portless auto-injects `--port` and `--host` flags.
 
+For tools not covered by auto-injection, use `{PORT}`, `{HOST}`, or `{PORTLESS_URL}` placeholders in your command args:
+
+```bash
+portless run my-server --port {PORT} --host {HOST}
+```
+
+Placeholders are replaced with the assigned values before the command runs. When placeholders are present, automatic `--port`/`--host` injection is skipped.
+
 ## Use in package.json
 
 ```json

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -14,8 +14,10 @@ import {
   findFreePort,
   getDefaultPort,
   getDefaultTld,
+  hasPlaceholders,
   injectFrameworkFlags,
   isProxyRunning,
+  replacePlaceholders,
   parsePidFromNetstat,
   readTldFromDir,
   resolveStateDir,
@@ -719,5 +721,93 @@ describe("validateTld", () => {
       expect(validateTld(tld)).toBeNull();
       expect(RISKY_TLDS.has(tld)).toBe(true);
     }
+  });
+});
+
+describe("hasPlaceholders", () => {
+  it("returns true when {PORT} is present", () => {
+    expect(hasPlaceholders(["my-server", "--port", "{PORT}"])).toBe(true);
+  });
+
+  it("returns true when {HOST} is present", () => {
+    expect(hasPlaceholders(["server", "--host", "{HOST}"])).toBe(true);
+  });
+
+  it("returns true when {PORTLESS_URL} is present", () => {
+    expect(hasPlaceholders(["server", "--url", "{PORTLESS_URL}"])).toBe(true);
+  });
+
+  it("returns false when no placeholders are present", () => {
+    expect(hasPlaceholders(["next", "dev"])).toBe(false);
+  });
+
+  it("returns false for empty args", () => {
+    expect(hasPlaceholders([])).toBe(false);
+  });
+
+  it("returns false for partial matches", () => {
+    expect(hasPlaceholders(["http://localhost:{PORT}"])).toBe(false);
+  });
+
+  it("returns false for lowercase variants", () => {
+    expect(hasPlaceholders(["{port}"])).toBe(false);
+  });
+});
+
+describe("replacePlaceholders", () => {
+  const vars = { PORT: "4567", HOST: "127.0.0.1", PORTLESS_URL: "http://myapp.localhost:1355" };
+
+  it("replaces {PORT}", () => {
+    const args = ["my-server", "--port", "{PORT}"];
+    replacePlaceholders(args, vars);
+    expect(args).toEqual(["my-server", "--port", "4567"]);
+  });
+
+  it("replaces {HOST}", () => {
+    const args = ["server", "--host", "{HOST}"];
+    replacePlaceholders(args, vars);
+    expect(args).toEqual(["server", "--host", "127.0.0.1"]);
+  });
+
+  it("replaces {PORTLESS_URL}", () => {
+    const args = ["server", "--url", "{PORTLESS_URL}"];
+    replacePlaceholders(args, vars);
+    expect(args).toEqual(["server", "--url", "http://myapp.localhost:1355"]);
+  });
+
+  it("replaces multiple placeholders", () => {
+    const args = ["server", "--host", "{HOST}", "--port", "{PORT}"];
+    replacePlaceholders(args, vars);
+    expect(args).toEqual(["server", "--host", "127.0.0.1", "--port", "4567"]);
+  });
+
+  it("does not replace partial matches", () => {
+    const args = ["--url", "http://localhost:{PORT}"];
+    replacePlaceholders(args, vars);
+    expect(args).toEqual(["--url", "http://localhost:{PORT}"]);
+  });
+
+  it("does not replace lowercase variants", () => {
+    const args = ["{port}", "{host}"];
+    replacePlaceholders(args, vars);
+    expect(args).toEqual(["{port}", "{host}"]);
+  });
+
+  it("does not replace unknown placeholders", () => {
+    const args = ["{FOO}", "{BAR}"];
+    replacePlaceholders(args, vars);
+    expect(args).toEqual(["{FOO}", "{BAR}"]);
+  });
+
+  it("does nothing for empty args", () => {
+    const args: string[] = [];
+    replacePlaceholders(args, vars);
+    expect(args).toEqual([]);
+  });
+
+  it("leaves non-placeholder args untouched", () => {
+    const args = ["next", "dev", "--port", "3000"];
+    replacePlaceholders(args, vars);
+    expect(args).toEqual(["next", "dev", "--port", "3000"]);
   });
 });

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -655,6 +655,42 @@ export function injectFrameworkFlags(commandArgs: string[], port: number): void 
   }
 }
 
+// ---------------------------------------------------------------------------
+// Placeholder substitution
+// ---------------------------------------------------------------------------
+
+/** Recognized placeholder tokens. */
+const PLACEHOLDERS = ["{PORT}", "{HOST}", "{PORTLESS_URL}"] as const;
+
+/**
+ * Check if any element in `commandArgs` is a recognized placeholder.
+ */
+export function hasPlaceholders(commandArgs: string[]): boolean {
+  return commandArgs.some((arg) => (PLACEHOLDERS as readonly string[]).includes(arg));
+}
+
+/**
+ * Replace placeholder tokens in `commandArgs` in-place.
+ * Only exact-match arguments are replaced (e.g. `{PORT}` but not
+ * `http://localhost:{PORT}`).
+ */
+export function replacePlaceholders(
+  commandArgs: string[],
+  vars: { PORT: string; HOST: string; PORTLESS_URL: string }
+): void {
+  const map: Record<string, string> = {
+    "{PORT}": vars.PORT,
+    "{HOST}": vars.HOST,
+    "{PORTLESS_URL}": vars.PORTLESS_URL,
+  };
+  for (let i = 0; i < commandArgs.length; i++) {
+    const replacement = map[commandArgs[i]];
+    if (replacement !== undefined) {
+      commandArgs[i] = replacement;
+    }
+  }
+}
+
 /**
  * Prompt the user for input via readline. Returns empty string if stdin closes.
  */

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -21,6 +21,7 @@ import {
   findPidOnPort,
   getDefaultPort,
   getDefaultTld,
+  hasPlaceholders,
   injectFrameworkFlags,
   isHttpsEnvEnabled,
   isWildcardEnvEnabled,
@@ -28,6 +29,7 @@ import {
   isWindows,
   prompt,
   readTldFromDir,
+  replacePlaceholders,
   readTlsMarker,
   resolveStateDir,
   spawnCommand,
@@ -512,8 +514,19 @@ async function runApp(
   const finalUrl = formatUrl(hostname, proxyPort, tls);
   console.log(chalk.cyan.bold(`\n  -> ${finalUrl}\n`));
 
-  // Inject --port for frameworks that ignore the PORT env var (e.g. Vite)
-  injectFrameworkFlags(commandArgs, port);
+  // Replace {PORT}, {HOST}, {PORTLESS_URL} placeholders in command args
+  const usedPlaceholders = hasPlaceholders(commandArgs);
+  replacePlaceholders(commandArgs, {
+    PORT: port.toString(),
+    HOST: "127.0.0.1",
+    PORTLESS_URL: finalUrl,
+  });
+
+  // Inject --port for frameworks that ignore the PORT env var (e.g. Vite).
+  // Skip when the user explicitly used placeholders.
+  if (!usedPlaceholders) {
+    injectFrameworkFlags(commandArgs, port);
+  }
 
   // Run the command
   console.log(
@@ -800,6 +813,14 @@ ${chalk.bold("Environment variables:")}
   PORTLESS_SYNC_HOSTS=1         Auto-sync ${HOSTS_DISPLAY} (auto-enabled for custom TLDs)
   PORTLESS_STATE_DIR=<path>     Override the state directory
   PORTLESS=0                    Run command directly without proxy
+
+${chalk.bold("Placeholders:")}
+  Use {PORT}, {HOST}, or {PORTLESS_URL} in command args to pass the
+  assigned values directly. Useful for tools that ignore the PORT env
+  var:
+    portless run my-server --port {PORT}
+    portless run my-server --port {PORT} --host {HOST}
+  When placeholders are used, automatic --port/--host injection is skipped.
 
 ${chalk.bold("Child process environment:")}
   PORT                          Ephemeral port the child should listen on

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -105,6 +105,14 @@ PORTLESS=0 pnpm dev   # Bypasses proxy, uses default port
 
 Most frameworks (Next.js, Express, Nuxt, etc.) respect the `PORT` env var automatically. For frameworks that ignore `PORT` (Vite, Astro, React Router, Angular, Expo, React Native), portless auto-injects the correct `--port` and `--host` CLI flags.
 
+For tools not covered by auto-injection, use `{PORT}`, `{HOST}`, or `{PORTLESS_URL}` placeholders in command args:
+
+```bash
+portless run my-server --port {PORT} --host {HOST}
+```
+
+Placeholders are replaced with the assigned values before the command runs. When placeholders are present, automatic `--port`/`--host` injection is skipped.
+
 ### State directory
 
 Portless stores its state (routes, PID file, port file) in a directory that depends on the proxy port:
@@ -197,10 +205,13 @@ portless proxy start -p 8080
 
 Portless auto-injects `--port` and `--host` flags for frameworks that ignore the `PORT` env var: **Vite**, **Astro**, **React Router**, **Angular**, **Expo**, and **React Native**. SvelteKit uses Vite internally and is handled automatically.
 
-For other frameworks that don't read `PORT`, pass the port manually:
+For other tools not covered by auto-injection, use placeholders:
 
-- **Webpack Dev Server**: use `--port $PORT`
-- **Custom servers**: read `process.env.PORT` and listen on it
+```bash
+portless run my-server --port {PORT} --host {HOST}
+```
+
+For custom servers, read `process.env.PORT` and listen on it.
 
 ### Permission errors
 


### PR DESCRIPTION
## Summary

- Many tools ignore the `PORT` env var and require CLI flags instead, with no standard flag name across tools
- The existing `injectFrameworkFlags` whitelist can't cover all tools, and Vite-based tools with their own CLI keep growing
- Users can't use `$PORT` in command args because the shell expands it before portless assigns a port; `sh -c "..."` works but is awkward
- `{PORT}`, `{HOST}`, and `{PORTLESS_URL}` placeholders in command args are now replaced with the assigned values before the command runs:
  ```
  portless run my-server --port {PORT} --host {HOST}
  ```
- When placeholders are present, automatic `--port`/`--host` injection is skipped
- `{...}` syntax has no special meaning in bash, zsh, fish, PowerShell, or cmd.exe, so it passes through to portless as-is

## Implementation Details

- `hasPlaceholders()` and `replacePlaceholders()` added to `cli-utils.ts`; exact-match only, uppercase only, unknown tokens ignored
- In `runApp()`, placeholders are replaced after port assignment and before `injectFrameworkFlags`; if any placeholder was present, framework injection is skipped entirely
- `PORT`/`HOST`/`PORTLESS_URL` env vars are still set regardless of placeholder usage

## Test plan

- [x] `pnpm exec vitest run src/cli-utils.test.ts` -- 92 tests pass (16 new for `hasPlaceholders`/`replacePlaceholders`)
- [x] `portless run my-server --port {PORT}` -- confirm port is replaced and server starts on the assigned port
- [x] `portless run vite dev` -- confirm auto-injection still works when no placeholders are used
- [x] Verify `--help` output includes the new Placeholders section