### PR TITLE
Fix proxy auto-start in non-interactive terminals and with previous config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ portless myapp next dev
 
 HTTPS with HTTP/2 is enabled by default. On first run, portless generates a local CA, trusts it, and binds port 443 (auto-elevates with sudo on macOS/Linux). Use `--no-tls` for plain HTTP.
 
-The proxy auto-starts when you run an app. A random port (4000--4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, VitePlus, Astro, React Router, Angular, Expo, React Native), portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag.
+The proxy auto-starts when you run an app. A random port (4000-4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, VitePlus, Astro, React Router, Angular, Expo, React Native), portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag.
+
+When auto-starting, portless reuses the configuration (port, TLS, TLD) from the most recent proxy run, so a restart or reboot does not silently revert to defaults. Explicit env vars (`PORTLESS_PORT`, `PORTLESS_HTTPS`, etc.) always take priority.
+
+In non-interactive environments (no TTY, or `CI=1`), portless exits with a descriptive error instead of prompting, so task runners like turborepo and CI scripts fail early with a clear message.
 
 ## Use in package.json
 
@@ -139,7 +143,7 @@ portless proxy start --lan --ip 192.168.1.42
 
 `--lan` switches the proxy to mDNS discovery: services are advertised as `<name>.local` and reachable from any device on the same network. Portless auto-detects your LAN IP and follows Wi-Fi/IP changes automatically, but you can pin another address with `--ip <address>` or by exporting `PORTLESS_LAN_IP`. Set `PORTLESS_LAN=1` in your shell (0/1 boolean) to make LAN mode the default whenever the proxy starts.
 
-Portless remembers LAN mode via `proxy.lan`, so if you stop a LAN proxy and start it again, it stays in LAN mode. Other proxy settings still follow the current flags and env vars. Use `PORTLESS_LAN=0` for one start to switch back to `.localhost` mode. If a proxy is already running with different explicit LAN/TLS/TLD settings, portless warns and asks you to stop it first.
+Portless remembers LAN mode via `proxy.lan`, so if you stop a LAN proxy and start it again, it stays in LAN mode. All proxy settings (port, TLS, TLD, LAN) are persisted and reused on auto-start unless overridden by explicit flags or env vars. Use `PORTLESS_LAN=0` for one start to switch back to `.localhost` mode. If a proxy is already running with different explicit LAN/TLS/TLD settings, portless warns and asks you to stop it first.
 
 LAN mode depends on the system mDNS tools that portless already spawns: macOS ships with `dns-sd`, while Linux uses `avahi-publish-address` from `avahi-utils` (install via `sudo apt install avahi-utils` or your distro’s equivalent). If the command is missing or your network isn’t reachable, `portless proxy start --lan` prints the relevant error and exits.
 

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -24,11 +24,13 @@ import {
   isProxyRunning,
   parsePidFromNetstat,
   readLanMarker,
+  readPersistedProxyState,
   readTldFromDir,
   resolveStateDir,
   validateTld,
   writeLanMarker,
   writeTldFile,
+  writeTlsMarker,
 } from "./cli-utils.js";
 
 describe("findFreePort", () => {
@@ -925,5 +927,74 @@ describe("validateTld", () => {
       expect(validateTld(tld)).toBeNull();
       expect(RISKY_TLDS.has(tld)).toBe(true);
     }
+  });
+});
+
+describe("readPersistedProxyState", () => {
+  let tmpDir: string;
+  let prevStateDir: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-persist-test-"));
+    prevStateDir = process.env.PORTLESS_STATE_DIR;
+    process.env.PORTLESS_STATE_DIR = tmpDir;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (prevStateDir === undefined) {
+      delete process.env.PORTLESS_STATE_DIR;
+    } else {
+      process.env.PORTLESS_STATE_DIR = prevStateDir;
+    }
+  });
+
+  it("returns null when no state files exist", () => {
+    expect(readPersistedProxyState()).toBeNull();
+  });
+
+  it("reads port from persisted state", () => {
+    fs.writeFileSync(path.join(tmpDir, "proxy.port"), "1355");
+    const state = readPersistedProxyState();
+    expect(state).not.toBeNull();
+    expect(state!.port).toBe(1355);
+  });
+
+  it("reads TLS marker from persisted state", () => {
+    fs.writeFileSync(path.join(tmpDir, "proxy.port"), "443");
+    writeTlsMarker(tmpDir, true);
+    const state = readPersistedProxyState();
+    expect(state).not.toBeNull();
+    expect(state!.tls).toBe(true);
+  });
+
+  it("reads TLD from persisted state", () => {
+    fs.writeFileSync(path.join(tmpDir, "proxy.port"), "1355");
+    writeTldFile(tmpDir, "test");
+    const state = readPersistedProxyState();
+    expect(state).not.toBeNull();
+    expect(state!.tld).toBe("test");
+  });
+
+  it("reads LAN mode from persisted state", () => {
+    fs.writeFileSync(path.join(tmpDir, "proxy.port"), "1355");
+    writeLanMarker(tmpDir, "192.168.1.10");
+    const state = readPersistedProxyState();
+    expect(state).not.toBeNull();
+    expect(state!.lanMode).toBe(true);
+  });
+
+  it("returns full previous config for a custom proxy setup", () => {
+    fs.writeFileSync(path.join(tmpDir, "proxy.port"), "1355");
+    writeTlsMarker(tmpDir, true);
+    writeTldFile(tmpDir, "local");
+    writeLanMarker(tmpDir, "192.168.1.42");
+    const state = readPersistedProxyState();
+    expect(state).toEqual({
+      port: 1355,
+      tls: true,
+      tld: "local",
+      lanMode: true,
+    });
   });
 });

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -306,6 +306,41 @@ export function isLanEnvEnabled(): boolean {
   return val === "1" || val === "true";
 }
 
