### PR TITLE
Harden release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 jobs:
   check-release:
@@ -29,7 +28,7 @@ jobs:
           LOCAL_VERSION=$(node -p "require('./packages/portless/package.json').version")
           echo "Local version: $LOCAL_VERSION"
 
-          NPM_VERSION=$(npm view portless version 2>/dev/null || echo "0.0.0")
+          NPM_VERSION=$(npm view portless version)
           echo "Registry version: $NPM_VERSION"
 
           if [ "$LOCAL_VERSION" != "$NPM_VERSION" ]; then
@@ -46,6 +45,10 @@ jobs:
     needs: check-release
     if: needs.check-release.outputs.should_release == 'true'
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -75,6 +78,8 @@ jobs:
     needs: [check-release, publish]
     if: needs.check-release.outputs.should_release == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
     needs: check-release
     if: needs.check-release.outputs.should_release == 'true'
     runs-on: ubuntu-latest
-    environment: release
+    environment: Release
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary
- Scope release workflow permissions to the jobs that need them.
- Bind npm publishing to the GitHub `release` environment for trusted publishing.
- Fail the release check if npm registry version lookup fails.