### PR TITLE
prepare v0.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.8.0
+
+<!-- release:start -->
+
+### Breaking Changes
+
+- **Strict subdomain routing is now the default** -- Subdomains no longer automatically match parent hostnames (e.g. `api.myapp.localhost` no longer routes to `myapp.localhost`). Use the `--wildcard` flag or `PORTLESS_WILDCARD=1` env var to restore the previous behavior. (#158)
+
+### New Features
+
+- **`--wildcard` flag** -- Opt in to wildcard subdomain routing where subdomains match registered parent hostnames. Configurable via `PORTLESS_WILDCARD` env var. (#158)
+
+### Bug Fixes
+
+- **Cert generation with dots in `$HOME`** -- Fix TLS certificate generation failing when the home directory path contains dots (#157)
+- **DNS label limit for `--name` flag** -- Fix regression where long `--name` values could exceed the 63-character DNS label limit (#144)
+- **Windows `DEP0190` deprecation warning** -- Silence Node.js deprecation warning on Windows by replacing `shell: true` with explicit `cmd.exe /d /s /c` spawning (#160)
+- **Windows duplicate `PATH` entries** -- Deduplicate `PATH` environment variables in child process spawn on Windows (#155)
+
+### Improvements
+
+- **Removed chalk dependency** -- Replaced chalk with lightweight ANSI color utilities to reduce install size (#170)
+- **Automated release process** -- Added CI workflow for automated npm publishing and GitHub releases (#169)
+
+### Contributors
+
+- @ctate
+- @mynameistito
+<!-- release:end -->
+
 ## 0.7.2
 
 ### Bug Fixes

--- a/apps/docs/src/app/changelog/page.mdx
+++ b/apps/docs/src/app/changelog/page.mdx
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.8.0
+
+### Breaking Changes
+
+- **Strict subdomain routing is now the default** -- Subdomains no longer automatically match parent hostnames (e.g. `api.myapp.localhost` no longer routes to `myapp.localhost`). Use the `--wildcard` flag or `PORTLESS_WILDCARD=1` env var to restore the previous behavior
+
+### New Features
+
+- **`--wildcard` flag** -- Opt in to wildcard subdomain routing where subdomains match registered parent hostnames. Configurable via `PORTLESS_WILDCARD` env var
+
+### Bug Fixes
+
+- **Cert generation with dots in `$HOME`** -- Fix TLS certificate generation failing when the home directory path contains dots
+- **DNS label limit for `--name` flag** -- Fix regression where long `--name` values could exceed the 63-character DNS label limit
+- **Windows `DEP0190` deprecation warning** -- Silence Node.js deprecation warning on Windows by replacing `shell: true` with explicit `cmd.exe /d /s /c` spawning
+- **Windows duplicate `PATH` entries** -- Deduplicate `PATH` environment variables in child process spawn on Windows
+
+### Improvements
+
+- **Removed chalk dependency** -- Replaced chalk with lightweight ANSI color utilities to reduce install size
+- **Automated release process** -- Added CI workflow for automated npm publishing and GitHub releases
+
 ## 0.7.2
 
 ### Bug Fixes

--- a/packages/portless/package.json
+++ b/packages/portless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portless",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Replace port numbers with stable, named .localhost URLs. For humans and agents.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Bump version to 0.8.0
- Add changelog entry with release markers for CI to extract
- Add matching docs changelog entry

## Changes in this release

### Breaking Changes
- Strict subdomain routing is now the default; use `--wildcard` to opt back in (#158)

### New Features
- `--wildcard` flag for wildcard subdomain routing (#158)

### Bug Fixes
- Cert generation with dots in `$HOME` (#157)
- DNS label limit regression for `--name` flag (#144)
- Windows `DEP0190` deprecation warning (#160)
- Windows duplicate `PATH` entries (#155)

### Improvements
- Removed chalk dependency (#170)
- Automated release process (#169)