### PR TITLE
feat: support installation as a project dev dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 Use `pnpm` for all package management commands (not npm or yarn).
 
-Exception: Global install instructions for end users should use `npm install -g` since it's universal.
+Exception: End-user install instructions should use `npm install -g` (global) or `npm install -D` (project dev dependency) since npm is universal.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,19 @@ Replace port numbers with stable, named .localhost URLs for local development. F
 
 ## Install
 
+**Global (recommended):**
+
 ```bash
 npm install -g portless
 ```
 
-> Install globally. Do not add as a project dependency or run via npx.
+**Or as a project dev dependency:**
+
+```bash
+npm install -D portless
+```
+
+> portless is pre-1.0. When installed per-project, different contributors may run different versions. The state directory format may change between releases, which can require re-running `portless trust`.
 
 ## Run your app
 

--- a/apps/docs/src/app/page.mdx
+++ b/apps/docs/src/app/page.mdx
@@ -9,11 +9,19 @@ Portless replaces port numbers with stable, named `.localhost` URLs for local de
 
 ## Install
 
+**Global (recommended):**
+
 ```bash
 npm install -g portless
 ```
 
-> Install globally. Do not add as a project dependency or run via npx.
+**Or as a project dev dependency:**
+
+```bash
+npm install -D portless
+```
+
+> portless is pre-1.0. When installed per-project, different contributors may run different versions. The state directory format may change between releases, which can require re-running `portless trust`.
 
 ## Run your app
 

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -71,6 +71,24 @@ function getEntryScript(): string {
 }
 
 /**
+ * Check whether portless is installed as a project dependency by walking
+ * up from cwd looking for node_modules/portless. Used to distinguish a
+ * local `npx portless` (allowed) from a one-off download (blocked).
+ */
+function isLocallyInstalled(): boolean {
+  let dir = process.cwd();
+  for (;;) {
+    if (fs.existsSync(path.join(dir, "node_modules", "portless", "package.json"))) {
+      return true;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return false;
+}
+
+/**
  * Collect PORTLESS_* env vars as KEY=VALUE strings suitable for
  * `sudo env KEY=VAL ...` invocations (sudo may strip the environment).
  */
@@ -771,8 +789,8 @@ Eliminates port conflicts, memorizing port numbers, and cookie/storage
 clashes by giving each dev server a stable .localhost URL.
 
 ${colors.bold("Install:")}
-  ${colors.cyan("npm install -g portless")}
-  Do NOT add portless as a project dependency.
+  ${colors.cyan("npm install -g portless")}          Global (recommended)
+  ${colors.cyan("npm install -D portless")}          Project dev dependency
 
 ${colors.bold("Usage:")}
   ${colors.cyan("portless proxy start")}             Start the proxy (HTTPS on port 443, daemon)
@@ -1645,15 +1663,17 @@ async function main() {
 
   const args = process.argv.slice(2);
 
-  // Block npx / pnpm dlx: portless should be installed globally, not run
-  // via npx. Running "sudo npx" is unsafe because it performs package
-  // resolution and downloads as root.
+  // Block one-off npx / pnpm dlx downloads. Running "sudo npx" is unsafe
+  // because it performs package resolution and downloads as root. When
+  // portless is installed as a project dependency the env vars still fire,
+  // so skip the block if we can find a local installation.
   const isNpx = process.env.npm_command === "exec" && !process.env.npm_lifecycle_event;
   const isPnpmDlx = !!process.env.PNPM_SCRIPT_SRC_DIR && !process.env.npm_lifecycle_event;
-  if (isNpx || isPnpmDlx) {
+  if ((isNpx || isPnpmDlx) && !isLocallyInstalled()) {
     console.error(colors.red("Error: portless should not be run via npx or pnpm dlx."));
-    console.error(colors.blue("Install globally instead:"));
+    console.error(colors.blue("Install globally or as a project dependency:"));
     console.error(colors.cyan("  npm install -g portless"));
+    console.error(colors.cyan("  npm install -D portless"));
     process.exit(1);
   }
 

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -21,18 +21,22 @@ Replace port numbers with stable, named .localhost URLs. For humans and agents.
 
 ## Installation
 
-portless is a global CLI tool. Do NOT add it as a project dependency (no `npm install portless` or `pnpm add portless` in a project). Do NOT use `npx` or `pnpm dlx`.
-
-Install globally:
+Install globally (recommended) or as a project dev dependency. Do NOT use `npx` or `pnpm dlx` for one-off execution.
 
 ```bash
+# Global (available everywhere)
 npm install -g portless
+
+# Or per-project dev dependency
+npm install -D portless
 ```
+
+When installed per-project, invoke via package.json scripts or `npx portless` (since the package is local, npx will not download anything).
 
 ## Quick Start
 
 ```bash
-# Install globally
+# Install globally (or add -D to a project)
 npm install -g portless
 
 # Run your app (auto-starts the HTTPS proxy on port 443)


### PR DESCRIPTION
portless already works as a local dev dependency (state lives in `~/.portless`, not relative to the install path, and there are no postinstall hooks), but the docs said "don't do this" and the CLI blocked npx/dlx even for locally-installed packages.

- Add `isLocallyInstalled()` helper that walks up from cwd looking for `node_modules/portless`; the npx/dlx block now only fires for one-off downloads, not project dependencies
- Update install sections in README, docs site, CLI `--help`, and agent skill to show both global and project dev dependency options
- Note the pre-1.0 state-format caveat for per-project installs

Closes #135