### PR TITLE
Fix lock contention when running parallel commands (#174)

### DIFF
--- a/packages/portless/src/routes.test.ts
+++ b/packages/portless/src/routes.test.ts
@@ -292,16 +292,109 @@ describe("RouteStore", () => {
     it("handles stale lock by recovering and completing the operation", () => {
       store.ensureDir();
       const lockPath = path.join(tmpDir, "routes.lock");
-      // Create a stale lock directory manually
       fs.mkdirSync(lockPath);
-      // Backdate mtime to 11 seconds ago
       const staleTime = new Date(Date.now() - 11_000);
       fs.utimesSync(lockPath, staleTime, staleTime);
-      // addRoute should recover from the stale lock
       expect(() => store.addRoute("test.localhost", 4001, process.pid)).not.toThrow();
       const routes = store.loadRoutes();
       expect(routes).toHaveLength(1);
       expect(routes[0].hostname).toBe("test.localhost");
     });
+
+    it("handles many parallel addRoute calls without lock errors", async () => {
+      const count = 20;
+      const scriptPath = path.join(tmpDir, "worker.mjs");
+      const pkgDir = path.resolve(import.meta.dirname, "..");
+      fs.writeFileSync(
+        scriptPath,
+        [
+          `import { RouteStore } from ${JSON.stringify(pkgDir + "/dist/index.js")};`,
+          `const [dir, hostname, port] = process.argv.slice(2);`,
+          `const store = new RouteStore(dir);`,
+          `try { store.addRoute(hostname, Number(port), process.pid); console.log("ok"); }`,
+          `catch (e) { console.log("error:" + e.message); process.exit(1); }`,
+          `process.stdin.resume();`,
+        ].join("\n")
+      );
+
+      const children: ReturnType<typeof spawn>[] = [];
+      const ready: Promise<{ code: number | null; stdout: string }>[] = [];
+      for (let i = 0; i < count; i++) {
+        const child = spawn(
+          process.execPath,
+          [scriptPath, tmpDir, `app${i}.localhost`, String(4000 + i)],
+          { stdio: ["pipe", "pipe", "pipe"] }
+        );
+        children.push(child);
+        ready.push(
+          new Promise((resolve) => {
+            let stdout = "";
+            child.stdout!.on("data", (d: Buffer) => {
+              stdout += d.toString();
+              if (stdout.includes("ok") || stdout.includes("error:")) {
+                resolve({ code: null, stdout: stdout.trim() });
+              }
+            });
+            child.on("close", (code) => resolve({ code, stdout: stdout.trim() }));
+          })
+        );
+      }
+
+      const outcomes = await Promise.all(ready);
+      const failures = outcomes.filter((o) => !o.stdout.startsWith("ok"));
+
+      const raw = JSON.parse(fs.readFileSync(store.getRoutesPath(), "utf-8"));
+
+      for (const child of children) {
+        child.stdin!.end();
+      }
+
+      expect(failures).toHaveLength(0);
+      expect(raw).toHaveLength(count);
+
+      const hostnames = raw.map((r: { hostname: string }) => r.hostname).sort();
+      const expected = Array.from({ length: count }, (_, i) => `app${i}.localhost`).sort();
+      expect(hostnames).toEqual(expected);
+    }, 15_000);
+
+    it("survives sustained lock contention that defeats a naive retry strategy", async () => {
+      store.ensureDir();
+      const lockPath = path.join(tmpDir, "routes.lock");
+
+      // A child process holds the lock for 1.5s, simulating a slow writer on
+      // a loaded machine. The old strategy (20 retries * 50ms = 1s budget)
+      // would time out; exponential backoff with a 5s budget survives.
+      const holdMs = 1500;
+      const holder = spawn(
+        process.execPath,
+        [
+          "-e",
+          [
+            `const fs = require("fs");`,
+            `const lockPath = ${JSON.stringify(lockPath)};`,
+            `fs.mkdirSync(lockPath, { recursive: true });`,
+            `console.log("holding");`,
+            `setTimeout(() => { try { fs.rmSync(lockPath, { recursive: true }); } catch {} console.log("released"); }, ${holdMs});`,
+          ].join("\n"),
+        ],
+        { stdio: ["ignore", "pipe", "pipe"] }
+      );
+
+      // Wait for the holder to acquire the lock
+      await new Promise<void>((resolve) => {
+        holder.stdout!.on("data", (d: Buffer) => {
+          if (d.toString().includes("holding")) resolve();
+        });
+      });
+
+      // addRoute must wait for the lock to be released (>1.5s)
+      expect(() => store.addRoute("contended.localhost", 5000, process.pid)).not.toThrow();
+
+      holder.kill("SIGTERM");
+
+      const routes = store.loadRoutes();
+      expect(routes).toHaveLength(1);
+      expect(routes[0].hostname).toBe("contended.localhost");
+    }, 10_000);
   });
 });

