### PR TITLE
Fix proxy startup failure when macOS security command is slow (#228)

### DIFF
--- a/packages/portless/src/certs.test.ts
+++ b/packages/portless/src/certs.test.ts
@@ -368,6 +368,33 @@ describe("trustCA", () => {
     expect(result.error).toContain("CA certificate not found");
     expect(result.error).toContain("portless trust");
   });
+
+  it.skipIf(process.platform !== "darwin")(
+    "returns actionable error when security command fails (#228)",
+    () => {
+      // Generate real certs so trustCA reaches the security command
+      ensureCerts(tmpDir);
+
+      // Create a fake security binary that always fails
+      const fakeBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-fake-sec-"));
+      const fakePath = path.join(fakeBinDir, "security");
+      fs.writeFileSync(fakePath, "#!/bin/sh\nexit 1\n");
+      fs.chmodSync(fakePath, 0o755);
+
+      const origPath = process.env.PATH;
+      try {
+        process.env.PATH = `${fakeBinDir}:${origPath}`;
+        const result = trustCA(tmpDir);
+        expect(result.trusted).toBe(false);
+        expect(result.error).toBeDefined();
+        // Should include the actual error, not just a raw internal message
+        expect(result.error!.length).toBeGreaterThan(10);
+      } finally {
+        process.env.PATH = origPath;
+        fs.rmSync(fakeBinDir, { recursive: true, force: true });
+      }
+    }
+  );
 });
 
 describe("untrustCA", () => {

--- a/packages/portless/src/certs.ts
+++ b/packages/portless/src/certs.ts
@@ -21,6 +21,27 @@ const CA_COMMON_NAME = "portless Local CA";
 /** openssl command timeout (ms). */
 const OPENSSL_TIMEOUT_MS = 15_000;
 
+/**
+ * Timeout for non-interactive macOS `security` commands (verify-cert, etc.).
+ * Needs generous headroom because the Keychain Services daemon (`securityd`)
+ * can stall under load or after a macOS update.
+ */
+const MACOS_SECURITY_TIMEOUT_MS = 15_000;
+
+/**
+ * Timeout for macOS `security add-trusted-cert` (non-root).
+ * This command triggers a system GUI authorization dialog (Touch ID or
+ * password), so the user may need time to interact with it.
+ */
+const MACOS_SECURITY_AUTH_TIMEOUT_MS = 120_000;
+
+/**
+ * Timeout for macOS `security add-trusted-cert` as root.
+ * The `-d` flag writes to the admin cert store without a GUI dialog,
+ * but the keychain subsystem can still be slow.
+ */
+const MACOS_SECURITY_ROOT_TIMEOUT_MS = 60_000;
+
 // ---------------------------------------------------------------------------
 // File names
 // ---------------------------------------------------------------------------
@@ -423,13 +444,13 @@ function isCATrustedMacOS(caCertPath: string): boolean {
         ["-u", sudoUser, "security", "verify-cert", "-c", caCertPath, "-L", "-p", "ssl"],
         {
           stdio: "pipe",
-          timeout: 5000,
+          timeout: MACOS_SECURITY_TIMEOUT_MS,
         }
       );
     } else {
       execFileSync("security", ["verify-cert", "-c", caCertPath, "-L", "-p", "ssl"], {
         stdio: "pipe",
-        timeout: 5000,
+        timeout: MACOS_SECURITY_TIMEOUT_MS,
       });
     }
     return true;
@@ -445,7 +466,7 @@ function loginKeychainPath(): string {
   try {
     const result = execFileSync("security", ["default-keychain"], {
       encoding: "utf-8",
-      timeout: 5000,
+      timeout: MACOS_SECURITY_TIMEOUT_MS,
     }).trim();
     // Output is like:    "/Users/foo/Library/Keychains/login.keychain-db"
     const match = result.match(/"(.+)"/);
@@ -812,14 +833,14 @@ export function trustCA(stateDir: string): { trusted: boolean; error?: string } 
             "/Library/Keychains/System.keychain",
             caCertPath,
           ],
-          { stdio: "pipe", timeout: 30_000 }
+          { stdio: "pipe", timeout: MACOS_SECURITY_ROOT_TIMEOUT_MS }
         );
       } else {
         const keychain = loginKeychainPath();
         execFileSync(
           "security",
           ["add-trusted-cert", "-r", "trustRoot", "-k", keychain, caCertPath],
-          { stdio: "pipe", timeout: 30_000 }
+          { stdio: "pipe", timeout: MACOS_SECURITY_AUTH_TIMEOUT_MS }
         );
       }
       return { trusted: true };
