### PR TITLE
fix: only inject portless Node dir into PATH on Windows

### DIFF
--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -710,11 +710,15 @@ function augmentedPath(env: NodeJS.ProcessEnv | undefined): string {
   // process.env but case-sensitive in plain objects created via spread).
   const base = source.PATH ?? source.Path ?? "";
   const bins = collectBinPaths(process.cwd());
-  // Ensure node's own directory is in PATH so .cmd wrappers in node_modules/.bin
-  // can locate the node executable (fixes Windows "node not recognized" errors).
-  const nodeBin = path.dirname(process.execPath);
-  const allBins = [...bins, nodeBin];
-  return allBins.join(path.delimiter) + path.delimiter + base;
+  // On Windows, append node's own directory so .cmd wrappers in node_modules/.bin
+  // can locate the node executable (fixes "node not recognized" errors).
+  // On Unix-like systems, skip this: the user's version manager (nvm/fnm/asdf/mise)
+  // already puts their preferred Node first in PATH, and prepending portless's own
+  // Node directory would shadow it, breaking setups that expect a specific version.
+  if (isWindows) {
+    bins.push(path.dirname(process.execPath));
+  }
+  return bins.join(path.delimiter) + path.delimiter + base;
 }
 
 /**


### PR DESCRIPTION
Fixes #241

## Problem

`augmentedPath` in `cli-utils.ts` unconditionally prepends `path.dirname(process.execPath)` to the `PATH` of every child process spawned by portless. When portless is installed via Homebrew (or any tool that uses its own Node), this places portless's Node binary directory before the user's PATH entries, shadowing the version they've configured through their version manager (nvm/fnm/asdf/mise).

Example from the issue:
```
$ node --version
v24.13.0           # asdf-managed LTS

$ portless myapp sh -c 'node --version'
v25.9.0            # Homebrew's node, injected by portless
```

## Solution

Restrict the `nodeBin` injection to Windows only. The comment in the original code already explains it's a Windows-specific need — `.cmd` wrappers in `node_modules/.bin` require `node` to be resolvable via PATH on Windows. On Unix-like systems (macOS/Linux), the user's version manager already places their preferred Node first in PATH, so adding portless's Node directory is both unnecessary and harmful.

## Testing

- On macOS/Linux: `portless run sh -c 'node --version'` now returns the user's version-manager Node, not portless's bundled Node.
- On Windows: behavior is unchanged — `.cmd` wrappers in `node_modules/.bin` still find `node` correctly.
- Existing test suite passes.