### PR TITLE
Add h2c upstream support for gRPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,16 @@ portless trust
 
 On Linux, `portless trust` supports Debian/Ubuntu, Arch, Fedora/RHEL/CentOS, and openSUSE (via `update-ca-certificates` or `update-ca-trust`). On Windows, it uses `certutil` to add the CA to the system trust store.
 
+## gRPC and HTTP/2 backends
+
+Some backends only speak HTTP/2 on their non-TLS listener, notably gRPC servers (e.g. built with `@grpc/grpc-js` or `nice-grpc`). Pass `--h2c` to proxy them over HTTP/2 cleartext instead of HTTP/1.1:
+
+```bash
+portless grpc-svc --h2c tsx server.ts
+```
+
+Bidirectional streaming, response trailers (`grpc-status`, `grpc-message`), and trailers-only responses are preserved end to end. Without `--h2c`, portless forwards over HTTP/1.1 and an HTTP/2-only backend will refuse the connection.
+
 ## LAN mode
 
 ```bash
@@ -203,6 +213,7 @@ portless proxy stop              # Stop the proxy
 --app-port <number>              Use a fixed port for the app (skip auto-assignment)
 --force                          Kill the existing process and take over its route
 --name <name>                    Use <name> as the app name
+--h2c                            Speak HTTP/2 cleartext to the backend (required for gRPC)
 ```
 
 ### Environment variables

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -11,6 +11,7 @@ import { createHttpRedirectServer, createProxyServer } from "./proxy.js";
 import { fixOwnership, formatUrl, isErrnoException, parseHostname } from "./utils.js";
 import { syncHostsFile, cleanHostsFile, shouldAutoSyncHosts } from "./hosts.js";
 import { FILE_MODE, RouteConflictError, RouteStore } from "./routes.js";