--- a/packages/portless/src/routes.test.ts
+++ b/packages/portless/src/routes.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
+import { pathToFileURL } from "node:url";
 import { spawn } from "node:child_process";
 import { RouteStore, RouteConflictError } from "./routes.js";
 
@@ -305,10 +306,11 @@ describe("RouteStore", () => {
       const count = 20;
       const scriptPath = path.join(tmpDir, "worker.mjs");
       const pkgDir = path.resolve(import.meta.dirname, "..");
+      const importUrl = pathToFileURL(path.join(pkgDir, "dist", "index.js")).href;
       fs.writeFileSync(
         scriptPath,
         [
-          `import { RouteStore } from ${JSON.stringify(pkgDir + "/dist/index.js")};`,
+          `import { RouteStore } from ${JSON.stringify(importUrl)};`,
           `const [dir, hostname, port] = process.argv.slice(2);`,
           `const store = new RouteStore(dir);`,
           `try { store.addRoute(hostname, Number(port), process.pid); console.log("ok"); }`,
@@ -343,13 +345,13 @@ describe("RouteStore", () => {
       const outcomes = await Promise.all(ready);
       const failures = outcomes.filter((o) => !o.stdout.startsWith("ok"));
 
-      const raw = JSON.parse(fs.readFileSync(store.getRoutesPath(), "utf-8"));
-
       for (const child of children) {
         child.stdin!.end();
       }
 
       expect(failures).toHaveLength(0);
+
+      const raw = JSON.parse(fs.readFileSync(store.getRoutesPath(), "utf-8"));
       expect(raw).toHaveLength(count);
 
       const hostnames = raw.map((r: { hostname: string }) => r.hostname).sort();

--- a/packages/portless/src/routes.ts
+++ b/packages/portless/src/routes.ts
@@ -7,11 +7,14 @@ import { SYSTEM_STATE_DIR } from "./cli-utils.js";
 /** How long (ms) before a lock directory is considered stale and forcibly removed. */
 const STALE_LOCK_THRESHOLD_MS = 10_000;
 
-/** Default maximum number of retries when acquiring the file lock. */
-const LOCK_MAX_RETRIES = 20;
+/** Total time budget (ms) for acquiring the file lock before giving up. */
+const LOCK_TIMEOUT_MS = 5_000;
 
-/** Delay (ms) between lock acquisition retries. */
-const LOCK_RETRY_DELAY_MS = 50;
+/** Initial delay (ms) between lock acquisition retries (doubles each attempt). */
+const LOCK_RETRY_BASE_MS = 10;
+
+/** Maximum delay (ms) between lock acquisition retries. */
+const LOCK_RETRY_CAP_MS = 500;
 
 /** File permission mode for route and state files. */
 export const FILE_MODE = 0o644;
@@ -118,14 +121,16 @@ export class RouteStore {
     Atomics.wait(RouteStore.sleepBuffer, 0, 0, ms);
   }
 
-  private acquireLock(maxRetries = LOCK_MAX_RETRIES, retryDelayMs = LOCK_RETRY_DELAY_MS): boolean {
-    for (let i = 0; i < maxRetries; i++) {
+  private acquireLock(): boolean {
+    const deadline = Date.now() + LOCK_TIMEOUT_MS;
+    let delay = LOCK_RETRY_BASE_MS;
+
+    while (Date.now() < deadline) {
       try {
         fs.mkdirSync(this.lockPath);
         return true;
       } catch (err: unknown) {
         if (isErrnoException(err) && err.code === "EEXIST") {
-          // Check for stale lock
           try {
             const stat = fs.statSync(this.lockPath);
             if (Date.now() - stat.mtimeMs > STALE_LOCK_THRESHOLD_MS) {
@@ -133,18 +138,16 @@ export class RouteStore {
               continue;
             }
           } catch {
-            // Lock dir gone already; retry
             continue;
           }
-          // Wait and retry
-          this.syncSleep(retryDelayMs);
+          const jitter = Math.floor(Math.random() * delay);
+          this.syncSleep(delay + jitter);
+          delay = Math.min(delay * 2, LOCK_RETRY_CAP_MS);
         } else {
-          // Unexpected error (e.g. missing parent dir); cannot acquire lock
           return false;
         }
       }
     }
-    // Timed out waiting for lock
     return false;
   }
 

--- a/tests/e2e/fixtures/minimal-server/server.js
+++ b/tests/e2e/fixtures/minimal-server/server.js
@@ -1,0 +1,14 @@
+/* global process, console */
+import http from "node:http";
+
+const port = parseInt(process.env.PORT || "3000", 10);
+const name = process.env.APP_NAME || "minimal";
+
+const server = http.createServer((_req, res) => {
+  res.writeHead(200, { "Content-Type": "text/plain" });
+  res.end(`ok:${name}`);
+});
+
+server.listen(port, "127.0.0.1", () => {
+  console.log(`${name} listening on http://127.0.0.1:${port}`);
+});

--- a/tests/e2e/src/parallel.test.ts
+++ b/tests/e2e/src/parallel.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { spawn, spawnSync, execSync, type ChildProcess } from "node:child_process";
+import * as fs from "node:fs";
+import * as http from "node:http";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI_PATH = path.resolve(__dirname, "../../../packages/portless/dist/cli.js");
+const FIXTURE_DIR = path.resolve(__dirname, "../fixtures/minimal-server");
+const PROXY_PORT = 19012;
+
+const isWindows = process.platform === "win32";
+
+function killPort(port: number): void {
+  try {
+    if (isWindows) {
+      const output = execSync("netstat -ano -p tcp", {
+        encoding: "utf-8",
+        timeout: 5000,
+      });
+      const myPid = process.pid;
+      for (const line of output.split(/\r?\n/)) {
+        if (!line.includes("LISTENING")) continue;
+        const parts = line.trim().split(/\s+/);
+        if (parts.length < 5) continue;
+        const localAddr = parts[1];
+        const lastColon = localAddr.lastIndexOf(":");
+        if (lastColon === -1) continue;
+        const addrPort = parseInt(localAddr.substring(lastColon + 1), 10);
+        if (addrPort !== port) continue;
+        const pid = parseInt(parts[parts.length - 1], 10);
+        if (isNaN(pid) || pid <= 0 || pid === myPid) continue;
+        try {
+          process.kill(pid, "SIGTERM");
+        } catch {
+          // already dead
+        }
+      }
+    } else {
+      const pids = execSync(`lsof -ti tcp:${port}`, {
+        encoding: "utf-8",
+        timeout: 5000,
+      }).trim();
+      if (pids) {
+        const myPid = process.pid;
+        for (const raw of pids.split("\n")) {
+          const pid = parseInt(raw, 10);
+          if (isNaN(pid) || pid === myPid) continue;
+          try {
+            process.kill(pid, "SIGTERM");
+          } catch {
+            // already dead
+          }
+        }
+      }
+    }
+  } catch {
+    // no process on port
+  }
+}
+
+function makeRequest(url: string, host: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(url, { headers: { Host: host } }, (res) => {
+      let body = "";
+      res.on("data", (chunk: Buffer) => {
+        body += chunk.toString();
+      });
+      res.on("end", () => resolve({ status: res.statusCode ?? 0, body }));
+    });
+    req.on("error", reject);
+    req.setTimeout(2000, () => {
+      req.destroy();
+      reject(new Error("timeout"));
+    });
+    req.end();
+  });
+}
+
+describe("parallel route registration", () => {
+  // Matches real-world monorepo scale (json-render has 19 parallel portless commands)
+  const APP_COUNT = 20;
+  const children: ChildProcess[] = [];
+  let stateDir: string;
+
+  afterAll(async () => {
+    for (const child of children) {
+      if (!child.killed) child.kill("SIGTERM");
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+    for (const child of children) {
+      if (!child.killed) child.kill("SIGKILL");
+    }
+
+    if (stateDir) {
+      spawnSync(process.execPath, [CLI_PATH, "proxy", "stop"], {
+        env: {
+          ...process.env,
+          PORTLESS_PORT: PROXY_PORT.toString(),
+          PORTLESS_STATE_DIR: stateDir,
+          NO_COLOR: "1",
+        },
+        timeout: 10_000,
+      });
+    }
+
+    killPort(PROXY_PORT);
+
+    if (stateDir) {
+      try {
+        fs.rmSync(stateDir, { recursive: true, force: true });
+      } catch {
+        // best effort
+      }
+    }
+  });
+
+  it("registers all routes when many portless run commands start in parallel", async () => {
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-e2e-parallel-"));
+
+    const baseEnv = {
+      ...process.env,
+      PORTLESS_PORT: PROXY_PORT.toString(),
+      PORTLESS_HTTPS: "0",
+      PORTLESS_STATE_DIR: stateDir,
+      NO_COLOR: "1",
+    };
+
+    // Start the proxy explicitly first so all parallel runs don't race to start it
+    spawnSync(
+      process.execPath,
+      [CLI_PATH, "proxy", "start", "--no-tls", "-p", PROXY_PORT.toString()],
+      {
+        env: baseEnv,
+        timeout: 15_000,
+      }
+    );
+
+    interface AppResult {
+      name: string;
+      hostname: string;
+      stdout: string;
+      stderr: string;
+      exited: boolean;
+      exitCode: number | null;
+    }
+
+    const apps: AppResult[] = [];
+
+    // Launch all apps in parallel, just like a monorepo task runner would
+    for (let i = 0; i < APP_COUNT; i++) {
+      const name = `parallel-app-${i}`;
+      const hostname = `${name}.localhost`;
+      const app: AppResult = {
+        name,
+        hostname,
+        stdout: "",
+        stderr: "",
+        exited: false,
+        exitCode: null,
+      };
+      apps.push(app);
+
+      const appPort = 17100 + i;
+      const child = spawn(
+        process.execPath,
+        [CLI_PATH, name, "--app-port", String(appPort), "node", "server.js"],
+        {
+          cwd: FIXTURE_DIR,
+          env: { ...baseEnv, APP_NAME: name },
+          stdio: ["ignore", "pipe", "pipe"],
+        }
+      );
+      children.push(child);
+
+      child.stdout!.on("data", (chunk: Buffer) => {
+        app.stdout += chunk.toString();
+      });
+      child.stderr!.on("data", (chunk: Buffer) => {
+        app.stderr += chunk.toString();
+      });
+      child.on("exit", (code) => {
+        app.exited = true;
+        app.exitCode = code;
+      });
+    }
+
+    // Wait for all apps to be registered (or for early failures)
+    const deadline = Date.now() + 60_000;
+    const registered = new Set<number>();
+
+    while (registered.size < APP_COUNT && Date.now() < deadline) {
+      for (let i = 0; i < APP_COUNT; i++) {
+        if (registered.has(i)) continue;
+
+        // If the process exited early, that's a failure we'll catch below
+        if (apps[i].exited) {
+          registered.add(i);
+          continue;
+        }
+
+        try {
+          const { status } = await makeRequest(`http://127.0.0.1:${PROXY_PORT}/`, apps[i].hostname);
+          if (status >= 200 && status < 400) {
+            registered.add(i);
+          }
+        } catch {
+          // not ready yet
+        }
+      }
+      if (registered.size < APP_COUNT) {
+        await new Promise((r) => setTimeout(r, 500));
+      }
+    }
+
+    // Verify no app crashed with a lock error
+    const lockFailures = apps.filter(
+      (a) =>
+        a.stderr.includes("Failed to acquire route lock") ||
+        a.stdout.includes("Failed to acquire route lock")
+    );
+    expect(lockFailures.map((a) => a.name)).toEqual([]);
+
+    // Verify no app exited unexpectedly
+    const crashedApps = apps.filter((a) => a.exited && a.exitCode !== 0);
+    expect(crashedApps.map((a) => ({ name: a.name, code: a.exitCode, stderr: a.stderr }))).toEqual(
+      []
+    );
+
+    // Verify all apps are reachable through the proxy
+    for (let i = 0; i < APP_COUNT; i++) {
+      const { status, body } = await makeRequest(
+        `http://127.0.0.1:${PROXY_PORT}/`,
+        apps[i].hostname
+      );
+      expect(status).toBe(200);
+      expect(body).toContain(`ok:parallel-app-${i}`);
+    }
+
+    // Verify the routes file has all entries
+    const routesPath = path.join(stateDir, "routes.json");
+    const routes = JSON.parse(fs.readFileSync(routesPath, "utf-8"));
+    const registeredHostnames = routes.map((r: { hostname: string }) => r.hostname).sort();
+    const expectedHostnames = Array.from(
+      { length: APP_COUNT },
+      (_, i) => `parallel-app-${i}.localhost`
+    ).sort();
+    expect(registeredHostnames).toEqual(expectedHostnames);
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces the fixed-delay retry strategy (20 retries x 50ms = 1s budget) with exponential backoff + jitter (10ms-500ms delays, 5s total budget), fixing "Failed to acquire route lock" errors in monorepos running many parallel `portless run` commands
- Adds unit tests proving the old parameters fail under sustained contention and the new parameters survive
- Adds an e2e test launching 20 parallel apps through the proxy (matching real-world monorepo scale)

Closes #174