### PR TITLE
Prepare v0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 # Changelog
 
-## 0.10.2
+## 0.10.3
 
 <!-- release:start -->
+
+### Bug Fixes
+
+- **Stale TLD persisting across proxy restart**: Fix the proxy reverting to a stale TLD (e.g. `.local`) after restart because transient state markers were not cleaned up on stop (#235)
+
+### Contributors
+
+- @ctate
+<!-- release:end -->
+
+## 0.10.2
 
 ### New Features
 
@@ -18,7 +29,6 @@
 ### Contributors
 
 - @ctate
-<!-- release:end -->
 
 ## 0.10.1
 

--- a/apps/docs/src/app/changelog/page.mdx
+++ b/apps/docs/src/app/changelog/page.mdx
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.10.3
+
+### Bug Fixes
+
+- **Stale TLD persisting across proxy restart**: Fix the proxy reverting to a stale TLD (e.g. `.local`) after restart because transient state markers were not cleaned up on stop
+
 ## 0.10.2
 
 ### New Features

--- a/packages/portless/package.json
+++ b/packages/portless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portless",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Replace port numbers with stable, named .localhost URLs. For humans and agents.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- Bump version to 0.10.3
- Add changelog entry for #235 (fix stale TLD persisting across proxy restart)