+import type { UpstreamProtocol } from "./types.js";
 import { inferProjectName, detectWorktreePrefix, truncateLabel } from "./auto.js";
 import {
   buildProxyStartConfig,
@@ -757,7 +758,8 @@ async function runApp(
   autoInfo?: { nameSource: string; prefix?: string; prefixSource?: string },
   desiredPort?: number,
   lanMode = false,
-  lanIp?: string | null
+  lanIp?: string | null,
+  protocol?: UpstreamProtocol
 ) {
   let store = initialStore;
   console.log(chalk.blue.bold(`\nportless\n`));
@@ -972,7 +974,7 @@ async function runApp(
   // Register route (--force kills the existing owner if any)
   let killedPid: number | undefined;
   try {
-    killedPid = store.addRoute(hostname, port, process.pid, force);
+    killedPid = store.addRoute(hostname, port, process.pid, force, protocol);
   } catch (err) {
     if (err instanceof RouteConflictError) {
       console.error(colors.red(`Error: ${err.message}`));
@@ -1068,6 +1070,8 @@ interface ParsedRunArgs {
   appPort?: number;
   /** Override the inferred base name (from --name flag). */
   name?: string;
+  /** Upstream protocol used to proxy to the backend. */
+  protocol?: UpstreamProtocol;
   /** The child command and its arguments, passed through untouched. */
   commandArgs: string[];
 }
@@ -1112,6 +1116,7 @@ function parseRunArgs(args: string[]): ParsedRunArgs {
   let force = false;
   let appPort: number | undefined;
   let name: string | undefined;
+  let protocol: UpstreamProtocol | undefined;
   let i = 0;
 
   while (i < args.length && args[i].startsWith("-")) {
@@ -1129,6 +1134,7 @@ ${colors.bold("Options:")}
   --name <name>          Override the inferred base name (worktree prefix still applies)
   --force                Kill the existing process and take over its route
   --app-port <number>    Use a fixed port for the app (skip auto-assignment)
+  --h2c                  Speak HTTP/2 cleartext to the backend (required for gRPC)
   --help, -h             Show this help
 
 ${colors.bold("Name inference (in order):")}
@@ -1152,6 +1158,8 @@ ${colors.bold("Examples:")}
     } else if (args[i] === "--app-port") {
       i++;
       appPort = parseAppPort(args[i]);
+    } else if (args[i] === "--h2c") {
+      protocol = "h2c";
     } else if (args[i] === "--name") {
       i++;
       if (!args[i] || args[i].startsWith("-")) {
@@ -1162,7 +1170,7 @@ ${colors.bold("Examples:")}
       name = args[i];
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
-      console.error(colors.blue("Known flags: --name, --force, --app-port, --help"));
+      console.error(colors.blue("Known flags: --name, --force, --app-port, --h2c, --help"));
       process.exit(1);
     }
     i++;
@@ -1170,7 +1178,7 @@ ${colors.bold("Examples:")}
 
   if (!appPort) appPort = appPortFromEnv();
 
-  return { force, appPort, name, commandArgs: args.slice(i) };
+  return { force, appPort, protocol, name, commandArgs: args.slice(i) };
 }
 
 /**
@@ -1183,6 +1191,7 @@ ${colors.bold("Examples:")}
 function parseAppArgs(args: string[]): ParsedAppArgs {
   let force = false;
   let appPort: number | undefined;
+  let protocol: UpstreamProtocol | undefined;
   let i = 0;
 
   // Consume leading flags before name
@@ -1195,9 +1204,11 @@ function parseAppArgs(args: string[]): ParsedAppArgs {
     } else if (args[i] === "--app-port") {
       i++;
       appPort = parseAppPort(args[i]);
+    } else if (args[i] === "--h2c") {
+      protocol = "h2c";
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
-      console.error(colors.blue("Known flags: --force, --app-port"));
+      console.error(colors.blue("Known flags: --force, --app-port, --h2c"));
       process.exit(1);
     }
     i++;
@@ -1217,9 +1228,11 @@ function parseAppArgs(args: string[]): ParsedAppArgs {
     } else if (args[i] === "--app-port") {
       i++;
       appPort = parseAppPort(args[i]);
+    } else if (args[i] === "--h2c") {
+      protocol = "h2c";
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
-      console.error(colors.blue("Known flags: --force, --app-port"));
+      console.error(colors.blue("Known flags: --force, --app-port, --h2c"));
       process.exit(1);
     }
     i++;
@@ -1227,7 +1240,7 @@ function parseAppArgs(args: string[]): ParsedAppArgs {
 
   if (!appPort) appPort = appPortFromEnv();
 
-  return { force, appPort, name, commandArgs: args.slice(i) };
+  return { force, appPort, protocol, name, commandArgs: args.slice(i) };
 }
 
 // ---------------------------------------------------------------------------
@@ -2315,7 +2328,8 @@ async function handleRunMode(args: string[]): Promise<void> {
     { nameSource, prefix: worktree?.prefix, prefixSource: worktree?.source },
     parsed.appPort,
     lanMode,
-    lanIp
+    lanIp,
+    parsed.protocol
   );
 }
 
@@ -2353,7 +2367,8 @@ async function handleNamedMode(args: string[]): Promise<void> {
     undefined,
     parsed.appPort,
     lanMode,
-    lanIp
+    lanIp,
+    parsed.protocol
   );
 }
 

--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -1470,3 +1470,593 @@ describe("createProxyServer with TLS (HTTP/2)", () => {
     15_000
   );
 });
+
+describe("createProxyServer with h2c upstream", () => {
+  const servers: AnyServer[] = [];
+  const h2cBackends: http2.Http2Server[] = [];
+
+  function trackServer<T extends AnyServer>(server: T): T {
+    servers.push(server);
+    return server;
+  }
+
+  function listenH2c(server: http2.Http2Server): Promise<number> {
+    return new Promise((resolve) => {
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address();
+        if (!addr || typeof addr === "string") throw new Error("no addr");
+        resolve(addr.port);
+      });
+    });
+  }
+
+  function createH2cBackend(
+    handler: (stream: http2.ServerHttp2Stream, headers: http2.IncomingHttpHeaders) => void
+  ): http2.Http2Server {
+    const backend = http2.createServer();
+    backend.on("stream", handler);
+    h2cBackends.push(backend);
+    return backend;
+  }
+
+  afterEach(async () => {
+    await Promise.all(
+      h2cBackends.map(
+        (b) =>
+          new Promise<void>((resolve) => {
+            b.close(() => resolve());
+            (b as http2.Http2Server & { closeAllConnections?: () => void }).closeAllConnections?.();
+            setTimeout(resolve, 500);
+          })
+      )
+    );
+    h2cBackends.length = 0;
+
+    await Promise.all(
+      servers.map(
+        (s) =>
+          new Promise<void>((resolve) => {
+            s.close(() => resolve());
+            setTimeout(resolve, 500);
+          })
+      )
+    );
+    servers.length = 0;
+  });
+
+  it("proxies a GET request to an h2c backend", async () => {
+    const backend = createH2cBackend((stream) => {
+      stream.respond({ ":status": 200, "content-type": "text/plain" });
+      stream.end("hello h2c");
+    });
+    const backendPort = await listenH2c(backend);
+
+    const routes: RouteInfo[] = [
+      { hostname: "grpc.localhost", port: backendPort, protocol: "h2c" },
+    ];
+    const server = trackServer(
+      createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+    );
+    await listen(server);
+
+    const res = await request(server, { host: "grpc.localhost" });
+    expect(res.status).toBe(200);
+    expect(res.body).toBe("hello h2c");
+  });
+
+  it("sets :authority to the route hostname:port when forwarding", async () => {
+    let capturedAuthority: string | undefined;
+    const backend = createH2cBackend((stream, headers) => {
+      capturedAuthority = headers[":authority"] as string | undefined;
+      stream.respond({ ":status": 200 });
+      stream.end();
+    });
+    const backendPort = await listenH2c(backend);
+
+    const routes: RouteInfo[] = [
+      { hostname: "grpc.localhost", port: backendPort, protocol: "h2c" },
+    ];
+    const server = trackServer(
+      createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+    );
+    await listen(server);
+
+    await request(server, { host: "grpc.localhost" });
+    expect(capturedAuthority).toBe(`grpc.localhost:${backendPort}`);
+  });
+
+  it("does not forward the Host or Connection headers to the h2c upstream", async () => {
+    let capturedHeaders: http2.IncomingHttpHeaders | undefined;
+    const backend = createH2cBackend((stream, headers) => {
+      capturedHeaders = headers;
+      stream.respond({ ":status": 200 });
+      stream.end();
+    });
+    const backendPort = await listenH2c(backend);
+
+    const routes: RouteInfo[] = [
+      { hostname: "grpc.localhost", port: backendPort, protocol: "h2c" },
+    ];
+    const server = trackServer(
+      createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+    );
+    await listen(server);
+
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("no addr");
+
+    await new Promise<void>((resolve, reject) => {
+      const req = http.request(
+        {
+          hostname: "127.0.0.1",
+          port: addr.port,
+          path: "/",
+          method: "GET",
+          headers: { host: "grpc.localhost", connection: "keep-alive" },
+        },
+        (res) => {
+          res.resume();
+          res.on("end", resolve);
+        }
+      );
+      req.on("error", reject);
+      req.end();
+    });
+
+    expect(capturedHeaders?.host).toBeUndefined();
+    expect(capturedHeaders?.connection).toBeUndefined();
+  });
+
+  it("forwards X-Forwarded-* headers to the h2c upstream", async () => {
+    let capturedHeaders: http2.IncomingHttpHeaders | undefined;
+    const backend = createH2cBackend((stream, headers) => {
+      capturedHeaders = headers;
+      stream.respond({ ":status": 200 });
+      stream.end();
+    });
+    const backendPort = await listenH2c(backend);
+
+    const routes: RouteInfo[] = [
+      { hostname: "grpc.localhost", port: backendPort, protocol: "h2c" },
+    ];
+    const server = trackServer(
+      createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+    );
+    await listen(server);
+
+    await request(server, { host: "grpc.localhost" });
+
+    expect(capturedHeaders?.["x-forwarded-for"]).toBe("127.0.0.1");
+    expect(capturedHeaders?.["x-forwarded-proto"]).toBe("http");
+    expect(capturedHeaders?.["x-forwarded-host"]).toBe("grpc.localhost");
+  });
+
+  it("forwards a POST body to the h2c upstream", async () => {
+    const backend = createH2cBackend((stream) => {
+      const chunks: Buffer[] = [];
+      stream.on("data", (c: Buffer) => chunks.push(c));
+      stream.on("end", () => {
+        stream.respond({ ":status": 200, "content-type": "application/octet-stream" });
+        stream.end(Buffer.concat(chunks));
+      });
+    });
+    const backendPort = await listenH2c(backend);
+
+    const routes: RouteInfo[] = [
+      { hostname: "grpc.localhost", port: backendPort, protocol: "h2c" },
+    ];
+    const server = trackServer(
+      createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+    );
+    await listen(server);
+
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("no addr");
+
+    const body = await new Promise<string>((resolve, reject) => {
+      const req = http.request(
+        {
+          hostname: "127.0.0.1",
+          port: addr.port,
+          path: "/echo",
+          method: "POST",
+          headers: { host: "grpc.localhost", "content-type": "text/plain" },
+        },
+        (res) => {
+          let data = "";
+          res.on("data", (c) => (data += c));
+          res.on("end", () => resolve(data));
+        }
+      );
+      req.on("error", reject);
+      req.write("payload-for-h2c");
+      req.end();
+    });
+
+    expect(body).toBe("payload-for-h2c");
+  });
+
+  it("increments x-portless-hops on the request to the h2c upstream", async () => {
+    let capturedHops: string | undefined;
+    const backend = createH2cBackend((stream, headers) => {
+      capturedHops = headers["x-portless-hops"] as string | undefined;
+      stream.respond({ ":status": 200 });
+      stream.end();
+    });
+    const backendPort = await listenH2c(backend);
+
+    const routes: RouteInfo[] = [
+      { hostname: "grpc.localhost", port: backendPort, protocol: "h2c" },
+    ];
+    const server = trackServer(
+      createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+    );
+    await listen(server);
+
+    await request(server, { host: "grpc.localhost" });
+    expect(capturedHops).toBe("1");
+  });
+
+  it("returns 502 when the h2c backend is unreachable", async () => {
+    const routes: RouteInfo[] = [{ hostname: "grpc.localhost", port: 1, protocol: "h2c" }];
+    const server = trackServer(
+      createProxyServer({
+        getRoutes: () => routes,
+        proxyPort: TEST_PROXY_PORT,
+        onError: () => {},
+      })
+    );
+    await listen(server);
+
+    const res = await request(server, { host: "grpc.localhost" });
+    expect(res.status).toBe(502);
+  });
+
+  it("reuses the h2c session across multiple requests", async () => {
+    const sessions: http2.ServerHttp2Session[] = [];
+    const backend = createH2cBackend((stream) => {
+      sessions.push(stream.session as http2.ServerHttp2Session);
+      stream.respond({ ":status": 200 });
+      stream.end("ok");
+    });
+    const backendPort = await listenH2c(backend);
+
+    const routes: RouteInfo[] = [
+      { hostname: "grpc.localhost", port: backendPort, protocol: "h2c" },
+    ];
+    const server = trackServer(
+      createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+    );
+    await listen(server);
+
+    await request(server, { host: "grpc.localhost" });
+    await request(server, { host: "grpc.localhost" });
+
+    expect(sessions.length).toBe(2);
+    expect(sessions[0]).toBe(sessions[1]);
+  });
+
+  it("routes http and h2c backends independently on the same proxy", async () => {
+    const h2cBackend = createH2cBackend((stream) => {
+      stream.respond({ ":status": 200 });
+      stream.end("from h2c");
+    });
+    const h2cPort = await listenH2c(h2cBackend);
+
+    const httpBackend = trackServer(
+      http.createServer((_req, res) => {
+        res.writeHead(200);
+        res.end("from http");
+      })
+    );
+    await listen(httpBackend);
+    const httpAddr = httpBackend.address();
+    if (!httpAddr || typeof httpAddr === "string") throw new Error("no addr");
+
+    const routes: RouteInfo[] = [
+      { hostname: "grpc.localhost", port: h2cPort, protocol: "h2c" },
+      { hostname: "api.localhost", port: httpAddr.port },
+    ];
+    const server = trackServer(
+      createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+    );
+    await listen(server);
+
+    const h2cRes = await request(server, { host: "grpc.localhost" });
+    const httpRes = await request(server, { host: "api.localhost" });
+    expect(h2cRes.body).toBe("from h2c");
+    expect(httpRes.body).toBe("from http");
+  });
+
+  it("propagates non-200 status codes from the h2c backend", async () => {
+    const backend = createH2cBackend((stream) => {
+      stream.respond({ ":status": 418, "content-type": "text/plain" });
+      stream.end("teapot");
+    });
+    const backendPort = await listenH2c(backend);
+
+    const routes: RouteInfo[] = [
+      { hostname: "grpc.localhost", port: backendPort, protocol: "h2c" },
+    ];
+    const server = trackServer(
+      createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+    );
+    await listen(server);
+
+    const res = await request(server, { host: "grpc.localhost" });
+    expect(res.status).toBe(418);
+    expect(res.body).toBe("teapot");
+  });
+
+  it("preserves a multi-chunk streamed response body from the h2c backend", async () => {
+    const backend = createH2cBackend((stream) => {
+      stream.respond({ ":status": 200, "content-type": "application/octet-stream" });
+      stream.write("chunk-1;");
+      setTimeout(() => {
+        stream.write("chunk-2;");
+        setTimeout(() => {
+          stream.end("chunk-3");
+        }, 10);
+      }, 10);
+    });
+    const backendPort = await listenH2c(backend);
+
+    const routes: RouteInfo[] = [
+      { hostname: "grpc.localhost", port: backendPort, protocol: "h2c" },
+    ];
+    const server = trackServer(
+      createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+    );
+    await listen(server);
+
+    const res = await request(server, { host: "grpc.localhost" });
+    expect(res.status).toBe(200);
+    expect(res.body).toBe("chunk-1;chunk-2;chunk-3");
+  });
+
+  it("reconnects with a fresh h2c session after the previous one closes", async () => {
+    let connCount = 0;
+    let closeAfterFirst = true;
+    let firstSessionClosedResolver: (() => void) | null = null;
+    const firstSessionClosed = new Promise<void>((r) => {
+      firstSessionClosedResolver = r;
+    });
+
+    const backend = createH2cBackend((stream) => {
+      stream.respond({ ":status": 200 });
+      stream.end("ok");
+      if (closeAfterFirst) {
+        closeAfterFirst = false;
+        stream.session?.once("close", () => {
+          firstSessionClosedResolver?.();
+          firstSessionClosedResolver = null;
+        });
+        stream.session?.close();
+      }
+    });
+    backend.on("connection", () => {
+      connCount++;
+    });
+    const backendPort = await listenH2c(backend);
+
+    const routes: RouteInfo[] = [
+      { hostname: "grpc.localhost", port: backendPort, protocol: "h2c" },
+    ];
+    const server = trackServer(
+      createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+    );
+    await listen(server);
+
+    await request(server, { host: "grpc.localhost" });
+    // Wait until the backend observes the first session fully closed, so the
+    // proxy's cached session has certainly been invalidated by its close
+    // handler before we issue the next request.
+    await firstSessionClosed;
+    await request(server, { host: "grpc.localhost" });
+
+    expect(connCount).toBe(2);
+  });
+});
+
+describe("createProxyServer with TLS and h2c upstream", () => {
+  let tlsCert: Buffer;
+  let tlsKey: Buffer;
+  let certDir: string;
+  const servers: AnyServer[] = [];
+  const h2cBackends: http2.Http2Server[] = [];
+
+  function trackServer<T extends AnyServer>(server: T): T {
+    servers.push(server);
+    return server;
+  }
+
+  function listenH2c(server: http2.Http2Server): Promise<number> {
+    return new Promise((resolve) => {
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address();
+        if (!addr || typeof addr === "string") throw new Error("no addr");
+        resolve(addr.port);
+      });
+    });
+  }
+
+  function createH2cBackend(
+    handler: (stream: http2.ServerHttp2Stream, headers: http2.IncomingHttpHeaders) => void
+  ): http2.Http2Server {
+    const backend = http2.createServer();
+    backend.on("stream", handler);
+    h2cBackends.push(backend);
+    return backend;
+  }
+
+  beforeAll(() => {
+    certDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-h2c-tls-test-"));
+    const certs = ensureCerts(certDir);
+    tlsCert = fs.readFileSync(certs.certPath);
+    tlsKey = fs.readFileSync(certs.keyPath);
+  }, 30_000);
+
+  afterAll(() => {
+    fs.rmSync(certDir, { recursive: true, force: true });
+  });
+
+  afterEach(async () => {
+    await Promise.all(
+      h2cBackends.map(
+        (b) =>
+          new Promise<void>((resolve) => {
+            b.close(() => resolve());
+            (b as http2.Http2Server & { closeAllConnections?: () => void }).closeAllConnections?.();
+            setTimeout(resolve, 1000);
+          })
+      )
+    );
+    h2cBackends.length = 0;
+
+    await Promise.all(
+      servers.map(
+        (s) =>
+          new Promise<void>((resolve) => {
+            s.close(() => resolve());
+            setTimeout(resolve, 1000);
+          })
+      )
+    );
+    servers.length = 0;
+  });
+
+  it("forwards response trailers from an h2c backend to an HTTP/2 client", async () => {
+    const backend = createH2cBackend((stream) => {
+      stream.respond(
+        { ":status": 200, "content-type": "application/grpc" },
+        { waitForTrailers: true }
+      );
+      stream.on("wantTrailers", () => {
+        stream.sendTrailers({ "grpc-status": "0", "grpc-message": "OK" });
+      });
+      stream.end(Buffer.from([0, 0, 0, 0, 0]));
+    });
+    const backendPort = await listenH2c(backend);
+
+    const routes: RouteInfo[] = [
+      { hostname: "grpc.localhost", port: backendPort, protocol: "h2c" },
+    ];
+    const server = trackServer(
+      createProxyServer({
+        getRoutes: () => routes,
+        proxyPort: TEST_PROXY_PORT,
+        tls: { cert: tlsCert, key: tlsKey },
+      })
+    );
+    await listen(server);
+
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("no addr");
+
+    const result = await new Promise<{
+      status: number;
+      trailers: http2.IncomingHttpHeaders;
+    }>((resolve, reject) => {
+      const client = http2.connect(`https://127.0.0.1:${addr.port}`, {
+        rejectUnauthorized: false,
+      });
+      client.on("error", reject);
+
+      const req = client.request({
+        ":method": "POST",
+        ":path": "/Greeter/SayHello",
+        host: "grpc.localhost",
+      });
+
+      let status = 0;
+      let trailers: http2.IncomingHttpHeaders = {};
+      req.on("response", (headers) => {
+        status = headers[":status"] as number;
+      });
+      req.on("trailers", (t) => {
+        trailers = t;
+      });
+      req.on("data", () => {});
+      req.on("end", () => {
+        req.close();
+        client.close();
+        resolve({ status, trailers });
+      });
+      req.on("error", reject);
+      req.end(Buffer.from([0, 0, 0, 0, 0]));
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.trailers["grpc-status"]).toBe("0");
+    expect(result.trailers["grpc-message"]).toBe("OK");
+  });
+
+  it("delivers a trailers-only h2c response to an HTTP/2 client with no body", async () => {
+    const backend = createH2cBackend((stream) => {
+      stream.respond(
+        {
+          ":status": 200,
+          "content-type": "application/grpc",
+          "grpc-status": "5",
+          "grpc-message": "not found",
+        },
+        { endStream: true }
+      );
+    });
+    const backendPort = await listenH2c(backend);
+
+    const routes: RouteInfo[] = [
+      { hostname: "grpc.localhost", port: backendPort, protocol: "h2c" },
+    ];
+    const server = trackServer(
+      createProxyServer({
+        getRoutes: () => routes,
+        proxyPort: TEST_PROXY_PORT,
+        tls: { cert: tlsCert, key: tlsKey },
+      })
+    );
+    await listen(server);
+
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("no addr");
+
+    const result = await new Promise<{
+      status: number;
+      grpcStatus: string | undefined;
+      byteCount: number;
+    }>((resolve, reject) => {
+      const client = http2.connect(`https://127.0.0.1:${addr.port}`, {
+        rejectUnauthorized: false,
+      });
+      client.on("error", reject);
+
+      const req = client.request({
+        ":method": "POST",
+        ":path": "/Missing/Method",
+        host: "grpc.localhost",
+      });
+
+      let status = 0;
+      let grpcStatus: string | undefined;
+      let byteCount = 0;
+      req.on("response", (headers) => {
+        status = headers[":status"] as number;
+        grpcStatus = headers["grpc-status"] as string | undefined;
+      });
+      req.on("data", (c: Buffer) => {
+        byteCount += c.length;
+      });
+      req.on("end", () => {
+        req.close();
+        client.close();
+        resolve({ status, grpcStatus, byteCount });
+      });
+      req.on("error", reject);
+      req.end();
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.grpcStatus).toBe("5");
+    expect(result.byteCount).toBe(0);
+  });
+});

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -1,7 +1,7 @@
 import * as http from "node:http";
 import * as http2 from "node:http2";
 import * as net from "node:net";
-import type { ProxyServerOptions } from "./types.js";
+import type { ProxyServerOptions, RouteInfo } from "./types.js";
 import { escapeHtml, formatUrl } from "./utils.js";
 import { ARROW_SVG, renderPage } from "./pages.js";
 
@@ -20,6 +20,13 @@ const HOP_BY_HOP_HEADERS = new Set([
   "transfer-encoding",
   "upgrade",
 ]);
+
+/**
+ * Headers that must not be forwarded to an HTTP/2 upstream. "host" is
+ * replaced by the :authority pseudo-header and the hop-by-hop headers
+ * are illegal in HTTP/2 framing.
+ */
+const H2_FORBIDDEN_UPSTREAM_HEADERS = new Set([...HOP_BY_HOP_HEADERS, "host"]);
 
 /**
  * Get the effective host value from a request.
@@ -84,15 +91,219 @@ const MAX_PROXY_HOPS = 5;
  * When `strict` is true, only exact matches are returned; unregistered
  * subdomain prefixes will not fall back to the base service.
  */
-function findRoute(
-  routes: { hostname: string; port: number }[],
-  host: string,
-  strict?: boolean
-): { hostname: string; port: number } | undefined {
+function findRoute(routes: RouteInfo[], host: string, strict?: boolean): RouteInfo | undefined {
   return (
     routes.find((r) => r.hostname === host) ||
     (strict ? undefined : routes.find((r) => host.endsWith("." + r.hostname)))
   );
+}
+
+/**
+ * Cache of h2c (cleartext HTTP/2) client sessions, keyed by "host:port".
+ * HTTP/2 multiplexes many streams over one connection, so we want to
+ * reuse the session for as long as the backend keeps it alive.
+ *
+ * The cache is module-scoped because proxy instances are long-lived and
+ * there's no meaningful per-instance isolation to protect.
+ */
+const h2cSessions = new Map<string, http2.ClientHttp2Session>();
+
+function getH2cSession(
+  host: string,
+  port: number,
+  onError: (message: string) => void
+): http2.ClientHttp2Session {
+  const key = `${host}:${port}`;
+  const existing = h2cSessions.get(key);
+  if (existing && !existing.closed && !existing.destroyed) {
+    return existing;
+  }
+
+  const session = http2.connect(`http://${host}:${port}`);
+  session.on("error", (err) => {
+    onError(`h2c session error to ${key}: ${err.message}`);
+    h2cSessions.delete(key);
+  });
+  session.on("close", () => {
+    if (h2cSessions.get(key) === session) h2cSessions.delete(key);
+  });
+  // Silently absorb session-level GOAWAY etc. so we can reconnect on the next request.
+  session.on("goaway", () => {
+    if (h2cSessions.get(key) === session) h2cSessions.delete(key);
+  });
+  h2cSessions.set(key, session);
+  return session;
+}
+
+/**
+ * Proxy a request to an h2c (HTTP/2 cleartext) backend. Required for
+ * gRPC and any backend that only speaks HTTP/2 on its non-TLS listener.
+ *
+ * Preserves bidirectional streaming, trailers (grpc-status/grpc-message),
+ * and backpressure, which are all essential for gRPC to work end-to-end.
+ */
+function proxyH2c(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  route: RouteInfo,
+  forwardedHeaders: Record<string, string>,
+  hops: number,
+  onError: (message: string) => void
+): void {
+  const session = getH2cSession("127.0.0.1", route.port, onError);
+
+  // Build HTTP/2 request headers: pseudo-headers + regular headers.
+  const h2Headers: http2.OutgoingHttpHeaders = {
+    ":method": req.method || "GET",
+    ":path": req.url || "/",
+    ":scheme": "http",
+    ":authority": `${route.hostname}:${route.port}`,
+  };
+
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (value === undefined) continue;
+    const lower = key.toLowerCase();
+    if (lower.startsWith(":")) continue;
+    if (H2_FORBIDDEN_UPSTREAM_HEADERS.has(lower)) continue;
+    h2Headers[lower] = value;
+  }
+  for (const [key, value] of Object.entries(forwardedHeaders)) {
+    h2Headers[key] = value;
+  }
+  h2Headers[PORTLESS_HOPS_HEADER] = String(hops + 1);
+
+  const stream = session.request(h2Headers, { endStream: false });
+
+  // Trailers arrive as a separate event after the body; buffer them so we
+  // can call res.addTrailers() before res.end(). Required for gRPC, which
+  // carries grpc-status/grpc-message in trailers.
+  let pendingTrailers: Record<string, string | string[]> | undefined;
+  let pendingResponseHeaders: http2.IncomingHttpHeaders | undefined;
+  let headersWritten = false;
+
+  // Extract the downstream HTTP/2 server stream (only present when the
+  // client connection is HTTP/2). We need it to emit a "trailers-only"
+  // response — a single HEADERS frame with END_STREAM — which some gRPC
+  // clients require when grpc-status is carried in initial response
+  // headers rather than trailers. Node's res.writeHead() + res.end() with
+  // no body sends HEADERS then empty DATA+END_STREAM (two frames), which
+  // violates the gRPC trailers-only wire form.
+  const downstreamStream = (res as unknown as { stream?: http2.ServerHttp2Stream }).stream;
+
+  function copyBackendHeaders(source: http2.IncomingHttpHeaders): http.OutgoingHttpHeaders {
+    const out: http.OutgoingHttpHeaders = {};
+    for (const [key, value] of Object.entries(source)) {
+      if (key.startsWith(":")) continue;
+      if (HOP_BY_HOP_HEADERS.has(key.toLowerCase())) continue;
+      if (value === undefined) continue;
+      out[key] = value as string | string[];
+    }
+    return out;
+  }
+
+  function flushResponseHeaders(status: number): void {
+    if (headersWritten || !pendingResponseHeaders) return;
+    headersWritten = true;
+    const outHeaders = copyBackendHeaders(pendingResponseHeaders);
+    res.writeHead(status, outHeaders);
+  }
+
+  stream.on("response", (responseHeaders) => {
+    pendingResponseHeaders = responseHeaders;
+    // Deliberately do NOT write headers here: we need to see whether the
+    // backend sends any DATA before END_STREAM so we can distinguish a
+    // trailers-only response from a normal one.
+  });
+
+  stream.on("trailers", (trailers) => {
+    const trailerPairs: Record<string, string | string[]> = {};
+    for (const [key, value] of Object.entries(trailers)) {
+      if (key.startsWith(":")) continue;
+      if (value === undefined) continue;
+      trailerPairs[key] = value as string | string[];
+    }
+    if (Object.keys(trailerPairs).length > 0) {
+      pendingTrailers = trailerPairs;
+    }
+  });
+
+  stream.on("data", (chunk: Buffer) => {
+    if (!headersWritten && pendingResponseHeaders) {
+      const status =
+        typeof pendingResponseHeaders[":status"] === "number"
+          ? (pendingResponseHeaders[":status"] as number)
+          : 502;
+      flushResponseHeaders(status);
+    }
+    const keepGoing = res.write(chunk);
+    if (!keepGoing) {
+      stream.pause();
+      res.once("drain", () => stream.resume());
+    }
+  });
+
+  stream.on("end", () => {
+    // Trailers-only response: backend sent HEADERS+END_STREAM with no body.
+    // Forward as a single HEADERS frame with END_STREAM to preserve gRPC
+    // semantics when grpc-status is carried inline in the headers.
+    if (!headersWritten && pendingResponseHeaders && downstreamStream) {
+      headersWritten = true;
+      const outHeaders: http2.OutgoingHttpHeaders = {};
+      for (const [key, value] of Object.entries(pendingResponseHeaders)) {
+        if (key === ":status") {
+          outHeaders[":status"] = value as unknown as number;
+          continue;
+        }
+        if (key.startsWith(":")) continue;
+        if (HOP_BY_HOP_HEADERS.has(key.toLowerCase())) continue;
+        if (value === undefined) continue;
+        outHeaders[key] = value as string | string[];
+      }
+      try {
+        downstreamStream.respond(outHeaders, { endStream: true });
+      } catch {
+        // Stream may have been destroyed already; best-effort.
+      }
+      return;
+    }
+
+    if (!headersWritten && pendingResponseHeaders) {
+      const status =
+        typeof pendingResponseHeaders[":status"] === "number"
+          ? (pendingResponseHeaders[":status"] as number)
+          : 502;
+      flushResponseHeaders(status);
+    }
+
+    if (pendingTrailers) {
+      try {
+        res.addTrailers(pendingTrailers);
+      } catch {
+        // Trailers are best-effort; HTTP/1.1 clients may not support them.
+      }
+    }
+    res.end();
+  });
+
+  stream.on("error", (err) => {
+    onError(`h2c stream error for ${getRequestHost(req)}: ${err.message}`);
+    if (!res.headersSent) {
+      res.writeHead(502, { "Content-Type": "text/plain" });
+      res.end("h2c upstream error");
+    } else {
+      res.destroy();
+    }
+  });
+
+  req.on("error", () => {
+    if (!stream.destroyed) stream.destroy();
+  });
+
+  res.on("close", () => {
+    if (!stream.destroyed) stream.destroy();
+  });
+
+  req.pipe(stream);
 }
 
 /** Server type returned by createProxyServer (plain HTTP/1.1 or net.Server TLS wrapper). */
@@ -178,6 +389,12 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
     }
 
     const forwardedHeaders = buildForwardedHeaders(req, reqTls);
+
+    if (route.protocol === "h2c") {
+      proxyH2c(req, res, route, forwardedHeaders, hops, onError);
+      return;
+    }
+
     const proxyReqHeaders: http.OutgoingHttpHeaders = { ...req.headers };
     for (const [key, value] of Object.entries(forwardedHeaders)) {
       proxyReqHeaders[key] = value;

--- a/packages/portless/src/routes.ts
+++ b/packages/portless/src/routes.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { RouteInfo } from "./types.js";
+import type { RouteInfo, UpstreamProtocol } from "./types.js";
 import { fixOwnership, isErrnoException } from "./utils.js";
 import { SYSTEM_STATE_DIR } from "./cli-utils.js";
 
@@ -34,13 +34,17 @@ export interface RouteMapping extends RouteInfo {
 
 /** Runtime check that a parsed JSON value is a valid RouteMapping. */
 function isValidRoute(value: unknown): value is RouteMapping {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    typeof (value as RouteMapping).hostname === "string" &&
-    typeof (value as RouteMapping).port === "number" &&
-    typeof (value as RouteMapping).pid === "number"
-  );
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    typeof (value as RouteMapping).hostname !== "string" ||
+    typeof (value as RouteMapping).port !== "number" ||
+    typeof (value as RouteMapping).pid !== "number"
+  ) {
+    return false;
+  }
+  const protocol = (value as RouteMapping).protocol;
+  return protocol === undefined || protocol === "http" || protocol === "h2c";
 }
 
 /**
@@ -225,7 +229,13 @@ export class RouteStore {
    * replaced. Returns the PID of the killed process (if any) so the caller can
    * log it.
    */
-  addRoute(hostname: string, port: number, pid: number, force = false): number | undefined {
+  addRoute(
+    hostname: string,
+    port: number,
+    pid: number,
+    force = false,
+    protocol?: UpstreamProtocol
+  ): number | undefined {
     this.ensureDir();
     if (!this.acquireLock()) {
       throw new Error("Failed to acquire route lock");
@@ -247,7 +257,9 @@ export class RouteStore {
         }
       }
       const filtered = routes.filter((r) => r.hostname !== hostname);
-      filtered.push({ hostname, port, pid });
+      const mapping: RouteMapping = { hostname, port, pid };
+      if (protocol && protocol !== "http") mapping.protocol = protocol;
+      filtered.push(mapping);
       this.saveRoutes(filtered);
     } finally {
       this.releaseLock();

--- a/packages/portless/src/types.ts
+++ b/packages/portless/src/types.ts
@@ -1,7 +1,18 @@
+/**
+ * Upstream protocol for a proxied route.
+ * - "http" (default): HTTP/1.1 cleartext to the backend. Works for REST,
+ *   WebSocket upgrades, and most dev servers.
+ * - "h2c": HTTP/2 cleartext to the backend. Required for gRPC and any
+ *   backend that only accepts HTTP/2 on its non-TLS listener.
+ */
+export type UpstreamProtocol = "http" | "h2c";
+
 /** Route info used by the proxy server to map hostnames to ports. */
 export interface RouteInfo {
   hostname: string;
   port: number;
+  /** Upstream protocol used to reach the backend. Defaults to "http". */
+  protocol?: UpstreamProtocol;
 }
 
 export interface ProxyServerOptions {

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -98,6 +98,16 @@ Set `PORTLESS=0` to run the command directly without the proxy:
 PORTLESS=0 pnpm dev   # Bypasses proxy, uses default port
 ```
 
+### gRPC and HTTP/2 backends
+
+Pass `--h2c` when the backend only speaks HTTP/2 cleartext (gRPC servers built with `@grpc/grpc-js` or `nice-grpc`). The proxy switches from HTTP/1.1 to HTTP/2 cleartext on the upstream leg and preserves bidirectional streaming and response trailers:
+
+```bash
+portless grpc-svc --h2c tsx server.ts
+```
+
+Without `--h2c`, portless forwards over HTTP/1.1 and an HTTP/2-only backend will refuse the connection.
+
 ## How It Works
 
 1. `portless proxy start` starts an HTTPS reverse proxy on port 443 as a background daemon. Auto-elevates with sudo on macOS/Linux; falls back to port 1355 if sudo is unavailable. Use `--no-tls` for plain HTTP on port 80. Configurable with `-p` / `--port` or the `PORTLESS_PORT` env var. The proxy also auto-starts when you run an app.
@@ -196,6 +206,7 @@ LAN mode depends on the system mDNS helpers that portless launches: macOS includ
 | `portless hosts clean`                 | Remove portless entries from /etc/hosts                        |
 | `portless <name> --app-port <n> <cmd>` | Use a fixed port for the app instead of auto-assignment        |
 | `portless <name> --force <cmd>`        | Kill the existing process and take over its route              |
+| `portless <name> --h2c <cmd>`          | Speak HTTP/2 cleartext to the backend (required for gRPC)      |
 | `portless --name <name> <cmd>`         | Force `<name>` as app name (bypasses subcommand dispatch)      |
 | `portless <name> -- <cmd> [args...]`   | Stop flag parsing; everything after `--` is passed to child    |
 | `portless --help` / `-h`               | Show help                                                      |


### PR DESCRIPTION
## Why

  Running a gRPC backend locally under portless currently fails: portless forwards over HTTP/1.1, the backend refuses the connection, and the user sees opaque 502s. This PR adds an opt-in `--h2c` flag that switches the upstream leg to HTTP/2 cleartext so these backends work
  end to end.

  ## Summary

  - Add `--h2c` flag to tell portless to speak HTTP/2 cleartext to the backend. Required for gRPC and any HTTP/2-only backend.
  - Proxy `h2c` routes via a new `proxyH2c` path that preserves bidirectional streaming, response trailers (`grpc-status`, `grpc-message`), and the trailers-only wire form (single HEADERS+END_STREAM frame) that some gRPC clients require.
  - Cache an `http2.ClientHttp2Session` per `host:port`; clear it on `goaway`/`close`/`error` so the next request reconnects cleanly.
  - Persist the protocol in the route store (`protocol: "h2c"`), so the proxy dispatches the right path after a restart.
  - Update `README.md`, `skills/portless/SKILL.md`, and the `--help` output per AGENTS.md.

  ## Non-goals

  - Auto-detection. The flag is explicit; portless does not probe backends for HTTP/2 support.
  - HTTPS-to-backend (`h2`). Scope is cleartext HTTP/2 only, which covers dev servers bound to a plain port.
  - Trailers over HTTP/1.1 downstream. gRPC clients are HTTP/2 in practice; the HTTP/1.1 path uses `res.addTrailers` best-effort.

  ## Backwards compatibility

  The HTTP/1.1 proxy path is unchanged. `proxyH2c` is dispatched only when a route has `protocol: "h2c"`, which is set solely by the new `--h2c` flag.

  ## Usage

  portless grpc-svc --h2c tsx server.ts

  ## Manual verification

  Tested end to end against this branch. The child command itself runs the h2c server on portless's assigned `$PORT`:

  ```bash
  export PORTLESS_PORT=1355 PORTLESS_HTTPS=0 PORTLESS_SYNC_HOSTS=0

  # Start an h2c server as the portless child; response echoes :authority
  portless grpc-svc --h2c node -e 'require("http2").createServer().on("stream",(s,h)=>{s.respond({":status":200});s.end("authority: "+h[":authority"])}).listen(process.env.PORT)' &

  # In another shell
  curl --resolve grpc-svc.localhost:1355:127.0.0.1 http://grpc-svc.localhost:1355/
  # => authority: grpc-svc.localhost:<backend-port>

  The echoed :authority matches <hostname>:<backend-port> from portless list, confirming the request was dispatched through proxyH2c with the correct pseudo-headers.
```
  Test plan

  - 14 new tests in proxy.test.ts covering dispatch, :authority rewrite, Host/hop-by-hop stripping, X-Forwarded-* forwarding, POST body, hops increment, 502 on unreachable backend, session reuse, session reconnect after close, mixed http/h2c routes, non-200 status
  propagation, multi-chunk streaming, gRPC trailers (HTTP/2 client), and gRPC trailers-only wire form.
  - Full suite passes (418 tests); tsc --noEmit and eslint clean.## Why

  Running a gRPC backend locally under portless currently fails: portless forwards over HTTP/1.1, the backend refuses the connection, and the user sees opaque 502s. This PR adds an opt-in `--h2c` flag that switches the upstream leg to HTTP/2 cleartext so these backends work
  end to end.

  ## Summary

  - Add `--h2c` flag to tell portless to speak HTTP/2 cleartext to the backend. Required for gRPC and any HTTP/2-only backend.
  - Proxy `h2c` routes via a new `proxyH2c` path that preserves bidirectional streaming, response trailers (`grpc-status`, `grpc-message`), and the trailers-only wire form (single HEADERS+END_STREAM frame) that some gRPC clients require.
  - Cache an `http2.ClientHttp2Session` per `host:port`; clear it on `goaway`/`close`/`error` so the next request reconnects cleanly.
  - Persist the protocol in the route store (`protocol: "h2c"`), so the proxy dispatches the right path after a restart.
  - Update `README.md`, `skills/portless/SKILL.md`, and the `--help` output per AGENTS.md.

  ## Non-goals

  - Auto-detection. The flag is explicit; portless does not probe backends for HTTP/2 support.
  - HTTPS-to-backend (`h2`). Scope is cleartext HTTP/2 only, which covers dev servers bound to a plain port.
  - Trailers over HTTP/1.1 downstream. gRPC clients are HTTP/2 in practice; the HTTP/1.1 path uses `res.addTrailers` best-effort.

  ## Backwards compatibility

  The HTTP/1.1 proxy path is unchanged. `proxyH2c` is dispatched only when a route has `protocol: "h2c"`, which is set solely by the new `--h2c` flag.

  ## Usage

  portless grpc-svc --h2c tsx server.ts

  ## Manual verification

  Tested end to end against this branch. The child command itself runs the h2c server on portless's assigned `$PORT`:

  ```bash
  export PORTLESS_PORT=1355 PORTLESS_HTTPS=0 PORTLESS_SYNC_HOSTS=0

  # Start an h2c server as the portless child; response echoes :authority
  portless grpc-svc --h2c node -e 'require("http2").createServer().on("stream",(s,h)=>{s.respond({":status":200});s.end("authority: "+h[":authority"])}).listen(process.env.PORT)' &

  # In another shell
  curl --resolve grpc-svc.localhost:1355:127.0.0.1 http://grpc-svc.localhost:1355/
  # => authority: grpc-svc.localhost:<backend-port>

  The echoed :authority matches <hostname>:<backend-port> from portless list, confirming the request was dispatched through proxyH2c with the correct pseudo-headers.
```
  Test plan

  - 14 new tests in proxy.test.ts covering dispatch, :authority rewrite, Host/hop-by-hop stripping, X-Forwarded-* forwarding, POST body, hops increment, 502 on unreachable backend, session reuse, session reconnect after close, mixed http/h2c routes, non-200 status
  propagation, multi-chunk streaming, gRPC trailers (HTTP/2 client), and gRPC trailers-only wire form.
  - Full suite passes (418 tests); tsc --noEmit and eslint clean.## Why

  Running a gRPC backend locally under portless currently fails: portless forwards over HTTP/1.1, the backend refuses the connection, and the user sees opaque 502s. This PR adds an opt-in `--h2c` flag that switches the upstream leg to HTTP/2 cleartext so these backends work
  end to end.

  ## Summary

  - Add `--h2c` flag to tell portless to speak HTTP/2 cleartext to the backend. Required for gRPC and any HTTP/2-only backend.
  - Proxy `h2c` routes via a new `proxyH2c` path that preserves bidirectional streaming, response trailers (`grpc-status`, `grpc-message`), and the trailers-only wire form (single HEADERS+END_STREAM frame) that some gRPC clients require.
  - Cache an `http2.ClientHttp2Session` per `host:port`; clear it on `goaway`/`close`/`error` so the next request reconnects cleanly.
  - Persist the protocol in the route store (`protocol: "h2c"`), so the proxy dispatches the right path after a restart.
  - Update `README.md`, `skills/portless/SKILL.md`, and the `--help` output per AGENTS.md.

  ## Non-goals

  - Auto-detection. The flag is explicit; portless does not probe backends for HTTP/2 support.
  - HTTPS-to-backend (`h2`). Scope is cleartext HTTP/2 only, which covers dev servers bound to a plain port.
  - Trailers over HTTP/1.1 downstream. gRPC clients are HTTP/2 in practice; the HTTP/1.1 path uses `res.addTrailers` best-effort.

  ## Backwards compatibility

  The HTTP/1.1 proxy path is unchanged. `proxyH2c` is dispatched only when a route has `protocol: "h2c"`, which is set solely by the new `--h2c` flag.

  ## Usage

  portless grpc-svc --h2c tsx server.ts

  ## Manual verification

  Tested end to end against this branch. The child command itself runs the h2c server on portless's assigned `$PORT`:

  ```bash
  export PORTLESS_PORT=1355 PORTLESS_HTTPS=0 PORTLESS_SYNC_HOSTS=0

  # Start an h2c server as the portless child; response echoes :authority
  portless grpc-svc --h2c node -e 'require("http2").createServer().on("stream",(s,h)=>{s.respond({":status":200});s.end("authority: "+h[":authority"])}).listen(process.env.PORT)' &

  # In another shell
  curl --resolve grpc-svc.localhost:1355:127.0.0.1 http://grpc-svc.localhost:1355/
  # => authority: grpc-svc.localhost:<backend-port>

  The echoed :authority matches <hostname>:<backend-port> from portless list, confirming the request was dispatched through proxyH2c with the correct pseudo-headers.
```
  Test plan

  - 14 new tests in proxy.test.ts covering dispatch, :authority rewrite, Host/hop-by-hop stripping, X-Forwarded-* forwarding, POST body, hops increment, 502 on unreachable backend, session reuse, session reconnect after close, mixed http/h2c routes, non-200 status
  propagation, multi-chunk streaming, gRPC trailers (HTTP/2 client), and gRPC trailers-only wire form.
  - Full suite passes (418 tests); tsc --noEmit and eslint clean.