### PR TITLE
Fix ERR_HTTP2_PROTOCOL_ERROR via H2 session recycling

### DIFF
--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -205,12 +205,20 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
             delete responseHeaders[h];
           }
         }
-        res.writeHead(proxyRes.statusCode || 502, responseHeaders);
-        proxyRes.on("error", () => {
-          if (!res.headersSent) {
-            res.writeHead(502, { "Content-Type": "text/plain" });
+        try {
+          res.writeHead(proxyRes.statusCode || 502, responseHeaders);
+        } catch {
+          proxyRes.resume();
+          return;
+        }
+        // destroy (RST_STREAM) rather than end() to avoid partial-body
+        // content-length mismatch killing the entire H2 session.
+        proxyRes.on("error", (err) => {
+          const code = (err as NodeJS.ErrnoException).code;
+          onError(`[portless] proxyRes error: ${code} ${err.message} — ${req.url}`);
+          if (!res.destroyed) {
+            res.destroy();
           }
-          res.end();
         });
         proxyRes.pipe(res);
       }
@@ -235,7 +243,6 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
       }
     });
 
-    // Abort the outgoing request if the client disconnects
     res.on("close", () => {
       if (!proxyReq.destroyed) {
         proxyReq.destroy();
@@ -362,14 +369,48 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
       cert: tls.ca ? Buffer.concat([tls.cert, tls.ca]) : tls.cert,
       key: tls.key,
       allowHTTP1: true,
+      settings: { maxConcurrentStreams: 1000 },
       ...(tls.SNICallback ? { SNICallback: tls.SNICallback } : {}),
     });
-    // With allowHTTP1, the 'request' event receives objects compatible with
-    // http.IncomingMessage / http.ServerResponse. Cast explicitly to satisfy TypeScript.
+    const h2Sessions = new Set<http2.ServerHttp2Session>();
+    h2Server.on("session", (session: http2.ServerHttp2Session) => {
+      h2Sessions.add(session);
+
+      // Recycle the session at 800 lifetime streams. Node.js's internal streams_
+      // map grows on every stream (GC removes entries, not close), so it can hit
+      // maxConcurrentStreams and cause GOAWAY INTERNAL_ERROR. Closing gracefully
+      // at 800 keeps the map below 1000; Chrome opens a fresh session silently.
+      let sessionStreamCount = 0;
+      session.on("stream", () => {
+        if (++sessionStreamCount >= 800 && !session.closed && !session.destroyed) {
+          session.close();
+        }
+      });
+
+      session.on("close", () => {
+        h2Sessions.delete(session);
+      });
+      session.on("error", () => {
+        session.close();
+        setTimeout(() => {
+          if (!session.destroyed) session.destroy();
+        }, 2000).unref();
+        h2Sessions.delete(session);
+      });
+    });
+    h2Server.on("error", () => {});
+    h2Server.on("unknownProtocol", (socket: net.Socket) => {
+      socket.destroy();
+    });
     h2Server.on("request", (req: http2.Http2ServerRequest, res: http2.Http2ServerResponse) => {
+      // Absorb RST_STREAM errors on the h2 stream — without this listener they
+      // propagate to the session and kill all concurrent streams.
+      // Do NOT call destroy() here: the browser already closed the stream.
+      if (req.stream) {
+        req.stream.once("error", () => {});
+      }
       handleRequest(req as unknown as http.IncomingMessage, res as unknown as http.ServerResponse);
     });
-    // WebSocket upgrades arrive over HTTP/1.1 connections (allowHTTP1)
     h2Server.on("upgrade", (req: http.IncomingMessage, socket: net.Socket, head: Buffer) => {
       handleUpgrade(req, socket, head);
     });
@@ -420,6 +461,9 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
     // Proxy close() through to inner servers so tests and cleanup work.
     const origClose = wrapper.close.bind(wrapper);
     wrapper.close = function (cb?: (err?: Error) => void) {
+      for (const session of h2Sessions) {
+        session.close();
+      }
       h2Server.close();
       plainServer.close();
       return origClose(cb);


### PR DESCRIPTION
Fixes #221.

## Root Cause

Node.js maintains an internal `streams_` map per H2 session. Entries are added on stream open but only removed on GC — not on close. With Vite HMR generating rapid `RST_STREAM CANCEL` cycles (e.g. CSS modules returning 304), the map accumulates faster than GC clears it. Once `streams_.size()` reaches `maxConcurrentStreams`, the next stream triggers `NGHTTP2_ERR_CALLBACK_FAILURE` and nghttp2 sends `GOAWAY INTERNAL_ERROR`, killing the entire session.

Confirmed via Chrome `net-export` across 4 sessions — all crashed with `error_code: 2 (INTERNAL_ERROR)` at 2085–3967 lifetime streams.

## Changes

- **Session recycling**: close sessions at 800 lifetime streams (`GOAWAY NO_ERROR`); Chrome reconnects silently
- **`maxConcurrentStreams: 1000`**: default (100) causes `REFUSED_STREAM` on Vite's large initial module graph; session recycling keeps the map safely below this limit
- **GOAWAY on shutdown**: send `GOAWAY NO_ERROR` to all sessions on `portless proxy stop` so browsers don't hit errors on the next navigation
- **RST_STREAM error absorption**: `req.stream.once("error", () => {})` prevents cancelled streams from propagating to the session
- **`res.destroy()` on backend error**: replaces `res.end()` to avoid sending a partial body that causes a content-length mismatch Chrome treats as a session-level error

## Test Plan

- [ ] `pnpm test` passes
- [ ] Vite app with HMR: reload repeatedly — no `ERR_HTTP2_PROTOCOL_ERROR`
- [ ] `portless proxy stop && portless proxy start` — next navigation works without hard reload
- [ ] Large Vite app loads on first visit without `REFUSED_STREAM`