### PR TITLE
fix(trust): generate CA cert when running portless trust on fresh install

### DIFF
--- a/packages/portless/src/certs.test.ts
+++ b/packages/portless/src/certs.test.ts
@@ -366,5 +366,6 @@ describe("trustCA", () => {
     const result = trustCA(tmpDir);
     expect(result.trusted).toBe(false);
     expect(result.error).toContain("CA certificate not found");
+    expect(result.error).toContain("portless trust");
   });
 });

--- a/packages/portless/src/certs.ts
+++ b/packages/portless/src/certs.ts
@@ -705,7 +705,10 @@ export function createSNICallback(
 export function trustCA(stateDir: string): { trusted: boolean; error?: string } {
   const caCertPath = path.join(stateDir, CA_CERT_FILE);
   if (!fileExists(caCertPath)) {
-    return { trusted: false, error: "CA certificate not found. Run with --https first." };
+    return {
+      trusted: false,
+      error: "CA certificate not found. Run portless trust to generate it.",
+    };
   }
 
   try {

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -880,6 +880,13 @@ function printVersion(): void {
 
 async function handleTrust(): Promise<void> {
   const { dir } = await discoverState();
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  const { caGenerated } = ensureCerts(dir);
+  if (caGenerated) {
+    console.log(colors.gray("Generated local CA certificate."));
+  }
   const result = trustCA(dir);
   if (result.trusted) {
     console.log(colors.green("Local CA added to system trust store."));


### PR DESCRIPTION
The trust subcommand called trustCA() without first ensuring the CA certificate existed. On a fresh install (no proxy started yet), this always failed with "CA certificate not found. Run with --https first."

Now handleTrust() calls ensureCerts() to generate the CA and server cert before trusting, and creates the state directory if missing.

Also updates the error message in trustCA() to reference the correct command (portless trust) instead of the non-existent --https flag.

Fixes #124