@@ -842,6 +863,16 @@ export function trustCA(stateDir: string): { trusted: boolean; error?: string } 
     return { trusted: false, error: `Unsupported platform: ${process.platform}` };
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
+    if (message.includes("ETIMEDOUT")) {
+      const hint =
+        process.platform === "darwin"
+          ? "The macOS security command timed out. This can happen when the " +
+            "Keychain Services daemon is unresponsive or a system authorization " +
+            "dialog was not dismissed in time. Try restarting Keychain Access " +
+            "(or run: sudo killall securityd) and then: portless trust"
+          : "The trust command timed out. Try: portless trust";
+      return { trusted: false, error: hint };
+    }
     if (
       message.includes("authorization") ||
       message.includes("permission") ||
@@ -892,7 +923,7 @@ function untrustCAMacOS(caCertPath: string): { removed: boolean; error?: string 
 
   const tryExec = (args: string[]) => {
     try {
-      execFileSync("security", args, { stdio: "pipe", timeout: 30_000 });
+      execFileSync("security", args, { stdio: "pipe", timeout: MACOS_SECURITY_ROOT_TIMEOUT_MS });
       return true;
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
@@ -925,12 +956,12 @@ function isCATrustedMacOSAfterAttempt(caCertPath: string): boolean {
       execFileSync(
         "sudo",
         ["-u", sudoUser, "security", "verify-cert", "-c", caCertPath, "-L", "-p", "ssl"],
-        { stdio: "pipe", timeout: 5000 }
+        { stdio: "pipe", timeout: MACOS_SECURITY_TIMEOUT_MS }
       );
     } else {
       execFileSync("security", ["verify-cert", "-c", caCertPath, "-L", "-p", "ssl"], {
         stdio: "pipe",
-        timeout: 5000,
+        timeout: MACOS_SECURITY_TIMEOUT_MS,
       });
     }
     return true;

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -318,6 +318,7 @@ export function buildProxyStartConfig(options: {
   foreground?: boolean;
   includePort?: boolean;
   proxyPort?: number;
+  skipTrust?: boolean;
 }): { effectiveTld: string; args: string[] } {
   const effectiveTld = options.lanMode ? "local" : options.tld;
   const args: string[] = [];
@@ -355,6 +356,10 @@ export function buildProxyStartConfig(options: {
 
   if (options.useWildcard) {
     args.push("--wildcard");
+  }
+
+  if (options.skipTrust) {
+    args.push("--skip-trust");
   }
 
   return { effectiveTld, args };

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -1000,4 +1000,71 @@ describe("CLI", () => {
       expect(stop.stdout).toContain("Proxy stopped");
     });
   });
+
+  describe("HTTPS proxy with broken security binary (#228)", () => {
+    let fakeBinDir: string;
+    let tmpDir: string;
+    let testPort: number;
+
+    beforeEach(async () => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-trust-timeout-"));
+      testPort = await getFreePort();
+
+      // Create a fake `security` binary that always fails, simulating the
+      // macOS Keychain Services daemon being unresponsive. The real issue
+      // (#228) is a slow/hanging securityd, but an instant failure exercises
+      // the same error-handling code path without making the test wait minutes.
+      fakeBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-fake-bin-"));
+      const fakeSecurityPath = path.join(fakeBinDir, "security");
+      fs.writeFileSync(fakeSecurityPath, "#!/bin/sh\nexit 1\n");
+      fs.chmodSync(fakeSecurityPath, 0o755);
+    });
+
+    afterEach(() => {
+      run(["proxy", "stop", "-p", String(testPort)], {
+        env: { PORTLESS_STATE_DIR: tmpDir },
+      });
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      fs.rmSync(fakeBinDir, { recursive: true, force: true });
+    });
+
+    it.skipIf(process.platform !== "darwin")(
+      "starts HTTPS proxy when security commands fail",
+      () => {
+        const env = {
+          PORTLESS_PORT: String(testPort),
+          PORTLESS_STATE_DIR: tmpDir,
+          // Put fake security first in PATH; real openssl is still reachable
+          PATH: `${fakeBinDir}:${process.env.PATH}`,
+        };
+
+        // HTTPS is on by default (no PORTLESS_HTTPS=0), so this exercises
+        // cert generation, the failing trust check, and daemon startup.
+        const start = spawnSync(process.execPath, [CLI_PATH, "proxy", "start"], {
+          encoding: "utf-8",
+          timeout: 30_000,
+          env: { ...process.env, ...env, NO_COLOR: "1" },
+        });
+
+        // The proxy should start despite the broken security binary.
+        // Before the fix, the daemon would re-run the failing trust flow,
+        // potentially stalling long enough for waitForProxy to time out.
+        // After the fix, the parent passes --skip-trust to the daemon.
+        expect(start.status).toBe(0);
+        expect(start.stdout).toContain(`proxy started on port ${testPort}`);
+
+        // Parent should warn that trust failed
+        const combined = start.stdout + start.stderr;
+        expect(combined).toContain("Could not add CA to system trust store");
+
+        // Daemon log should NOT contain trust attempts (--skip-trust was passed)
+        const logPath = path.join(tmpDir, "proxy.log");
+        if (fs.existsSync(logPath)) {
+          const log = fs.readFileSync(logPath, "utf-8");
+          expect(log).not.toContain("Adding CA to system trust store");
+          expect(log).toContain("HTTPS/2 proxy listening");
+        }
+      }
+    );
+  });
 });

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1336,7 +1336,7 @@ async function handleTrust(): Promise<void> {
   }
 
   // Auto-elevate with sudo on macOS/Linux, but only for permission errors.
-  // Non-permission failures (missing cert, unsupported platform) skip sudo.
+  // Non-permission failures (missing cert, unsupported platform, timeout) skip sudo.
   const isPermissionError =
     result.error?.includes("Permission denied") || result.error?.includes("EACCES");
   if (isPermissionError && !isWindows && process.getuid?.() !== 0) {
@@ -1754,6 +1754,7 @@ ${colors.bold("LAN mode (--lan):")}
   }
 
   const isForeground = args.includes("--foreground");
+  const skipTrust = args.includes("--skip-trust");
 
   // HTTPS is on by default. Disable with --no-tls or PORTLESS_HTTPS=0.
   const hasHttpsFlag = args.includes("--https");
@@ -2112,7 +2113,7 @@ ${colors.bold("LAN mode (--lan):")}
         console.log(colors.green("Generated local CA certificate."));
       }
 
-      if (!isCATrusted(stateDir)) {
+      if (!skipTrust && !isCATrusted(stateDir)) {
         console.log(colors.yellow("Adding CA to system trust store..."));
         const trustResult = trustCA(stateDir);
         if (trustResult.trusted) {
@@ -2178,6 +2179,7 @@ ${colors.bold("LAN mode (--lan):")}
         foreground: true,
         includePort: true,
         proxyPort,
+        skipTrust: true,
       }).args,
     ];
 


### PR DESCRIPTION
## Summary

- Increase macOS `security` command timeouts (verify-cert 5s to 15s, add-trusted-cert 30s to 120s for GUI dialog, 60s for root) to accommodate slow `securityd`
- Pass `--skip-trust` to the daemon process so it skips the redundant trust flow the parent already attempted, eliminating the double-timeout that caused `waitForProxy` to give up
- Return an actionable ETIMEDOUT error message suggesting `sudo killall securityd` instead of the raw `spawnSync security ETIMEDOUT`

Closes #228