### PR TITLE
feat: ca cert download

### DIFF
--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1265,6 +1265,7 @@ ${colors.bold("Usage:")}
   ${colors.cyan("portless alias --remove <name>")}   Remove a static route
   ${colors.cyan("portless list")}                    Show active routes
   ${colors.cyan("portless trust")}                   Add local CA to system trust store
+  ${colors.cyan("portless cert")}                    Output CA certificate to stdout (for piping over SSH)
   ${colors.cyan("portless clean")}                   Remove portless state, trust entry, and hosts block
   ${colors.cyan("portless hosts sync")}              Add routes to ${HOSTS_DISPLAY} (fixes Safari)
   ${colors.cyan("portless hosts clean")}             Remove portless entries from ${HOSTS_DISPLAY}
@@ -1368,7 +1369,7 @@ ${colors.bold("Skip portless:")}
   PORTLESS=0 pnpm dev           # Runs command directly without proxy
 
 ${colors.bold("Reserved names:")}
-  run, get, alias, hosts, list, trust, clean, proxy are subcommands and cannot
+  run, get, alias, hosts, list, trust, cert, clean, proxy are subcommands and cannot
   be used as app names directly. Use "portless run" to infer the name,
   or "portless --name <name>" to force any name including reserved ones.
 `);
@@ -1423,6 +1424,19 @@ async function handleTrust(): Promise<void> {
 
   console.error(colors.red(`Failed to trust CA: ${result.error}`));
   process.exit(1);
+}
+
+async function handleCert(): Promise<void> {
+  const { dir, tld } = await discoverState();
+  const caPath = path.join(dir, "ca.pem");
+  if (!fs.existsSync(caPath)) {
+    console.error(colors.red("No CA certificate found. Start the proxy first to generate one."));
+    process.exit(1);
+  }
+  const proxyPort = getDefaultPort(true);
+  const url = `https://cert.${tld}${proxyPort === 443 ? "" : `:${proxyPort}`}`;
+  console.error(colors.gray(`Cert page: ${url}`));
+  process.stdout.write(fs.readFileSync(caPath));
 }
 
 async function handleClean(args: string[]): Promise<void> {
@@ -2502,6 +2516,10 @@ async function main() {
     }
     if (args[0] === "--version" || args[0] === "-v") {
       printVersion();
+      return;
+    }
+    if (args[0] === "cert") {
+      await handleCert();
       return;
     }
     if (args[0] === "trust") {

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -521,6 +521,8 @@ function startProxyServer(
     console.log(
       colors.green(`${proto} proxy listening on port ${proxyPort}${tldLabel}${modeLabel}`)
     );
+    // Plain URL for VS Code / IDE port auto-detection
+    console.log(`${isTls ? "https" : "http"}://127.0.0.1:${proxyPort}`);
     if (activeLanIp) {
       console.log(chalk.green(`LAN mode: ${activeLanIp}`));
       console.log(chalk.gray("Services are discoverable as <name>.local on your network"));

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -464,6 +464,13 @@ function startProxyServer(
     strict,
     onError: (msg) => console.error(colors.red(msg)),
     tls: tlsOptions,
+    getCaCert: () => {
+      try {
+        return fs.readFileSync(path.join(store.dir, "ca.pem"));
+      } catch {
+        return null;
+      }
+    },
   });
 
   server.on("error", (err: NodeJS.ErrnoException) => {

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -2458,7 +2458,7 @@ async function main() {
 
   // --name flag: treat the next arg as an explicit app name, bypassing
   // subcommand dispatch. Useful when the app name collides with a reserved
-  // subcommand (run, alias, hosts, list, trust, clean, proxy).
+  // subcommand (run, alias, hosts, list, trust, cert, clean, proxy).
   if (args[0] === "--name") {
     args.shift();
     if (!args[0]) {

--- a/packages/portless/src/pages.test.ts
+++ b/packages/portless/src/pages.test.ts
@@ -53,6 +53,15 @@ describe("detectOS", () => {
   it("returns unknown for unrecognized User-Agent", () => {
     expect(detectOS("curl/8.1.2")).toBe("unknown");
   });
+
+  it("detects macOS from a User-Agent containing 'darwin' (not confused by 'win' substring)", () => {
+    expect(detectOS("SomeClient/darwin/23.0")).toBe("mac");
+  });
+
+  it("still detects Windows from win32 and win64", () => {
+    expect(detectOS("Mozilla/5.0 (Windows NT 10.0; Win64; x64)")).toBe("windows");
+    expect(detectOS("Mozilla/5.0 (Windows NT 10.0; Win32; x86)")).toBe("windows");
+  });
 });
 
 describe("renderCertPage", () => {

--- a/packages/portless/src/pages.test.ts
+++ b/packages/portless/src/pages.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { detectOS, renderCertPage } from "./pages.js";
+
+describe("detectOS", () => {
+  it("detects macOS from Safari User-Agent", () => {
+    expect(
+      detectOS(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"
+      )
+    ).toBe("mac");
+  });
+
+  it("detects macOS from Chrome on Mac", () => {
+    expect(
+      detectOS(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+      )
+    ).toBe("mac");
+  });
+
+  it("detects Windows from Chrome User-Agent", () => {
+    expect(
+      detectOS(
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+      )
+    ).toBe("windows");
+  });
+
+  it("detects Linux from Firefox User-Agent", () => {
+    expect(detectOS("Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/115.0")).toBe(
+      "linux"
+    );
+  });
+
+  it("detects iPhone as mac", () => {
+    expect(
+      detectOS("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15")
+    ).toBe("mac");
+  });
+
+  it("detects Android as linux", () => {
+    expect(
+      detectOS(
+        "Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 Chrome/120.0.0.0 Mobile Safari/537.36"
+      )
+    ).toBe("linux");
+  });
+
+  it("returns unknown for empty string", () => {
+    expect(detectOS("")).toBe("unknown");
+  });
+
+  it("returns unknown for unrecognized User-Agent", () => {
+    expect(detectOS("curl/8.1.2")).toBe("unknown");
+  });
+});
+
+describe("renderCertPage", () => {
+  it("renders HTML with download link", () => {
+    const html = renderCertPage("mac");
+    expect(html).toContain('<a class="download-btn" href="/download">Download Certificate</a>');
+  });
+
+  it("includes macOS instructions when mac is detected", () => {
+    const html = renderCertPage("mac");
+    expect(html).toContain("Keychain Access");
+    expect(html).toContain("security add-trusted-cert");
+  });
+
+  it("includes Windows instructions when windows is detected", () => {
+    const html = renderCertPage("windows");
+    expect(html).toContain("Install Certificate");
+    expect(html).toContain("certutil");
+  });
+
+  it("includes Linux instructions when linux is detected", () => {
+    const html = renderCertPage("linux");
+    expect(html).toContain("update-ca-certificates");
+    expect(html).toContain("update-ca-trust");
+  });
+
+  it("places detected OS tab first", () => {
+    const html = renderCertPage("windows");
+    const firstTabIdx = html.indexOf('class="os-tab active"');
+    const windowsTabIdx = html.indexOf('data-os="windows"');
+    const macTabIdx = html.indexOf('data-os="mac"');
+    expect(firstTabIdx).toBeGreaterThan(-1);
+    expect(windowsTabIdx).toBeLessThan(macTabIdx);
+  });
+
+  it("defaults to macOS first when OS is unknown", () => {
+    const html = renderCertPage("unknown");
+    const macTabIdx = html.indexOf('data-os="mac"');
+    const windowsTabIdx = html.indexOf('data-os="windows"');
+    expect(macTabIdx).toBeLessThan(windowsTabIdx);
+    expect(html).not.toContain("Detected OS");
+  });
+
+  it("includes SSH hint", () => {
+    const html = renderCertPage("mac");
+    expect(html).toContain("portless cert");
+    expect(html).toContain("ssh");
+  });
+
+  it("includes tab-switching JavaScript", () => {
+    const html = renderCertPage("mac");
+    expect(html).toContain("os-tab");
+    expect(html).toContain("addEventListener");
+  });
+
+  it("contains all three OS panels regardless of detected OS", () => {
+    const html = renderCertPage("mac");
+    expect(html).toContain('data-os="mac"');
+    expect(html).toContain('data-os="windows"');
+    expect(html).toContain('data-os="linux"');
+  });
+});

--- a/packages/portless/src/pages.ts
+++ b/packages/portless/src/pages.ts
@@ -220,3 +220,195 @@ export function detectOS(userAgent: string): "mac" | "windows" | "linux" | "unkn
   if (ua.includes("linux") || ua.includes("android")) return "linux";
   return "unknown";
 }
+
+const CERT_PAGE_STYLES = `
+  .cert-header { text-align: center; }
+  .cert-header h2 { font-size: 20px; font-weight: 500; margin-bottom: 8px; }
+  .cert-header p { font-size: 14px; color: var(--text-2); }
+  .download-btn {
+    display: inline-block;
+    margin-top: 20px;
+    padding: 10px 24px;
+    background: var(--accent);
+    color: #fff;
+    border-radius: 8px;
+    text-decoration: none;
+    font-size: 14px;
+    font-weight: 500;
+    transition: opacity 0.15s;
+  }
+  .download-btn:hover { opacity: 0.85; }
+  .os-tabs {
+    display: flex;
+    gap: 0;
+    margin-top: 32px;
+    border-bottom: 1px solid var(--border);
+  }
+  .os-tab {
+    padding: 10px 16px;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-3);
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    background: none;
+    border-top: none;
+    border-left: none;
+    border-right: none;
+    font-family: var(--font-sans);
+  }
+  .os-tab.active {
+    color: var(--fg);
+    border-bottom-color: var(--accent);
+  }
+  .os-panel { display: none; margin-top: 20px; }
+  .os-panel.active { display: block; }
+  .os-panel ol {
+    font-size: 14px;
+    color: var(--text-2);
+    line-height: 1.8;
+    padding-left: 20px;
+  }
+  .os-panel li { margin-bottom: 4px; }
+  .ssh-hint {
+    margin-top: 32px;
+    padding-top: 20px;
+    border-top: 1px solid var(--border);
+  }
+  .ssh-hint p {
+    font-size: 13px;
+    color: var(--text-3);
+    margin-bottom: 8px;
+  }
+`;
+
+function macInstructions(): string {
+  return `<ol>
+    <li>Click the download button above to save <strong>portless-ca.pem</strong></li>
+    <li>Double-click the downloaded file to open it in <strong>Keychain Access</strong></li>
+    <li>If prompted, select the <strong>login</strong> keychain and click Add</li>
+    <li>Find "portless Local CA" in the list and double-click it</li>
+    <li>Expand the <strong>Trust</strong> section</li>
+    <li>Set "When using this certificate" to <strong>Always Trust</strong></li>
+    <li>Close the window and authenticate when prompted</li>
+  </ol>
+  <p class="label" style="margin-top:16px">Or from the terminal:</p>
+  <pre class="terminal">sudo security add-trusted-cert -d -r trustRoot \\
+  -k /Library/Keychains/System.keychain portless-ca.pem</pre>`;
+}
+
+function windowsInstructions(): string {
+  return `<ol>
+    <li>Click the download button above to save <strong>portless-ca.pem</strong></li>
+    <li>Double-click the downloaded file to open the certificate dialog</li>
+    <li>Click <strong>Install Certificate...</strong></li>
+    <li>Choose <strong>Current User</strong> (or Local Machine for all users)</li>
+    <li>Select <strong>Place all certificates in the following store</strong></li>
+    <li>Click <strong>Browse</strong> and select <strong>Trusted Root Certification Authorities</strong></li>
+    <li>Click Next, then Finish</li>
+    <li>Accept the security warning</li>
+  </ol>
+  <p class="label" style="margin-top:16px">Or from the terminal (PowerShell):</p>
+  <pre class="terminal">certutil -addstore -user Root portless-ca.pem</pre>`;
+}
+
+function linuxInstructions(): string {
+  return `<ol>
+    <li>Click the download button above to save <strong>portless-ca.pem</strong></li>
+    <li>Copy it to the system CA directory and update the trust store</li>
+  </ol>
+  <p class="label" style="margin-top:16px">Debian / Ubuntu:</p>
+  <pre class="terminal">sudo cp portless-ca.pem /usr/local/share/ca-certificates/portless-ca.crt
+sudo update-ca-certificates</pre>
+  <p class="label" style="margin-top:16px">Fedora / RHEL:</p>
+  <pre class="terminal">sudo cp portless-ca.pem /etc/pki/ca-trust/source/anchors/portless-ca.crt
+sudo update-ca-trust</pre>
+  <p class="label" style="margin-top:16px">Arch:</p>
+  <pre class="terminal">sudo cp portless-ca.pem /etc/ca-certificates/trust-source/anchors/portless-ca.crt
+sudo update-ca-trust</pre>`;
+}
+
+/**
+ * Render the CA certificate download and trust instructions page.
+ * Shows OS-specific instructions based on the User-Agent, with
+ * tabs to switch between operating systems.
+ */
+export function renderCertPage(detectedOs: "mac" | "windows" | "linux" | "unknown"): string {
+  const osOrder: Array<"mac" | "windows" | "linux"> =
+    detectedOs === "unknown"
+      ? ["mac", "windows", "linux"]
+      : [detectedOs, ...(["mac", "windows", "linux"] as const).filter((os) => os !== detectedOs)];
+
+  const osLabels: Record<string, string> = {
+    mac: "macOS",
+    windows: "Windows",
+    linux: "Linux",
+  };
+
+  const osPanels: Record<string, string> = {
+    mac: macInstructions(),
+    windows: windowsInstructions(),
+    linux: linuxInstructions(),
+  };
+
+  const tabsHtml = osOrder
+    .map(
+      (os, i) =>
+        `<button class="os-tab${i === 0 ? " active" : ""}" data-os="${os}">${osLabels[os]}</button>`
+    )
+    .join("");
+
+  const panelsHtml = osOrder
+    .map(
+      (os, i) =>
+        `<div class="os-panel${i === 0 ? " active" : ""}" data-os="${os}">${osPanels[os]}</div>`
+    )
+    .join("");
+
+  const detectedLabel =
+    detectedOs !== "unknown" ? `<p>Detected OS: <strong>${osLabels[detectedOs]}</strong></p>` : "";
+
+  const body = `<div class="content">
+    <div class="cert-header">
+      <h2>Install the portless CA Certificate</h2>
+      ${detectedLabel}
+      <a class="download-btn" href="/download">Download Certificate</a>
+    </div>
+    <div class="os-tabs">${tabsHtml}</div>
+    ${panelsHtml}
+    <div class="ssh-hint">
+      <p>Alternatively, copy the certificate from a remote machine via SSH:</p>
+      <pre class="terminal">ssh &lt;remote-host&gt; portless cert &gt; portless-ca.pem</pre>
+    </div>
+  </div>`;
+
+  const js = `<script>
+  document.querySelectorAll('.os-tab').forEach(function(tab) {
+    tab.addEventListener('click', function() {
+      var os = this.getAttribute('data-os');
+      document.querySelectorAll('.os-tab').forEach(function(t) { t.classList.remove('active'); });
+      document.querySelectorAll('.os-panel').forEach(function(p) { p.classList.remove('active'); });
+      this.classList.add('active');
+      document.querySelector('.os-panel[data-os="' + os + '"]').classList.add('active');
+    });
+  });
+  </script>`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="light dark">
+<title>Install CA Certificate</title>
+<style>${PAGE_STYLES}${CERT_PAGE_STYLES}</style>
+</head>
+<body>
+<div class="page">
+${body}
+<p class="footer">portless</p>
+</div>
+${js}
+</body>
+</html>`;
+}

--- a/packages/portless/src/pages.ts
+++ b/packages/portless/src/pages.ts
@@ -214,9 +214,9 @@ ${body}
  */
 export function detectOS(userAgent: string): "mac" | "windows" | "linux" | "unknown" {
   const ua = userAgent.toLowerCase();
-  if (ua.includes("win") || ua.includes("windows")) return "windows";
   if (ua.includes("mac") || ua.includes("darwin") || ua.includes("iphone") || ua.includes("ipad"))
     return "mac";
+  if (ua.includes("windows") || ua.includes("win32") || ua.includes("win64")) return "windows";
   if (ua.includes("linux") || ua.includes("android")) return "linux";
   return "unknown";
 }

--- a/packages/portless/src/pages.ts
+++ b/packages/portless/src/pages.ts
@@ -207,3 +207,16 @@ ${body}
 </body>
 </html>`;
 }
+
+/**
+ * Detect the client OS from a User-Agent string.
+ * Returns "mac", "windows", "linux", or "unknown".
+ */
+export function detectOS(userAgent: string): "mac" | "windows" | "linux" | "unknown" {
+  const ua = userAgent.toLowerCase();
+  if (ua.includes("win") || ua.includes("windows")) return "windows";
+  if (ua.includes("mac") || ua.includes("darwin") || ua.includes("iphone") || ua.includes("ipad"))
+    return "mac";
+  if (ua.includes("linux") || ua.includes("android")) return "linux";
+  return "unknown";
+}

--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -782,6 +782,118 @@ describe("createProxyServer", () => {
     });
   });
 
+  describe("cert endpoint", () => {
+    const fakeCaCert = Buffer.from(
+      "-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----\n"
+    );
+
+    it("serves cert page at cert.localhost", async () => {
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => [],
+          proxyPort: TEST_PROXY_PORT,
+          getCaCert: () => fakeCaCert,
+        })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "cert.localhost" });
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toBe("text/html");
+      expect(res.body).toContain("Install the portless CA Certificate");
+      expect(res.body).toContain("/download");
+    });
+
+    it("serves PEM download at /download", async () => {
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => [],
+          proxyPort: TEST_PROXY_PORT,
+          getCaCert: () => fakeCaCert,
+        })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "cert.localhost", path: "/download" });
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toBe("application/x-pem-file");
+      expect(res.headers["content-disposition"]).toBe('attachment; filename="portless-ca.pem"');
+      expect(res.body).toBe(fakeCaCert.toString());
+    });
+
+    it("serves PEM download at /ca.pem", async () => {
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => [],
+          proxyPort: TEST_PROXY_PORT,
+          getCaCert: () => fakeCaCert,
+        })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "cert.localhost", path: "/ca.pem" });
+      expect(res.status).toBe(200);
+      expect(res.body).toBe(fakeCaCert.toString());
+    });
+
+    it("returns 404 when CA cert is not available", async () => {
+      const server = trackServer(
+        createProxyServer({ getRoutes: () => [], proxyPort: TEST_PROXY_PORT })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "cert.localhost" });
+      expect(res.status).toBe(404);
+      expect(res.body).toContain("CA certificate not available");
+    });
+
+    it("respects custom TLD", async () => {
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => [],
+          proxyPort: TEST_PROXY_PORT,
+          tld: "test",
+          getCaCert: () => fakeCaCert,
+        })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "cert.test" });
+      expect(res.status).toBe(200);
+      expect(res.body).toContain("Install the portless CA Certificate");
+    });
+
+    it("does not match cert.localhost on different TLD", async () => {
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => [],
+          proxyPort: TEST_PROXY_PORT,
+          tld: "test",
+          getCaCert: () => fakeCaCert,
+        })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "cert.localhost" });
+      expect(res.status).toBe(404);
+    });
+
+    it("strips query string from download path", async () => {
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => [],
+          proxyPort: TEST_PROXY_PORT,
+          getCaCert: () => fakeCaCert,
+        })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "cert.localhost", path: "/download?t=123" });
+      expect(res.status).toBe(200);
+      expect(res.headers["content-type"]).toBe("application/x-pem-file");
+    });
+  });
+
   describe("XSS safety", () => {
     it("escapes hostname in 404 page", async () => {
       const routes: RouteInfo[] = [];
@@ -1469,4 +1581,37 @@ describe("createProxyServer with TLS (HTTP/2)", () => {
     },
     15_000
   );
+
+  it("uses getCaCert when both getCaCert and tls.ca are available", async () => {
+    const tlsCa = Buffer.from("TLS-CA");
+    const callbackCa = Buffer.from("CALLBACK-CA");
+    const server = trackServer(
+      createProxyServer({
+        getRoutes: () => [],
+        proxyPort: TEST_PROXY_PORT,
+        tls: { cert: tlsCert, key: tlsKey, ca: tlsCa },
+        getCaCert: () => callbackCa,
+      })
+    );
+    await listen(server);
+
+    const res = await httpsRequest(server, { host: "cert.localhost", path: "/download" });
+    expect(res.body).toBe("CALLBACK-CA");
+  });
+
+  it("falls back to tls.ca when getCaCert returns null", async () => {
+    const tlsCa = Buffer.from("TLS-CA");
+    const server = trackServer(
+      createProxyServer({
+        getRoutes: () => [],
+        proxyPort: TEST_PROXY_PORT,
+        tls: { cert: tlsCert, key: tlsKey, ca: tlsCa },
+        getCaCert: () => null,
+      })
+    );
+    await listen(server);
+
+    const res = await httpsRequest(server, { host: "cert.localhost", path: "/download" });
+    expect(res.body).toBe("TLS-CA");
+  });
 });

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -3,7 +3,7 @@ import * as http2 from "node:http2";
 import * as net from "node:net";
 import type { ProxyServerOptions } from "./types.js";
 import { escapeHtml, formatUrl } from "./utils.js";
-import { ARROW_SVG, renderPage } from "./pages.js";
+import { ARROW_SVG, renderPage, renderCertPage, detectOS } from "./pages.js";
 
 /** Response header used to identify a portless proxy (for health checks). */
 export const PORTLESS_HEADER = "X-Portless";
@@ -153,6 +153,30 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
 }</pre></div></div>`
         )
       );
+      return;
+    }
+
+    // Cert download endpoint: cert.<tld>
+    if (host === "cert." + tld) {
+      const caCert = options.getCaCert?.() ?? tls?.ca;
+      if (!caCert) {
+        res.writeHead(404, { "Content-Type": "text/plain" });
+        res.end("CA certificate not available");
+        return;
+      }
+      const urlPath = req.url?.split("?")[0] || "/";
+      if (urlPath === "/download" || urlPath === "/ca.pem") {
+        res.writeHead(200, {
+          "Content-Type": "application/x-pem-file",
+          "Content-Disposition": 'attachment; filename="portless-ca.pem"',
+        });
+        res.end(caCert);
+      } else {
+        const userAgent = req.headers["user-agent"] || "";
+        const os = detectOS(userAgent);
+        res.writeHead(200, { "Content-Type": "text/html" });
+        res.end(renderCertPage(os));
+      }
       return;
     }
 

--- a/packages/portless/src/types.ts
+++ b/packages/portless/src/types.ts
@@ -31,4 +31,9 @@ export interface ProxyServerOptions {
       cb: (err: Error | null, ctx?: import("node:tls").SecureContext) => void
     ) => void;
   };
+  /**
+   * Returns the CA certificate PEM content for the cert download endpoint.
+   * Used by cert.<tld> to serve the CA cert even when TLS is not enabled.
+   */
+  getCaCert?: () => Buffer | null;
 }


### PR DESCRIPTION
## Summary

- Add `cert.<tld>` HTTP endpoint that serves an OS-aware HTML instructions page (detects OS from User-Agent) or a raw PEM download at `/download` and `/ca.pem`
- Add `portless cert` CLI command that outputs the CA certificate to stdout for piping over SSH (`ssh <host> portless cert > portless-ca.pem`)
- Add `getCaCert` callback to `ProxyServerOptions` so the cert is available even without TLS enabled

## Why

My use case, which this PR solves is the following:

Multi-machine environment. One machine (A) has a webapp that uses portless. Another machine (B) effectively controls A via ssh and conveniently uses port-forwarding to access resources on A, including the aforementioned webapp.

Portless handles the CA management locally on A but in this case, the CA needs to be installed on B.

So, yeah, I built this little thing and functionally it works. Now I can download the cert from B and install it and it works fine.
I am not 100% sure about the UX yet but I am sharing this in case you like the idea and we want to push this down the line together. 

Happy to put some neurons and tokens to work to ship it if you like it.

<img width="516" height="771" alt="image" src="https://github.com/user-attachments/assets/168b95ed-d29a-48d2-9d02-d22556c26ea1" />

There is dark mode as well, don't freak out! 😄   

### Gotchas

I manage machine A from VSCode/Cursor in B for some design work, so I echo the listening server so that VSCode can pick up the port-forwarding automatically. 
It works by pattern matching, so perhaps it could look better with a nicer message, unless you reckon it's just better to drop it entirely and let the user handle it manually. 

## Test Plan

- [x] 17 new tests for `detectOS` and `renderCertPage` in `pages.test.ts`
- [x] 9 new proxy tests for cert endpoint (page, download, 404, TLD handling, query string stripping, TLS fallback)
- [x] All 346 existing tests continue to pass
- [x] Type check and lint pass cleanly
- [x] Manual: visit `https://cert.localhost` in browser and verify page renders
- [x] Manual: run `portless cert > /tmp/test-ca.pem` and verify valid PEM output
