### PR TITLE
fix: warn when --lan and --wildcard are used together

### DIFF
--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -619,6 +619,31 @@ describe("CLI", () => {
     });
 
     it.skipIf(process.platform === "win32")(
+      "warns when --lan and --wildcard are both provided",
+      () => {
+        // Use an empty PATH so the mDNS check fails early, causing the
+        // process to exit without needing a running proxy server.
+        const emptyPath = fs.mkdtempSync(path.join(os.tmpdir(), "portless-empty-path-"));
+        try {
+          const { status, stderr } = run(
+            ["proxy", "start", "--lan", "--wildcard", "--ip", "192.168.1.42"],
+            {
+              env: {
+                PATH: emptyPath,
+                PORTLESS_STATE_DIR: tmpDir,
+                PORTLESS_PORT: "19876",
+              },
+            }
+          );
+          expect(status).toBe(1);
+          expect(stderr).toContain("--wildcard has no effect in LAN mode");
+        } finally {
+          fs.rmSync(emptyPath, { recursive: true, force: true });
+        }
+      }
+    );
+
+    it.skipIf(process.platform === "win32")(
       "fails early when the mDNS publisher binary is missing",
       () => {
         const emptyPath = fs.mkdtempSync(path.join(os.tmpdir(), "portless-empty-path-"));

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1324,7 +1324,7 @@ ${colors.bold("Options:")}
   --key <path>                  Use a custom TLS private key
   --foreground                  Run proxy in foreground (for debugging)
   --tld <tld>                   Use a custom TLD instead of .localhost (e.g. test, dev)
-  --wildcard                    Allow unregistered subdomains to fall back to parent route
+  --wildcard                    Allow unregistered subdomains to fall back to parent route (local only, not LAN)
   --app-port <number>           Use a fixed port for the app (skip auto-assignment)
   --force                       Kill the existing process and take over its route
   --name <name>                 Use <name> as the app name (bypasses subcommand dispatch)
@@ -1336,7 +1336,7 @@ ${colors.bold("Environment variables:")}
   PORTLESS_HTTPS=0              Disable HTTPS (same as --no-tls)
   PORTLESS_LAN=1                Enable LAN mode when set to 1 (set in .bashrc / .zshrc)
   PORTLESS_TLD=<tld>            Use a custom TLD (e.g. test, dev; default: localhost)
-  PORTLESS_WILDCARD=1           Allow unregistered subdomains to fall back to parent route
+  PORTLESS_WILDCARD=1           Allow unregistered subdomains to fall back to parent route (local only, not LAN)
   PORTLESS_SYNC_HOSTS=0         Disable auto-sync of ${HOSTS_DISPLAY} (on by default)
   PORTLESS_STATE_DIR=<path>     Override the state directory
   PORTLESS=0                    Run command directly without proxy
@@ -1793,7 +1793,7 @@ ${colors.bold("Usage:")}
   ${colors.cyan("portless proxy start --foreground")}   Start in foreground (for debugging)
   ${colors.cyan("portless proxy start -p 1355")}        Start on a custom port (no sudo)
   ${colors.cyan("portless proxy start --tld test")}     Use .test instead of .localhost
-  ${colors.cyan("portless proxy start --wildcard")}     Allow unregistered subdomains to fall back to parent
+  ${colors.cyan("portless proxy start --wildcard")}     Allow unregistered subdomains to fall back to parent (local only)
   ${colors.cyan("portless proxy stop")}                 Stop the proxy
 
 ${colors.bold("LAN mode (--lan):")}
@@ -1803,6 +1803,8 @@ ${colors.bold("LAN mode (--lan):")}
   --ip to pin one.
   Stopped LAN proxies keep LAN mode for the next start via proxy.lan.
   Use PORTLESS_LAN=0 for one start to switch back to .localhost mode.
+  Note: --wildcard is not supported in LAN mode. mDNS does not resolve
+  wildcard subdomains, so only explicitly registered routes work on other devices.
 `);
     process.exit(isProxyHelp || !args[1] ? 0 : 1);
   }
@@ -1954,6 +1956,15 @@ ${colors.bold("LAN mode (--lan):")}
         )
       );
     }
+  }
+
+  if (lanMode && desiredWildcard) {
+    console.warn(
+      chalk.yellow(
+        "Warning: --wildcard has no effect in LAN mode. mDNS does not support wildcard records," +
+          " so only explicitly registered routes resolve on other devices."
+      )
+    );
   }
 
   const riskyReason = RISKY_TLDS.get(tld);


### PR DESCRIPTION
Fixes #215

## Problem

`--lan` mode uses mDNS (`.local` domains) to make services accessible to other devices on the local network. However, mDNS does not support wildcard records — only explicitly registered route hostnames are resolvable on other devices.

When a user passes both `--lan` and `--wildcard` to `portless proxy start`, the wildcard subdomain fallback silently has no effect for LAN clients (other devices can't resolve the wildcard subdomains via mDNS). There was no indication of this limitation.

## Solution

- Added a runtime warning when both `--lan` and `--wildcard` are used together:
  ```
  Warning: --wildcard has no effect in LAN mode. mDNS does not support wildcard records,
  so only explicitly registered routes resolve on other devices.
  ```
- Updated the `--wildcard` flag description in the `run` command help to note "(local only, not LAN)"
- Updated `PORTLESS_WILDCARD` env var description similarly
- Updated the `proxy start` help to note LAN mode incompatibility with `--wildcard`
- Added a test for the warning

## Testing

Added a new test `warns when --lan and --wildcard are both provided` following the same pattern as the existing `warns when --lan and --tld are both provided` test. All 402 tests pass.