+/**
+ * Read the last-known proxy configuration from state directories on disk.
+ * Unlike {@link discoverState}, this does not check whether the proxy is
+ * actually running. It simply reads whatever state files exist so a
+ * subsequent auto-start can reuse the previous settings.
+ *
+ * Checks USER_STATE_DIR first, then SYSTEM_STATE_DIR (or PORTLESS_STATE_DIR
+ * if set). Returns null when no prior state is found.
+ */
+export function readPersistedProxyState(): {
+  port: number;
+  tls: boolean;
+  tld: string;
+  lanMode: boolean;
+} | null {
+  const dirs: string[] = [];
+  if (process.env.PORTLESS_STATE_DIR) {
+    dirs.push(process.env.PORTLESS_STATE_DIR);
+  } else {
+    dirs.push(USER_STATE_DIR, SYSTEM_STATE_DIR);
+  }
+
+  for (const dir of dirs) {
+    const port = readPortFromDir(dir);
+    if (port !== null) {
+      const tls = readTlsMarker(dir);
+      const tld = readTldFromDir(dir);
+      const lanIp = readLanMarker(dir);
+      return { port, tls, tld, lanMode: lanIp !== null || tld === "local" };
+    }
+  }
+
+  return null;
+}
+
 export function buildProxyStartConfig(options: {
   useHttps: boolean;
   customCertPath?: string | null;
@@ -460,8 +495,8 @@ export async function discoverState(): Promise<{
   return {
     dir,
     port: configuredPort,
-    tls: false,
-    tld: getDefaultTld(),
+    tls: readTlsMarker(dir),
+    tld: readTldFromDir(dir),
     lanMode: readLanMarker(dir) !== null,
     lanIp: null,
   };

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -36,6 +36,7 @@ import {
   isWindows,
   prompt,
   readLanMarker,
+  readPersistedProxyState,
   readTldFromDir,
   readTlsMarker,
   resolveStateDir,
@@ -785,25 +786,59 @@ async function runApp(
     !!process.env.PORTLESS_STATE_DIR && (await isPortListening(proxyPort));
 
   if (!proxyResponsive && !proxyListeningFromStateDir) {
-    const defaultPort = getDefaultPort(desiredConfig.useHttps);
-    const needsSudo = !isWindows && defaultPort < PRIVILEGED_PORT_THRESHOLD;
-    const manualStartCommand = formatProxyStartCommand(defaultPort, desiredConfig);
-    const fallbackStartCommand = formatProxyStartCommand(FALLBACK_PROXY_PORT, desiredConfig);
+    // Merge persisted state from a previous proxy run so auto-start reuses
+    // the same port/TLS/TLD instead of falling back to defaults (#225).
+    const persisted = readPersistedProxyState();
+    const startConfig = { ...desiredConfig };
+    let startPort: number | undefined;
 
-    if (needsSudo && !process.stdin.isTTY) {
-      console.error(colors.red("Proxy is not running and no TTY is available for sudo."));
-      console.error(colors.blue("Option 1: start the proxy in a terminal (will prompt for sudo):"));
-      console.error(colors.cyan(`  ${manualStartCommand}`));
-      console.error(
-        colors.blue(
-          `Option 2: use an unprivileged port (no sudo needed, URLs will include :${FALLBACK_PROXY_PORT}):`
-        )
-      );
-      console.error(colors.cyan(`  ${fallbackStartCommand}`));
+    if (persisted) {
+      if (!explicit.useHttps && persisted.tls !== desiredConfig.useHttps) {
+        startConfig.useHttps = persisted.tls;
+      }
+      if (!explicit.tld && persisted.tld !== desiredConfig.tld) {
+        startConfig.tld = persisted.tld;
+      }
+      if (!explicit.lanMode && persisted.lanMode !== desiredConfig.lanMode) {
+        startConfig.lanMode = persisted.lanMode;
+      }
+      const envPort = getDefaultPort(startConfig.useHttps);
+      if (persisted.port !== envPort) {
+        startPort = persisted.port;
+      }
+    }
+
+    const effectivePort = startPort ?? getDefaultPort(startConfig.useHttps);
+    const needsSudo = !isWindows && effectivePort < PRIVILEGED_PORT_THRESHOLD;
+    const manualStartCommand = formatProxyStartCommand(effectivePort, startConfig);
+    const fallbackStartCommand = formatProxyStartCommand(FALLBACK_PROXY_PORT, startConfig);
+
+    // Detect non-interactive environments: no TTY, CI runners, or task
+    // runners like turborepo that pipe stdin (#224).
+    const isInteractive = !!process.stdin.isTTY && !process.env.CI;
+
+    if (!isInteractive) {
+      if (needsSudo) {
+        console.error(colors.red("Proxy is not running and no TTY is available for sudo."));
+        console.error(
+          colors.blue("Option 1: start the proxy in a terminal (will prompt for sudo):")
+        );
+        console.error(colors.cyan(`  ${manualStartCommand}`));
+        console.error(
+          colors.blue(
+            `Option 2: use an unprivileged port (no sudo needed, URLs will include :${FALLBACK_PROXY_PORT}):`
+          )
+        );
+        console.error(colors.cyan(`  ${fallbackStartCommand}`));
+      } else {
+        console.error(colors.red("Proxy is not running."));
+        console.error(colors.blue("Start it first:"));
+        console.error(colors.cyan(`  ${manualStartCommand}`));
+      }
       process.exit(1);
     }
 
-    if (needsSudo && process.stdin.isTTY) {
+    if (needsSudo) {
       const answer = await prompt(colors.yellow("Proxy not running. Start it? [Y/n/skip] "));
 
       if (answer === "n" || answer === "no") {
@@ -818,16 +853,26 @@ async function runApp(
       }
     }
 
-    console.log(colors.yellow("Starting proxy..."));
+    if (persisted && startPort !== undefined) {
+      console.log(
+        colors.yellow(
+          `Starting proxy with previous configuration (port ${startPort}, ${startConfig.useHttps ? "HTTPS" : "HTTP"})...`
+        )
+      );
+    } else {
+      console.log(colors.yellow("Starting proxy..."));
+    }
     const proxyStartConfig = buildProxyStartConfig({
-      useHttps: desiredConfig.useHttps,
-      customCertPath: desiredConfig.customCertPath,
-      customKeyPath: desiredConfig.customKeyPath,
-      lanMode: desiredConfig.lanMode,
-      lanIp: desiredConfig.lanIpExplicit ? desiredConfig.lanIp : null,
-      lanIpExplicit: desiredConfig.lanIpExplicit,
-      tld: desiredConfig.tld,
-      useWildcard: desiredConfig.useWildcard,
+      useHttps: startConfig.useHttps,
+      customCertPath: startConfig.customCertPath,
+      customKeyPath: startConfig.customKeyPath,
+      lanMode: startConfig.lanMode,
+      lanIp: startConfig.lanIpExplicit ? startConfig.lanIp : null,
+      lanIpExplicit: startConfig.lanIpExplicit,
+      tld: startConfig.tld,
+      useWildcard: startConfig.useWildcard,
+      includePort: startPort !== undefined,
+      proxyPort: startPort,
     });
     const startArgs = [getEntryScript(), "proxy", "start", ...proxyStartConfig.args];
 
@@ -853,7 +898,7 @@ async function runApp(
 
     if (!discovered) {
       console.error(colors.red("Failed to start proxy."));
-      const fallbackDir = resolveStateDir(getDefaultPort(desiredConfig.useHttps));
+      const fallbackDir = resolveStateDir(effectivePort);
       const logPath = path.join(fallbackDir, "proxy.log");
       console.error(colors.blue("Try starting it manually:"));
       console.error(colors.cyan(`  ${manualStartCommand}`));
@@ -1249,7 +1294,8 @@ ${colors.bold("LAN mode:")}
   Expo keeps Metro's default LAN host behavior in this mode.
   Auto-detected LAN IPs follow network changes automatically.
   Stopped LAN proxies keep LAN mode for the next start via proxy.lan.
-  Other proxy settings still follow the current flags and env vars.
+  All proxy settings are persisted and reused on auto-start unless
+  overridden by explicit flags or env vars.
   Use PORTLESS_LAN=0 for one start to switch back to .localhost mode.
   If a proxy is already running with different explicit LAN/TLS/TLD settings,
   stop it first.

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -48,7 +48,9 @@ portless myapp next dev
 # -> https://myapp.localhost
 ```
 
-The proxy auto-starts when you run an app. You can also start it explicitly with `portless proxy start`.
+The proxy auto-starts when you run an app. You can also start it explicitly with `portless proxy start`. Auto-start reuses the configuration (port, TLS, TLD) from the most recent proxy run, so a restart or reboot does not silently revert to defaults. Explicit env vars always take priority.
+
+In non-interactive environments (no TTY, or `CI=1`), portless exits with a descriptive error instead of prompting. Task runners like turborepo should pre-start the proxy.
 
 ## Integration Patterns
 
@@ -152,7 +154,7 @@ portless proxy start --lan --ip 192.168.1.42
 
 `--lan` advertises `<name>.local` hostnames over mDNS so any device on the same Wi-Fi can reach your apps. Portless auto-detects your LAN IP and follows network changes automatically, but you can pin a specific address with `--ip <address>` or the `PORTLESS_LAN_IP` environment variable. Set `PORTLESS_LAN=1` to default to LAN mode every time the proxy starts.
 
-Portless remembers LAN mode via `proxy.lan`, so if you stop a LAN proxy and start again, it stays in LAN mode. Other proxy settings still follow the current flags and env vars. Use `PORTLESS_LAN=0` for one start to switch back to `.localhost` mode. If a proxy is already running with different explicit LAN/TLS/TLD settings, portless warns and asks you to stop it first.
+Portless remembers LAN mode via `proxy.lan`, so if you stop a LAN proxy and start again, it stays in LAN mode. All proxy settings (port, TLS, TLD, LAN) are persisted and reused on auto-start unless overridden by explicit flags or env vars. Use `PORTLESS_LAN=0` for one start to switch back to `.localhost` mode. If a proxy is already running with different explicit LAN/TLS/TLD settings, portless warns and asks you to stop it first.
 
 LAN mode depends on the system mDNS helpers that portless launches: macOS includes `dns-sd`, while Linux uses `avahi-publish-address` from `avahi-utils` (install via `sudo apt install avahi-utils` or your distro’s tooling).
 


### PR DESCRIPTION
## Summary

- Non-interactive environments (no TTY, or `CI=1`) now exit with a clear error and manual start instructions instead of showing a prompt that hangs in task runners like turborepo (#224)
- Auto-start reads persisted state files (`proxy.port`, `proxy.tls`, `proxy.tld`, `proxy.lan`) from the most recent proxy run so a reboot does not silently revert to default configuration; explicit env vars and flags still take priority (#225)
- `discoverState()` fallback now reads TLS/TLD markers from disk instead of hardcoding `tls: false` and the default TLD

Closes #224, closes #225