### PR TITLE
Automatically inject NODE_EXTRA_CA_CERTS for child processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ PORTLESS_STATE_DIR=<path>        Override the state directory
 PORT                             Ephemeral port the child should listen on
 HOST                             Usually 127.0.0.1 (omitted for Expo in LAN mode)
 PORTLESS_URL                     Public URL (e.g. https://myapp.localhost)
+NODE_EXTRA_CA_CERTS              Path to the portless CA (when HTTPS is active)
 ```
 
 > **Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `trust`, `clean`, and `proxy` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name from your project, or `portless --name <name> <cmd>` to force any name including reserved ones.
@@ -275,7 +276,7 @@ devServer: {
 }
 ```
 
-If your tooling doesn't trust the portless CA, point Node.js at it: `NODE_EXTRA_CA_CERTS=/tmp/portless/ca.pem` (or `~/.portless/ca.pem` when the proxy runs on a non-privileged port like 1355). Alternatively, use `--no-tls` for plain HTTP.
+Portless automatically sets `NODE_EXTRA_CA_CERTS` in child processes so Node.js trusts the portless CA. If you run a separate Node.js process outside portless, point it at the CA manually: `NODE_EXTRA_CA_CERTS=/tmp/portless/ca.pem` (or `~/.portless/ca.pem` when the proxy runs on a non-privileged port like 1355). Alternatively, use `--no-tls` for plain HTTP.
 
 Portless detects this misconfiguration and responds with `508 Loop Detected` along with a message pointing to this fix.
 

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -714,6 +714,7 @@ describe("CLI", () => {
 
     async function runWithMockProxy(opts: {
       tls?: boolean;
+      writeCaPem?: boolean;
       env?: Record<string, string | undefined>;
     }): Promise<{ status: number | null; capture: Record<string, unknown> }> {
       const server = http.createServer((_req, res) => {
@@ -735,7 +736,9 @@ describe("CLI", () => {
         if (opts.tls !== false) {
           fs.writeFileSync(path.join(tmpDir, "proxy.tls"), "1");
         }
-        fs.writeFileSync(path.join(tmpDir, "ca.pem"), "fake-ca-cert");
+        if (opts.writeCaPem !== false) {
+          fs.writeFileSync(path.join(tmpDir, "ca.pem"), "fake-ca-cert");
+        }
 
         const capturePath = path.join(tmpDir, "capture.json");
         const scriptPath = path.join(tmpDir, "capture-env.js");
@@ -774,6 +777,15 @@ describe("CLI", () => {
       const { status, capture } = await runWithMockProxy({
         tls: false,
         env: { PORTLESS_HTTPS: "0", NODE_EXTRA_CA_CERTS: undefined },
+      });
+      expect(status).toBe(0);
+      expect(capture.NODE_EXTRA_CA_CERTS).toBeUndefined();
+    });
+
+    it("does not set NODE_EXTRA_CA_CERTS when ca.pem is missing", async () => {
+      const { status, capture } = await runWithMockProxy({
+        writeCaPem: false,
+        env: { NODE_EXTRA_CA_CERTS: undefined },
       });
       expect(status).toBe(0);
       expect(capture.NODE_EXTRA_CA_CERTS).toBeUndefined();

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -701,6 +701,159 @@ describe("CLI", () => {
     });
   });
 
+  describe("NODE_EXTRA_CA_CERTS injection", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-cli-ca-test-"));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("sets NODE_EXTRA_CA_CERTS when TLS is active and ca.pem exists", async () => {
+      const server = http.createServer((_req, res) => {
+        res.setHeader("X-Portless", "1");
+        res.end("ok");
+      });
+      const capturePath = path.join(tmpDir, "capture.json");
+
+      try {
+        const proxyPort = await new Promise<number>((resolve) => {
+          server.listen(0, "127.0.0.1", () => {
+            const addr = server.address();
+            if (addr && typeof addr !== "string") {
+              resolve(addr.port);
+            }
+          });
+        });
+
+        fs.writeFileSync(path.join(tmpDir, "proxy.port"), proxyPort.toString());
+        fs.writeFileSync(path.join(tmpDir, "proxy.tls"), "1");
+        fs.writeFileSync(path.join(tmpDir, "ca.pem"), "fake-ca-cert");
+
+        // Capture script that writes NODE_EXTRA_CA_CERTS to a file
+        const captureScript = [
+          'const fs = require("node:fs");',
+          `fs.writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify({`,
+          "  NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS,",
+          "}));",
+        ].join("\n");
+
+        const { status } = run(
+          ["run", "--name", "testapp", "node", "-e", captureScript],
+          {
+            env: {
+              PORTLESS_STATE_DIR: tmpDir,
+              NODE_EXTRA_CA_CERTS: undefined,
+            },
+          }
+        );
+
+        expect(status).toBe(0);
+        const capture = JSON.parse(fs.readFileSync(capturePath, "utf-8"));
+        expect(capture.NODE_EXTRA_CA_CERTS).toBe(path.join(tmpDir, "ca.pem"));
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    });
+
+    it("does not set NODE_EXTRA_CA_CERTS when TLS is disabled", async () => {
+      const server = http.createServer((_req, res) => {
+        res.setHeader("X-Portless", "1");
+        res.end("ok");
+      });
+      const capturePath = path.join(tmpDir, "capture.json");
+
+      try {
+        const proxyPort = await new Promise<number>((resolve) => {
+          server.listen(0, "127.0.0.1", () => {
+            const addr = server.address();
+            if (addr && typeof addr !== "string") {
+              resolve(addr.port);
+            }
+          });
+        });
+
+        fs.writeFileSync(path.join(tmpDir, "proxy.port"), proxyPort.toString());
+        fs.writeFileSync(path.join(tmpDir, "ca.pem"), "fake-ca-cert");
+        // No proxy.tls marker
+
+        const captureScript = [
+          'const fs = require("node:fs");',
+          `fs.writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify({`,
+          "  NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS,",
+          "}));",
+        ].join("\n");
+
+        const { status } = run(
+          ["run", "--name", "testapp", "node", "-e", captureScript],
+          {
+            env: {
+              PORTLESS_STATE_DIR: tmpDir,
+              PORTLESS_HTTPS: "0",
+              NODE_EXTRA_CA_CERTS: undefined,
+            },
+          }
+        );
+
+        expect(status).toBe(0);
+        const capture = JSON.parse(fs.readFileSync(capturePath, "utf-8"));
+        expect(capture.NODE_EXTRA_CA_CERTS).toBeUndefined();
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    });
+
+    it("does not override user-set NODE_EXTRA_CA_CERTS", async () => {
+      const server = http.createServer((_req, res) => {
+        res.setHeader("X-Portless", "1");
+        res.end("ok");
+      });
+      const capturePath = path.join(tmpDir, "capture.json");
+      const userCaPath = "/custom/ca.pem";
+
+      try {
+        const proxyPort = await new Promise<number>((resolve) => {
+          server.listen(0, "127.0.0.1", () => {
+            const addr = server.address();
+            if (addr && typeof addr !== "string") {
+              resolve(addr.port);
+            }
+          });
+        });
+
+        fs.writeFileSync(path.join(tmpDir, "proxy.port"), proxyPort.toString());
+        fs.writeFileSync(path.join(tmpDir, "proxy.tls"), "1");
+        fs.writeFileSync(path.join(tmpDir, "ca.pem"), "fake-ca-cert");
+
+        const captureScript = [
+          'const fs = require("node:fs");',
+          `fs.writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify({`,
+          "  NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS,",
+          "}));",
+        ].join("\n");
+
+        const { status } = run(
+          ["run", "--name", "testapp", "node", "-e", captureScript],
+          {
+            env: {
+              PORTLESS_STATE_DIR: tmpDir,
+              NODE_EXTRA_CA_CERTS: userCaPath,
+            },
+          }
+        );
+
+        expect(status).toBe(0);
+        const capture = JSON.parse(fs.readFileSync(capturePath, "utf-8"));
+        expect(capture.NODE_EXTRA_CA_CERTS).toBe(userCaPath);
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    });
+  });
+
   describe("get subcommand", () => {
     let tmpDir: string;
 

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -712,12 +712,14 @@ describe("CLI", () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     });
 
-    it("sets NODE_EXTRA_CA_CERTS when TLS is active and ca.pem exists", async () => {
+    async function runWithMockProxy(opts: {
+      tls?: boolean;
+      env?: Record<string, string | undefined>;
+    }): Promise<{ status: number | null; capture: Record<string, unknown> }> {
       const server = http.createServer((_req, res) => {
         res.setHeader("X-Portless", "1");
         res.end("ok");
       });
-      const capturePath = path.join(tmpDir, "capture.json");
 
       try {
         const proxyPort = await new Promise<number>((resolve) => {
@@ -730,127 +732,60 @@ describe("CLI", () => {
         });
 
         fs.writeFileSync(path.join(tmpDir, "proxy.port"), proxyPort.toString());
-        fs.writeFileSync(path.join(tmpDir, "proxy.tls"), "1");
+        if (opts.tls !== false) {
+          fs.writeFileSync(path.join(tmpDir, "proxy.tls"), "1");
+        }
         fs.writeFileSync(path.join(tmpDir, "ca.pem"), "fake-ca-cert");
 
-        // Capture script that writes NODE_EXTRA_CA_CERTS to a file
-        const captureScript = [
-          'const fs = require("node:fs");',
-          `fs.writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify({`,
-          "  NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS,",
-          "}));",
-        ].join("\n");
-
-        const { status } = run(
-          ["run", "--name", "testapp", "node", "-e", captureScript],
-          {
-            env: {
-              PORTLESS_STATE_DIR: tmpDir,
-              NODE_EXTRA_CA_CERTS: undefined,
-            },
-          }
+        const capturePath = path.join(tmpDir, "capture.json");
+        const scriptPath = path.join(tmpDir, "capture-env.js");
+        fs.writeFileSync(
+          scriptPath,
+          [
+            'const fs = require("node:fs");',
+            `fs.writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify({`,
+            "  NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS,",
+            "}));",
+          ].join("\n") + "\n"
         );
 
-        expect(status).toBe(0);
-        const capture = JSON.parse(fs.readFileSync(capturePath, "utf-8"));
-        expect(capture.NODE_EXTRA_CA_CERTS).toBe(path.join(tmpDir, "ca.pem"));
+        const { status } = run(["run", "--name", "testapp", "node", scriptPath], {
+          env: { PORTLESS_STATE_DIR: tmpDir, ...opts.env },
+        });
+
+        const capture = fs.existsSync(capturePath)
+          ? JSON.parse(fs.readFileSync(capturePath, "utf-8"))
+          : {};
+        return { status, capture };
       } finally {
         await new Promise<void>((resolve) => server.close(() => resolve()));
       }
+    }
+
+    it("sets NODE_EXTRA_CA_CERTS when TLS is active and ca.pem exists", async () => {
+      const { status, capture } = await runWithMockProxy({
+        env: { NODE_EXTRA_CA_CERTS: undefined },
+      });
+      expect(status).toBe(0);
+      expect(capture.NODE_EXTRA_CA_CERTS).toBe(path.join(tmpDir, "ca.pem"));
     });
 
     it("does not set NODE_EXTRA_CA_CERTS when TLS is disabled", async () => {
-      const server = http.createServer((_req, res) => {
-        res.setHeader("X-Portless", "1");
-        res.end("ok");
+      const { status, capture } = await runWithMockProxy({
+        tls: false,
+        env: { PORTLESS_HTTPS: "0", NODE_EXTRA_CA_CERTS: undefined },
       });
-      const capturePath = path.join(tmpDir, "capture.json");
-
-      try {
-        const proxyPort = await new Promise<number>((resolve) => {
-          server.listen(0, "127.0.0.1", () => {
-            const addr = server.address();
-            if (addr && typeof addr !== "string") {
-              resolve(addr.port);
-            }
-          });
-        });
-
-        fs.writeFileSync(path.join(tmpDir, "proxy.port"), proxyPort.toString());
-        fs.writeFileSync(path.join(tmpDir, "ca.pem"), "fake-ca-cert");
-        // No proxy.tls marker
-
-        const captureScript = [
-          'const fs = require("node:fs");',
-          `fs.writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify({`,
-          "  NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS,",
-          "}));",
-        ].join("\n");
-
-        const { status } = run(
-          ["run", "--name", "testapp", "node", "-e", captureScript],
-          {
-            env: {
-              PORTLESS_STATE_DIR: tmpDir,
-              PORTLESS_HTTPS: "0",
-              NODE_EXTRA_CA_CERTS: undefined,
-            },
-          }
-        );
-
-        expect(status).toBe(0);
-        const capture = JSON.parse(fs.readFileSync(capturePath, "utf-8"));
-        expect(capture.NODE_EXTRA_CA_CERTS).toBeUndefined();
-      } finally {
-        await new Promise<void>((resolve) => server.close(() => resolve()));
-      }
+      expect(status).toBe(0);
+      expect(capture.NODE_EXTRA_CA_CERTS).toBeUndefined();
     });
 
     it("does not override user-set NODE_EXTRA_CA_CERTS", async () => {
-      const server = http.createServer((_req, res) => {
-        res.setHeader("X-Portless", "1");
-        res.end("ok");
-      });
-      const capturePath = path.join(tmpDir, "capture.json");
       const userCaPath = "/custom/ca.pem";
-
-      try {
-        const proxyPort = await new Promise<number>((resolve) => {
-          server.listen(0, "127.0.0.1", () => {
-            const addr = server.address();
-            if (addr && typeof addr !== "string") {
-              resolve(addr.port);
-            }
-          });
-        });
-
-        fs.writeFileSync(path.join(tmpDir, "proxy.port"), proxyPort.toString());
-        fs.writeFileSync(path.join(tmpDir, "proxy.tls"), "1");
-        fs.writeFileSync(path.join(tmpDir, "ca.pem"), "fake-ca-cert");
-
-        const captureScript = [
-          'const fs = require("node:fs");',
-          `fs.writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify({`,
-          "  NODE_EXTRA_CA_CERTS: process.env.NODE_EXTRA_CA_CERTS,",
-          "}));",
-        ].join("\n");
-
-        const { status } = run(
-          ["run", "--name", "testapp", "node", "-e", captureScript],
-          {
-            env: {
-              PORTLESS_STATE_DIR: tmpDir,
-              NODE_EXTRA_CA_CERTS: userCaPath,
-            },
-          }
-        );
-
-        expect(status).toBe(0);
-        const capture = JSON.parse(fs.readFileSync(capturePath, "utf-8"));
-        expect(capture.NODE_EXTRA_CA_CERTS).toBe(userCaPath);
-      } finally {
-        await new Promise<void>((resolve) => server.close(() => resolve()));
-      }
+      const { status, capture } = await runWithMockProxy({
+        env: { NODE_EXTRA_CA_CERTS: userCaPath },
+      });
+      expect(status).toBe(0);
+      expect(capture.NODE_EXTRA_CA_CERTS).toBe(userCaPath);
     });
   });
 

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -963,6 +963,19 @@ async function runApp(
     )
   );
 
+  // Point Node.js at the portless CA so server-side fetches (e.g. Next.js
+  // Server Components) trust portless-proxied HTTPS services. Node.js does
+  // not use the system trust store, so without this env var it rejects the
+  // portless CA as "self-signed certificate in certificate chain".
+  // Respect any value the user already set.
+  const caEnv: Record<string, string> = {};
+  if (tls && !process.env.NODE_EXTRA_CA_CERTS) {
+    const caPath = path.join(stateDir, "ca.pem");
+    if (fs.existsSync(caPath)) {
+      caEnv.NODE_EXTRA_CA_CERTS = caPath;
+    }
+  }
+
   spawnCommand(commandArgs, {
     env: {
       ...process.env,
@@ -974,6 +987,7 @@ async function runApp(
       // baked-in pinging, making this env var ineffective. Expo handles its
       // own LAN discovery natively.
       ...(lanMode ? { PORTLESS_LAN: "1" } : {}),
+      ...caEnv,
     },
     onCleanup: () => {
       try {
@@ -1272,6 +1286,7 @@ ${colors.bold("Child process environment:")}
   HOST                          Usually 127.0.0.1 (omitted for Expo in LAN mode)
   PORTLESS_URL                  Public URL of the app (e.g. https://myapp.localhost)
   PORTLESS_LAN                  Set to 1 when proxy is in LAN mode
+  NODE_EXTRA_CA_CERTS           Path to the portless CA (set when HTTPS is active)
 
 ${colors.bold("Safari / DNS:")}
   .localhost subdomains auto-resolve in Chrome, Firefox, and Edge.

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -956,13 +956,6 @@ async function runApp(
   // Inject --port for frameworks that ignore the PORT env var (e.g. Vite)
   injectFrameworkFlags(commandArgs, port);
 
-  // Run the command
-  console.log(
-    chalk.gray(
-      `Running: PORT=${port}${hostBind ? ` HOST=${hostBind}` : ""} PORTLESS_URL=${finalUrl} ${commandArgs.join(" ")}\n`
-    )
-  );
-
   // Point Node.js at the portless CA so server-side fetches (e.g. Next.js
   // Server Components) trust portless-proxied HTTPS services. Node.js does
   // not use the system trust store, so without this env var it rejects the
@@ -975,6 +968,16 @@ async function runApp(
       caEnv.NODE_EXTRA_CA_CERTS = caPath;
     }
   }
+
+  // Run the command
+  const caFragment = caEnv.NODE_EXTRA_CA_CERTS
+    ? ` NODE_EXTRA_CA_CERTS=${caEnv.NODE_EXTRA_CA_CERTS}`
+    : "";
+  console.log(
+    chalk.gray(
+      `Running: PORT=${port}${hostBind ? ` HOST=${hostBind}` : ""} PORTLESS_URL=${finalUrl}${caFragment} ${commandArgs.join(" ")}\n`
+    )
+  );
 
   spawnCommand(commandArgs, {
     env: {

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -960,7 +960,10 @@ async function runApp(
   // Server Components) trust portless-proxied HTTPS services. Node.js does
   // not use the system trust store, so without this env var it rejects the
   // portless CA as "self-signed certificate in certificate chain".
-  // Respect any value the user already set.
+  // Respect any value the user already set. Note: we check process.env here
+  // rather than the constructed child env because the child env inherits from
+  // process.env via spread. If a future code path injects NODE_EXTRA_CA_CERTS
+  // into the child env independently, this guard would need updating.
   const caEnv: Record<string, string> = {};
   if (tls && !process.env.NODE_EXTRA_CA_CERTS) {
     const caPath = path.join(stateDir, "ca.pem");
@@ -971,7 +974,7 @@ async function runApp(
 
   // Run the command
   const caFragment = caEnv.NODE_EXTRA_CA_CERTS
-    ? ` NODE_EXTRA_CA_CERTS=${caEnv.NODE_EXTRA_CA_CERTS}`
+    ? ` NODE_EXTRA_CA_CERTS="${caEnv.NODE_EXTRA_CA_CERTS}"`
     : "";
   console.log(
     chalk.gray(

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -287,7 +287,7 @@ proxy: {
 }
 ```
 
-If your tooling doesn't trust the portless CA, point Node.js at it: `NODE_EXTRA_CA_CERTS=/tmp/portless/ca.pem` (or `~/.portless/ca.pem` when the proxy runs on a non-privileged port like 1355). Alternatively, use `--no-tls` for plain HTTP.
+Portless automatically sets `NODE_EXTRA_CA_CERTS` in child processes so Node.js trusts the portless CA. If you run a separate Node.js process outside portless, point it at the CA manually: `NODE_EXTRA_CA_CERTS=/tmp/portless/ca.pem` (or `~/.portless/ca.pem` when the proxy runs on a non-privileged port like 1355). Alternatively, use `--no-tls` for plain HTTP.
 
 ### Requirements
 


### PR DESCRIPTION
Fixes Node.js server-side fetches failing with "self-signed certificate in certificate chain" when making HTTPS requests to portless-proxied services.

## Problem
Node.js uses its own hardcoded CA bundle and ignores the system trust store. When server-side code (like Next.js Server Components) makes fetch requests to portless HTTPS URLs, Node.js rejects the portless CA as untrusted, even though browsers work fine.

## Changes
- Automatically inject `NODE_EXTRA_CA_CERTS` pointing to the portless CA cert when spawning child processes
- Only set when TLS is active and user hasn't already configured it
- Added comprehensive tests covering TLS enabled/disabled and user override scenarios
- Updated documentation to reflect automatic injection

## Implementation
The fix adds the CA cert path to the child process environment alongside existing variables like `PORT`, `HOST`, and `PORTLESS_URL`. This tells Node.js to trust the portless CA in addition to its built-in certificate bundle.

Fixes #218