### PR TITLE
Fix ERR_HTTP2_PROTOCOL_ERROR from stream reset flood during HMR

### DIFF
--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -1375,4 +1375,90 @@ describe("createProxyServer with TLS (HTTP/2)", () => {
     expect(result.headers["x-custom"]).toBe("preserved");
     expect(result.body).toBe("ok");
   });
+
+  it("session survives sustained stream cancellation (issues #217, #221)", async () => {
+    const backend = trackServer(
+      http.createServer((_req, res) => {
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.end("ok");
+      })
+    );
+    await listen(backend);
+    const backendAddr = backend.address();
+    if (!backendAddr || typeof backendAddr === "string") throw new Error("no addr");
+
+    const routes: RouteInfo[] = [{ hostname: "h2burst.localhost", port: backendAddr.port }];
+    const server = trackServer(
+      createProxyServer({
+        getRoutes: () => routes,
+        proxyPort: TEST_PROXY_PORT,
+        tls: { cert: tlsCert, key: tlsKey },
+      })
+    );
+    await listen(server);
+
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("no addr");
+
+    // Simulate Vite/Nuxt HMR: sustained bursts of stream cancellations.
+    // Without streamResetBurst/streamResetRate tuning, Node sends GOAWAY
+    // INTERNAL_ERROR (code 2) after ~1000 cumulative resets, killing the
+    // HTTP/2 session and causing ERR_HTTP2_PROTOCOL_ERROR in Chrome.
+    const client = http2.connect(`https://127.0.0.1:${addr.port}`, {
+      rejectUnauthorized: false,
+    });
+
+    let gotGoaway = false;
+    client.on("goaway", () => {
+      gotGoaway = true;
+    });
+    client.on("error", () => {});
+
+    // Send 1500 resets in rapid batches (exceeds the ~1000 threshold that
+    // triggers GOAWAY on an untuned server).
+    const TOTAL = 1500;
+    const BATCH = 100;
+    let sent = 0;
+    await new Promise<void>((resolve) => {
+      const timer = setInterval(() => {
+        if (gotGoaway || sent >= TOTAL) {
+          clearInterval(timer);
+          resolve();
+          return;
+        }
+        for (let i = 0; i < BATCH && sent < TOTAL; i++) {
+          const req = client.request({
+            ":method": "GET",
+            ":path": `/${sent}`,
+            host: "h2burst.localhost",
+          });
+          req.on("error", () => {});
+          req.close(http2.constants.NGHTTP2_CANCEL);
+          sent++;
+        }
+      }, 10);
+    });
+
+    // Verify the session is still alive with a real request
+    let finalStatus = 0;
+    if (!client.destroyed && !client.closed) {
+      finalStatus = await new Promise<number>((resolve, reject) => {
+        const req = client.request({
+          ":method": "GET",
+          ":path": "/final",
+          host: "h2burst.localhost",
+        });
+        req.on("response", (headers) => {
+          req.close();
+          resolve(headers[":status"] as number);
+        });
+        req.on("error", reject);
+        req.end();
+      });
+    }
+
+    client.close();
+    expect(gotGoaway).toBe(false);
+    expect(finalStatus).toBe(200);
+  }, 15_000);
 });

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -209,8 +209,13 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
         proxyRes.on("error", () => {
           if (!res.headersSent) {
             res.writeHead(502, { "Content-Type": "text/plain" });
+            res.end();
+          } else {
+            // Headers already sent (mid-stream): destroy instead of end to
+            // send RST_STREAM. Calling res.end() here can cause a
+            // content-length mismatch that Chrome treats as a session error.
+            res.destroy();
           }
-          res.end();
         });
         proxyRes.pipe(res);
       }
@@ -362,11 +367,25 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
       cert: tls.ca ? Buffer.concat([tls.cert, tls.ca]) : tls.cert,
       key: tls.key,
       allowHTTP1: true,
+      // Tolerate high rates of RST_STREAM from browsers during HMR and
+      // page navigations. Without this, Node sends GOAWAY INTERNAL_ERROR
+      // after ~1000 cumulative stream resets and kills the session,
+      // surfacing as ERR_HTTP2_PROTOCOL_ERROR in Chrome. Available in
+      // Node 22.11+; silently ignored on older versions.
+      ...({ streamResetBurst: 10000, streamResetRate: 100 } as Record<string, unknown>),
       ...(tls.SNICallback ? { SNICallback: tls.SNICallback } : {}),
     });
+
+    // Absorb session-level errors (connection resets, protocol errors from
+    // abrupt client disconnects) so they don't crash the proxy.
+    h2Server.on("sessionError", () => {});
+
     // With allowHTTP1, the 'request' event receives objects compatible with
     // http.IncomingMessage / http.ServerResponse. Cast explicitly to satisfy TypeScript.
     h2Server.on("request", (req: http2.Http2ServerRequest, res: http2.Http2ServerResponse) => {
+      // Absorb RST_STREAM errors from cancelled requests (browser navigation,
+      // HMR) so they don't propagate to the HTTP/2 session.
+      req.stream?.on("error", () => {});
       handleRequest(req as unknown as http.IncomingMessage, res as unknown as http.ServerResponse);
     });
     // WebSocket upgrades arrive over HTTP/1.1 connections (allowHTTP1)


### PR DESCRIPTION
## Summary

- Fixes `ERR_HTTP2_PROTOCOL_ERROR` that occurs when using portless as an HTTP/2 proxy in front of Vite/Nuxt dev servers. Browsers send rapid `RST_STREAM CANCEL` frames during HMR and page navigations; Node's default tolerance (~1000 cumulative resets) triggers `GOAWAY INTERNAL_ERROR`, killing the session.
- Adds `streamResetBurst`/`streamResetRate` options to `http2.createSecureServer()` (Node 22.11+; silently ignored on older versions), absorbs session-level and per-stream errors from abrupt disconnects, and uses `res.destroy()` for mid-stream backend errors to avoid content-length mismatches.

Fixes #217. Fixes #221.