### PR TITLE
Fix stale TLD persisting across proxy restart

### DIFF
--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -654,6 +654,9 @@ async function stopProxy(store: RouteStore, proxyPort: number, _tls: boolean): P
     if (isNaN(pid)) {
       console.error(colors.red("Corrupted PID file. Removing it."));
       fs.unlinkSync(pidPath);
+      writeTlsMarker(store.dir, false);
+      writeTldFile(store.dir, DEFAULT_TLD);
+      writeLanMarker(store.dir, null);
       return;
     }
 

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -564,6 +564,7 @@ function startProxyServer(
     }
     writeTlsMarker(store.dir, false);
     writeTldFile(store.dir, DEFAULT_TLD);
+    writeLanMarker(store.dir, null);
     if (autoSyncHosts) cleanHostsFile();
     server.close(() => process.exit(0));
     // Force exit after a short timeout in case connections don't drain
@@ -613,6 +614,9 @@ async function stopProxy(store: RouteStore, proxyPort: number, _tls: boolean): P
           } catch {
             // Port file may already be absent; non-fatal
           }
+          writeTlsMarker(store.dir, false);
+          writeTldFile(store.dir, DEFAULT_TLD);
+          writeLanMarker(store.dir, null);
           console.log(colors.green(`Killed process ${pid}. Proxy stopped.`));
         } catch (err: unknown) {
           if (isErrnoException(err) && err.code === "EPERM") {
@@ -668,6 +672,9 @@ async function stopProxy(store: RouteStore, proxyPort: number, _tls: boolean): P
       } catch {
         // Port file may already be absent; non-fatal
       }
+      writeTlsMarker(store.dir, false);
+      writeTldFile(store.dir, DEFAULT_TLD);
+      writeLanMarker(store.dir, null);
       return;
     }
 
@@ -682,6 +689,9 @@ async function stopProxy(store: RouteStore, proxyPort: number, _tls: boolean): P
       );
       console.log(colors.yellow("Removing stale PID file."));
       fs.unlinkSync(pidPath);
+      writeTlsMarker(store.dir, false);
+      writeTldFile(store.dir, DEFAULT_TLD);
+      writeLanMarker(store.dir, null);
       return;
     }
 
@@ -692,6 +702,9 @@ async function stopProxy(store: RouteStore, proxyPort: number, _tls: boolean): P
     } catch {
       // Port file may already be removed; non-fatal
     }
+    writeTlsMarker(store.dir, false);
+    writeTldFile(store.dir, DEFAULT_TLD);
+    writeLanMarker(store.dir, null);
     console.log(colors.green("Proxy stopped."));
   } catch (err: unknown) {
     if (isErrnoException(err) && err.code === "EPERM") {


### PR DESCRIPTION
## Summary

- `proxy stop` removed only PID and port files, leaving `proxy.tld`, `proxy.tls`, and `proxy.lan` on disk. On the next `proxy start` without flags, `discoverState` read the stale `proxy.lan` marker, set `persistedLanMode` to true, and `defaultProxyConfig` forced the TLD back to `.local`.
- Clear all transient proxy state markers (TLD, TLS, LAN) in the daemon's SIGTERM cleanup handler (which was missing the LAN marker) and in every success path of `stopProxy`.