### PR TITLE
Prepare v0.10.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,26 @@
 # Changelog
 
-## 0.10.1
+## 0.10.2
 
 <!-- release:start -->
+
+### New Features
+
+- **Auto-inject `NODE_EXTRA_CA_CERTS`**: Child processes spawned by `portless run` now automatically receive `NODE_EXTRA_CA_CERTS` pointing to the portless CA certificate, so Node.js subprocesses trust the local CA without manual configuration (#220)
+
+### Bug Fixes
+
+- **Proxy startup on slow macOS `security` command**: Fix the proxy failing to start when the macOS `security` command takes longer than expected to verify CA trust (#229)
+- **Lock contention with parallel commands**: Fix lock contention that could cause failures when multiple `portless` commands run simultaneously (#230)
+- **`ERR_HTTP2_PROTOCOL_ERROR` during HMR**: Fix HTTP/2 stream reset flood during hot module replacement causing protocol errors (#231)
+- **Proxy auto-start in non-interactive terminals**: Fix auto-start failing in non-interactive terminals (e.g. IDE task runners) and when previous proxy config exists (#232)
+
+### Contributors
+
+- @ctate
+<!-- release:end -->
+
+## 0.10.1
 
 ### New Features
 
@@ -15,7 +33,6 @@
 ### Contributors
 
 - @ctate
-<!-- release:end -->
 
 ## 0.10.0
 

--- a/apps/docs/src/app/changelog/page.mdx
+++ b/apps/docs/src/app/changelog/page.mdx
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.10.2
+
+### New Features
+
+- **Auto-inject `NODE_EXTRA_CA_CERTS`**: Child processes spawned by `portless run` now automatically receive `NODE_EXTRA_CA_CERTS` pointing to the portless CA certificate, so Node.js subprocesses trust the local CA without manual configuration
+
+### Bug Fixes
+
+- **Proxy startup on slow macOS `security` command**: Fix the proxy failing to start when the macOS `security` command takes longer than expected to verify CA trust
+- **Lock contention with parallel commands**: Fix lock contention that could cause failures when multiple `portless` commands run simultaneously
+- **`ERR_HTTP2_PROTOCOL_ERROR` during HMR**: Fix HTTP/2 stream reset flood during hot module replacement causing protocol errors
+- **Proxy auto-start in non-interactive terminals**: Fix auto-start failing in non-interactive terminals (e.g. IDE task runners) and when previous proxy config exists
+
 ## 0.10.1
 
 ### New Features

--- a/packages/portless/package.json
+++ b/packages/portless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portless",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Replace port numbers with stable, named .localhost URLs. For humans and agents.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Bump version to 0.10.2
- Add changelog entry for auto-inject `NODE_EXTRA_CA_CERTS` (#220), proxy startup on slow macOS `security` command (#229), lock contention fix (#230), HTTP/2 stream reset flood fix (#231), and non-interactive auto-start fix (#232)
- Update docs changelog