### PR TITLE
docs: add Windows debugging tips to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,12 @@ CI compares the version in `packages/portless/package.json` to what's on npm. If
 
 A remote Windows Server 2022 EC2 instance is available for debugging Windows-specific issues. It uses AWS Systems Manager (SSM) with no SSH or open ports. Commands run via `aws ssm send-command` and return stdout/stderr.
 
+All scripts require `AWS_PROFILE=portless-debug` (or the profile must be set as default). Prefix every command with it or export it for the session:
+
+```bash
+export AWS_PROFILE=portless-debug
+```
+
 ### Prerequisites
 
 The instance must be provisioned first (one-time, by a human):
@@ -84,18 +90,36 @@ Stop the instance when done (avoids cost):
 ./scripts/windows-debug/stop.sh
 ```
 
+### Important notes
+
+**SSM agent takes a long time to come online.** After starting or restarting the instance, the SSM agent can take 5 to 10 minutes before it accepts commands. If `run.sh` returns `InvalidInstanceId`, wait and retry. Do not assume the instance is broken; poll with increasing intervals.
+
+**PowerShell uses `;` not `&&`.** The `run.sh` wrapper executes PowerShell, which does not support `&&` as a command separator. Use `;` instead:
+
+```bash
+./scripts/windows-debug/run.sh "cd C:\portless; pnpm test"
+```
+
+**OpenSSL may not be at the expected path.** The bootstrap installs OpenSSL to `C:\Program Files\OpenSSL-Win64\bin`, but this can fail silently. Git bundles its own OpenSSL at `C:\Program Files\Git\mingw64\bin`. If `openssl` is not found, add Git's path:
+
+```bash
+./scripts/windows-debug/run.sh '$env:PATH = "C:\Program Files\Git\mingw64\bin;$env:PATH"; openssl version'
+```
+
+**SSM runs as SYSTEM.** Commands execute as the SYSTEM account, not a normal user. This affects user-specific operations (e.g., `certutil -addstore -user Root` targets SYSTEM's trust store, not a real user's). Keep this in mind when testing user-facing features.
+
 ### Common Workflows
 
 Run unit tests on Windows:
 
 ```bash
-./scripts/windows-debug/run.sh "cd C:\portless && pnpm test"
+./scripts/windows-debug/run.sh "cd C:\portless; pnpm test"
 ```
 
 Run e2e tests on Windows:
 
 ```bash
-./scripts/windows-debug/run.sh "cd C:\portless && pnpm test:e2e"
+./scripts/windows-debug/run.sh "cd C:\portless; pnpm test:e2e"
 ```
 
 Check bootstrap progress (first boot only):


### PR DESCRIPTION
## Summary

- Adds practical guidance to the Windows Debugging section learned from debugging #124
- Documents `AWS_PROFILE=portless-debug` requirement for all scripts
- Notes SSM agent startup delay (5-10 min), PowerShell syntax (`;` not `&&`), OpenSSL fallback path, and SYSTEM account context
- Fixes command examples to use `;` instead of `&&`