### PR TITLE
Config file support, zero-arg mode, and multi-app orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,26 +40,23 @@ In non-interactive environments (no TTY, or `CI=1`), portless exits with a descr
 
 ## Configuration
 
-Create a `portless.json` to enable zero-arg mode. Your `package.json` scripts stay portless-free:
+Bare `portless` works out of the box. It runs the `"dev"` script from `package.json` through the proxy, inferring the app name from the package name, git root, or directory:
 
-**portless.json:**
+```bash
+portless        # -> runs "dev" script, https://<project>.localhost
+```
+
+Use an optional `portless.json` to override defaults:
 
 ```json
 { "name": "myapp" }
 ```
 
-**package.json:**
-
-```json
-{ "scripts": { "dev": "next dev" } }
-```
-
 ```bash
-portless        # -> reads config, runs "dev" script, https://myapp.localhost
-pnpm dev        # -> works without portless, plain "next dev"
+portless        # -> runs "dev" script, https://myapp.localhost
 ```
 
-The name is inferred from `package.json` if not set in config. The script defaults to `"dev"`.
+The script defaults to `"dev"`. The name is inferred from `package.json` if not set in config.
 
 ### Monorepo
 
@@ -282,7 +279,7 @@ LAN mode depends on the system mDNS tools that portless already spawns: macOS sh
 ## Commands
 
 ```bash
-portless                        # With portless.json: run dev script through proxy
+portless                        # Run dev script through proxy
 portless                        # From monorepo root: run all workspace packages
 portless run [--name <name>] [cmd] [args...]  # Infer name, run through proxy
 portless <name> <cmd> [args...]  # Run app at https://<name>.localhost

--- a/README.md
+++ b/README.md
@@ -83,12 +83,13 @@ The `apps` map is optional and only needed for name overrides. Packages not list
 
 ### Config fields
 
-| Field     | Type   | Default  | Description                                               |
-| --------- | ------ | -------- | --------------------------------------------------------- |
-| `name`    | string | inferred | Base app name. Worktree prefix still applies.             |
-| `script`  | string | `"dev"`  | Name of a `package.json` script to run.                   |
-| `appPort` | number | auto     | Fixed port for the child process.                         |
-| `apps`    | object |          | Overrides for workspace packages, keyed by relative path. |
+| Field     | Type    | Default  | Description                                               |
+| --------- | ------- | -------- | --------------------------------------------------------- |
+| `name`    | string  | inferred | Base app name. Worktree prefix still applies.             |
+| `script`  | string  | `"dev"`  | Name of a `package.json` script to run.                   |
+| `appPort` | number  | auto     | Fixed port for the child process.                         |
+| `proxy`   | boolean | auto     | Whether to route through the proxy. Auto-detected.        |
+| `apps`    | object  |          | Overrides for workspace packages, keyed by relative path. |
 
 ### --script flag
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The name is inferred from `package.json` if not set in config. The script defaul
 
 ### Monorepo
 
-One `portless.json` at the repo root covers all workspace packages. Portless reads `pnpm-workspace.yaml` to discover packages:
+One `portless.json` at the repo root covers all workspace packages. Portless discovers packages from `pnpm-workspace.yaml`, or the `"workspaces"` field in `package.json` (npm, yarn, bun):
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -38,7 +38,68 @@ When auto-starting, portless reuses the configuration (port, TLS, TLD) from the 
 
 In non-interactive environments (no TTY, or `CI=1`), portless exits with a descriptive error instead of prompting, so task runners like turborepo and CI scripts fail early with a clear message.
 
+## Configuration
+
+Create a `portless.json` to enable zero-arg mode. Your `package.json` scripts stay portless-free:
+
+```json
+// portless.json
+{ "name": "myapp" }
+```
+
+```json
+// package.json
+{ "scripts": { "dev": "next dev" } }
+```
+
+```bash
+portless        # -> reads config, runs "dev" script, https://myapp.localhost
+pnpm dev        # -> works without portless, plain "next dev"
+```
+
+The name is inferred from `package.json` if not set in config. The script defaults to `"dev"`.
+
+### Monorepo
+
+One `portless.json` at the repo root covers all workspace packages. Portless reads `pnpm-workspace.yaml` to discover packages:
+
+```json
+{
+  "apps": {
+    "apps/web": { "name": "myapp" },
+    "apps/api": { "name": "api.myapp" }
+  }
+}
+```
+
+```bash
+portless        # from repo root: starts all workspace packages with a "dev" script
+cd apps/web && portless   # start just one package
+```
+
+The `apps` map is optional and only needed for name overrides. Packages not listed still auto-discover with names inferred from their `package.json`.
+
+### Config fields
+
+| Field     | Type   | Default  | Description                                               |
+| --------- | ------ | -------- | --------------------------------------------------------- |
+| `name`    | string | inferred | Base app name. Worktree prefix still applies.             |
+| `script`  | string | `"dev"`  | Name of a `package.json` script to run.                   |
+| `appPort` | number | auto     | Fixed port for the child process.                         |
+| `apps`    | object |          | Overrides for workspace packages, keyed by relative path. |
+
+### --script flag
+
+Override the default script for a single invocation:
+
+```bash
+portless --script start       # run "start" instead of "dev"
+portless --script test        # run "test" instead of "dev"
+```
+
 ## Use in package.json
+
+You can still use portless in `package.json` scripts:
 
 ```json
 {
@@ -47,6 +108,18 @@ In non-interactive environments (no TTY, or `CI=1`), portless exits with a descr
   }
 }
 ```
+
+With a `portless.json`, you can simplify to:
+
+```json
+{
+  "scripts": {
+    "dev": "next dev"
+  }
+}
+```
+
+Then run `portless` or `portless run` to go through the proxy.
 
 ## Subdomains
 
@@ -163,7 +236,9 @@ LAN mode depends on the system mDNS tools that portless already spawns: macOS sh
 ## Commands
 
 ```bash
-portless run [--name <name>] <cmd> [args...]  # Infer name (or override with --name), run through proxy
+portless                        # With portless.json: run dev script through proxy
+portless                        # From monorepo root: run all workspace packages
+portless run [--name <name>] [cmd] [args...]  # Infer name, run through proxy
 portless <name> <cmd> [args...]  # Run app at https://<name>.localhost
 portless alias <name> <port>     # Register a static route (e.g. for Docker)
 portless alias <name> <port> --force  # Overwrite an existing route
@@ -200,6 +275,7 @@ portless proxy stop              # Stop the proxy
 --foreground                     Run proxy in foreground instead of daemon
 --tld <tld>                      Use a custom TLD instead of .localhost (e.g. test)
 --wildcard                       Allow unregistered subdomains to fall back to parent route
+--script <name>                  Run a specific package.json script (default: dev)
 --app-port <number>              Use a fixed port for the app (skip auto-assignment)
 --force                          Kill the existing process and take over its route
 --name <name>                    Use <name> as the app name

--- a/README.md
+++ b/README.md
@@ -100,6 +100,24 @@ portless --script start       # run "start" instead of "dev"
 portless --script test        # run "test" instead of "dev"
 ```
 
+### Turborepo
+
+To use portless with turborepo, put `portless` as the `dev` script and the real command in a separate script:
+
+```json
+{
+  "scripts": {
+    "dev": "portless",
+    "dev:app": "next dev"
+  },
+  "portless": { "name": "myapp", "script": "dev:app" }
+}
+```
+
+Turbo runs each package's `dev` script, which invokes portless. Portless reads the config, detects the package manager, and runs `pnpm run dev:app` (or yarn/bun/npm) through the proxy. No changes to `turbo.json` are needed.
+
+`pnpm dev` at the root works through turbo as usual. People without portless can run `pnpm run dev:app` directly.
+
 ## Use in package.json
 
 You can still use portless in `package.json` scripts:

--- a/README.md
+++ b/README.md
@@ -42,13 +42,15 @@ In non-interactive environments (no TTY, or `CI=1`), portless exits with a descr
 
 Create a `portless.json` to enable zero-arg mode. Your `package.json` scripts stay portless-free:
 
+**portless.json:**
+
 ```json
-// portless.json
 { "name": "myapp" }
 ```
 
+**package.json:**
+
 ```json
-// package.json
 { "scripts": { "dev": "next dev" } }
 ```
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ cd apps/web && portless   # start just one package
 
 The `apps` map is optional and only needed for name overrides. Packages not listed still auto-discover with names inferred from their `package.json`.
 
+Without an `apps` map, hostnames follow the `<package>.<project>.localhost` convention. The project name comes from the most common npm scope across workspace packages (e.g. `@myorg/web` and `@myorg/api` produce `myorg`), falling back to the workspace root directory name. If a package's short name matches the project name, it gets the bare `<project>.localhost` without duplication.
+
 ### Config fields
 
 | Field     | Type    | Default  | Description                                               |
@@ -90,6 +92,29 @@ The `apps` map is optional and only needed for name overrides. Packages not list
 | `appPort` | number  | auto     | Fixed port for the child process.                         |
 | `proxy`   | boolean | auto     | Whether to route through the proxy. Auto-detected.        |
 | `apps`    | object  |          | Overrides for workspace packages, keyed by relative path. |
+| `turbo`   | boolean | `true`   | Set `false` to use direct spawning instead of turborepo.  |
+
+### package.json "portless" key
+
+Instead of a separate `portless.json`, you can add a `"portless"` key to your `package.json`. A string value is shorthand for setting the name:
+
+```json
+{
+  "name": "@myorg/web",
+  "portless": "myapp"
+}
+```
+
+An object supports all per-app fields (`name`, `script`, `appPort`, `proxy`):
+
+```json
+{
+  "name": "@myorg/web",
+  "portless": { "name": "myapp", "script": "dev:app" }
+}
+```
+
+The `package.json` `"portless"` key takes precedence over `portless.json` app entries but is overridden by CLI flags.
 
 ### --script flag
 
@@ -377,7 +402,7 @@ devServer: {
 }
 ```
 
-Portless automatically sets `NODE_EXTRA_CA_CERTS` in child processes so Node.js trusts the portless CA. If you run a separate Node.js process outside portless, point it at the CA manually: `NODE_EXTRA_CA_CERTS=/tmp/portless/ca.pem` (or `~/.portless/ca.pem` when the proxy runs on a non-privileged port like 1355). Alternatively, use `--no-tls` for plain HTTP.
+Portless automatically sets `NODE_EXTRA_CA_CERTS` in child processes so Node.js trusts the portless CA. If you run a separate Node.js process outside portless, point it at the CA manually: `NODE_EXTRA_CA_CERTS=~/.portless/ca.pem`. Alternatively, use `--no-tls` for plain HTTP.
 
 Portless detects this misconfiguration and responds with `508 Loop Detected` along with a message pointing to this fix.
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "portless portless next dev",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start"
   },

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@portless/docs",
   "version": "0.0.0",
+  "portless": "portless",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/docs/src/app/commands/page.mdx
+++ b/apps/docs/src/app/commands/page.mdx
@@ -6,15 +6,15 @@
 portless
 ```
 
-With a `portless.json` in the current directory, runs the configured script (default: `"dev"`) through the proxy. From a monorepo root (detected via `pnpm-workspace.yaml` or `package.json` `"workspaces"`), starts all workspace packages that have the target script.
+Runs the `"dev"` script from `package.json` through the proxy. The app name is inferred from the package name, git root, or directory name. From a monorepo root (detected via `pnpm-workspace.yaml` or `package.json` `"workspaces"`), starts all workspace packages that have the target script.
 
 ```bash
-portless                      # single app (with portless.json)
+portless                      # single app: run dev script
 portless                      # monorepo root: start all apps
 portless --script start       # run "start" instead of "dev"
 ```
 
-See [Configuration](/configuration) for `portless.json` setup.
+Use a `portless.json` to override defaults. See [Configuration](/configuration).
 
 ## Run an app
 
@@ -23,12 +23,12 @@ portless run [--name <name>] [cmd] [args...]
 portless <name> <cmd> [args...]
 ```
 
-`portless run` infers the project name from `portless.json`, `package.json`, git root, or directory name. When no command is given and a `portless.json` exists, runs the configured script (default: `"dev"`). Use `--name` to override the inferred name while still applying worktree prefixes.
+`portless run` infers the project name from `portless.json`, `package.json`, git root, or directory name. When no command is given, runs the configured script (default: `"dev"`) from `package.json`. Use `--name` to override the inferred name while still applying worktree prefixes.
 
 `portless <name>` uses an explicit name with no inference or prefixing.
 
 ```bash
-portless run                             # with portless.json: run dev script
+portless run                             # run dev script through proxy
 portless run next dev                    # infer name from project
 portless run --name myapp next dev       # override inferred name
 portless myapp next dev                  # explicit name

--- a/apps/docs/src/app/commands/page.mdx
+++ b/apps/docs/src/app/commands/page.mdx
@@ -6,7 +6,7 @@
 portless
 ```
 
-With a `portless.json` in the current directory, runs the configured script (default: `"dev"`) through the proxy. From a monorepo root (with `pnpm-workspace.yaml`), starts all workspace packages that have the target script.
+With a `portless.json` in the current directory, runs the configured script (default: `"dev"`) through the proxy. From a monorepo root (detected via `pnpm-workspace.yaml` or `package.json` `"workspaces"`), starts all workspace packages that have the target script.
 
 ```bash
 portless                      # single app (with portless.json)

--- a/apps/docs/src/app/commands/page.mdx
+++ b/apps/docs/src/app/commands/page.mdx
@@ -6,7 +6,7 @@
 portless
 ```
 
-With a `portless.json` in the current or parent directory, runs the configured script (default: `"dev"`) through the proxy. From a monorepo root (with `pnpm-workspace.yaml`), starts all workspace packages that have the target script.
+With a `portless.json` in the current directory, runs the configured script (default: `"dev"`) through the proxy. From a monorepo root (with `pnpm-workspace.yaml`), starts all workspace packages that have the target script.
 
 ```bash
 portless                      # single app (with portless.json)

--- a/apps/docs/src/app/commands/page.mdx
+++ b/apps/docs/src/app/commands/page.mdx
@@ -1,17 +1,34 @@
 # Commands
 
+## Zero-arg mode
+
+```bash
+portless
+```
+
+With a `portless.json` in the current or parent directory, runs the configured script (default: `"dev"`) through the proxy. From a monorepo root (with `pnpm-workspace.yaml`), starts all workspace packages that have the target script.
+
+```bash
+portless                      # single app (with portless.json)
+portless                      # monorepo root: start all apps
+portless --script start       # run "start" instead of "dev"
+```
+
+See [Configuration](/configuration) for `portless.json` setup.
+
 ## Run an app
 
 ```bash
-portless run [--name <name>] <cmd> [args...]
+portless run [--name <name>] [cmd] [args...]
 portless <name> <cmd> [args...]
 ```
 
-`portless run` infers the project name from package.json, git root, or directory name. Use `--name` to override the inferred name while still applying worktree prefixes.
+`portless run` infers the project name from `portless.json`, `package.json`, git root, or directory name. When no command is given and a `portless.json` exists, runs the configured script (default: `"dev"`). Use `--name` to override the inferred name while still applying worktree prefixes.
 
 `portless <name>` uses an explicit name with no inference or prefixing.
 
 ```bash
+portless run                             # with portless.json: run dev script
 portless run next dev                    # infer name from project
 portless run --name myapp next dev       # override inferred name
 portless myapp next dev                  # explicit name
@@ -32,8 +49,12 @@ portless docs.myapp next dev
       <td>Override the inferred base name (worktree prefix still applies). Only for `portless run`.</td>
     </tr>
     <tr>
+      <td>`--script <name>`</td>
+      <td>Run a specific `package.json` script instead of the default (`"dev"`). Global flag.</td>
+    </tr>
+    <tr>
       <td>`--app-port <number>`</td>
-      <td>Use a fixed port for the app instead of auto-assignment. Also configurable via `PORTLESS_APP_PORT`.</td>
+      <td>Use a fixed port for the app instead of auto-assignment. Also configurable via `PORTLESS_APP_PORT` or `portless.json`.</td>
     </tr>
     <tr>
       <td>`--force`</td>

--- a/apps/docs/src/app/configuration/page.mdx
+++ b/apps/docs/src/app/configuration/page.mdx
@@ -72,7 +72,7 @@ Each `apps` entry has the same shape (`name`, `script`, `appPort`, `proxy`). Whe
 
 ### Monorepo
 
-For pnpm workspaces, one `portless.json` at the repo root covers all packages. Portless reads `pnpm-workspace.yaml` to discover them:
+One `portless.json` at the repo root covers all workspace packages. Portless discovers packages from `pnpm-workspace.yaml`, or the `"workspaces"` field in `package.json` (npm, yarn, bun):
 
 ```json
 {

--- a/apps/docs/src/app/configuration/page.mdx
+++ b/apps/docs/src/app/configuration/page.mdx
@@ -54,6 +54,12 @@ Without a `portless.json`, the name is inferred from `package.json` and the scri
       <td>Fixed port for the child process.</td>
     </tr>
     <tr>
+      <td>`proxy`</td>
+      <td>boolean</td>
+      <td>auto</td>
+      <td>Whether to route through the proxy. Auto-detected from the command; set `false` for non-server scripts.</td>
+    </tr>
+    <tr>
       <td>`apps`</td>
       <td>object</td>
       <td></td>
@@ -62,7 +68,7 @@ Without a `portless.json`, the name is inferred from `package.json` and the scri
   </tbody>
 </table>
 
-Each `apps` entry has the same shape (`name`, `script`, `appPort`). When `apps` is present, top-level fields apply only in single-app mode.
+Each `apps` entry has the same shape (`name`, `script`, `appPort`, `proxy`). When `apps` is present, top-level fields apply only in single-app mode.
 
 ### Monorepo
 
@@ -87,11 +93,13 @@ The `apps` map is optional and only needed for overrides. Packages not listed st
 
 ### Precedence
 
-For `name`: CLI `--name` flag > `portless.json` > `package.json` inference.
+Closest config wins, like Prettier and ESLint:
 
-For `script`: CLI `--script` flag > `portless.json` > default `"dev"`.
+For `name`: CLI `--name` flag > `package.json` `"portless"` key > `portless.json` app entry > `package.json` inference.
 
-For `appPort`: CLI `--app-port` flag > `PORTLESS_APP_PORT` env var > `portless.json` > auto-assigned.
+For `script`: CLI `--script` flag > `package.json` `"portless"` key > `portless.json` app entry > default `"dev"`.
+
+For `appPort`: CLI `--app-port` flag > `PORTLESS_APP_PORT` env var > `package.json` `"portless"` key > `portless.json` app entry > auto-assigned.
 
 ## Environment variables
 

--- a/apps/docs/src/app/configuration/page.mdx
+++ b/apps/docs/src/app/configuration/page.mdx
@@ -57,7 +57,10 @@ Without a `portless.json`, the name is inferred from `package.json` and the scri
       <td>`proxy`</td>
       <td>boolean</td>
       <td>auto</td>
-      <td>Whether to route through the proxy. Auto-detected from the command; set `false` for non-server scripts.</td>
+      <td>
+        Whether to route through the proxy. Auto-detected from the command; set `false` for
+        non-server scripts.
+      </td>
     </tr>
     <tr>
       <td>`apps`</td>

--- a/apps/docs/src/app/configuration/page.mdx
+++ b/apps/docs/src/app/configuration/page.mdx
@@ -1,27 +1,24 @@
 # Configuration
 
+Bare `portless` works out of the box. It runs the `"dev"` script from `package.json` through the proxy, inferring the app name from the package name, git root, or directory:
+
+```bash
+portless        # runs "dev" script, https://<project>.localhost
+```
+
 ## portless.json
 
-Create an optional `portless.json` to enable zero-arg mode. Your `package.json` scripts stay portless-free:
-
-**portless.json:**
+Use an optional `portless.json` to override defaults:
 
 ```json
 { "name": "myapp" }
 ```
 
-**package.json:**
-
-```json
-{ "scripts": { "dev": "next dev" } }
-```
-
 ```bash
-portless        # reads config, runs "dev" script, https://myapp.localhost
-pnpm dev        # works without portless, plain "next dev"
+portless        # runs "dev" script, https://myapp.localhost
 ```
 
-Without a `portless.json`, the name is inferred from `package.json` and the script defaults to `"dev"`.
+The name is inferred from `package.json` if not set in config. The script defaults to `"dev"`.
 
 ### Fields
 

--- a/apps/docs/src/app/configuration/page.mdx
+++ b/apps/docs/src/app/configuration/page.mdx
@@ -4,13 +4,15 @@
 
 Create an optional `portless.json` to enable zero-arg mode. Your `package.json` scripts stay portless-free:
 
+**portless.json:**
+
 ```json
-// portless.json
 { "name": "myapp" }
 ```
 
+**package.json:**
+
 ```json
-// package.json
 { "scripts": { "dev": "next dev" } }
 ```
 

--- a/apps/docs/src/app/configuration/page.mdx
+++ b/apps/docs/src/app/configuration/page.mdx
@@ -91,6 +91,24 @@ portless --script start   # run "start" instead of "dev"
 
 The `apps` map is optional and only needed for overrides. Packages not listed still auto-discover with names inferred from their `package.json`.
 
+### Turborepo
+
+For turborepo projects, use `portless` as the `dev` script and the real command in a separate script:
+
+```json
+{
+  "scripts": {
+    "dev": "portless",
+    "dev:app": "next dev"
+  },
+  "portless": { "name": "myapp", "script": "dev:app" }
+}
+```
+
+`pnpm dev` at the root runs turbo, which runs `portless` in each package. Portless detects the package manager and runs `pnpm run dev:app` through the proxy. No `turbo.json` changes are needed.
+
+People without portless installed can run `pnpm run dev:app` directly.
+
 ### Precedence
 
 Closest config wins, like Prettier and ESLint:

--- a/apps/docs/src/app/configuration/page.mdx
+++ b/apps/docs/src/app/configuration/page.mdx
@@ -1,6 +1,95 @@
 # Configuration
 
-Portless is configured through environment variables. No config files needed.
+## portless.json
+
+Create an optional `portless.json` to enable zero-arg mode. Your `package.json` scripts stay portless-free:
+
+```json
+// portless.json
+{ "name": "myapp" }
+```
+
+```json
+// package.json
+{ "scripts": { "dev": "next dev" } }
+```
+
+```bash
+portless        # reads config, runs "dev" script, https://myapp.localhost
+pnpm dev        # works without portless, plain "next dev"
+```
+
+Without a `portless.json`, the name is inferred from `package.json` and the script defaults to `"dev"`.
+
+### Fields
+
+<table>
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Type</th>
+      <th>Default</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`name`</td>
+      <td>string</td>
+      <td>inferred</td>
+      <td>Base app name. Worktree prefix still applies.</td>
+    </tr>
+    <tr>
+      <td>`script`</td>
+      <td>string</td>
+      <td>`"dev"`</td>
+      <td>Name of a `package.json` script to run.</td>
+    </tr>
+    <tr>
+      <td>`appPort`</td>
+      <td>number</td>
+      <td>auto</td>
+      <td>Fixed port for the child process.</td>
+    </tr>
+    <tr>
+      <td>`apps`</td>
+      <td>object</td>
+      <td></td>
+      <td>Overrides for workspace packages, keyed by relative path.</td>
+    </tr>
+  </tbody>
+</table>
+
+Each `apps` entry has the same shape (`name`, `script`, `appPort`). When `apps` is present, top-level fields apply only in single-app mode.
+
+### Monorepo
+
+For pnpm workspaces, one `portless.json` at the repo root covers all packages. Portless reads `pnpm-workspace.yaml` to discover them:
+
+```json
+{
+  "apps": {
+    "apps/web": { "name": "myapp" },
+    "apps/api": { "name": "api.myapp" }
+  }
+}
+```
+
+```bash
+portless                  # from repo root: start all packages with a "dev" script
+cd apps/web && portless   # start just one package
+portless --script start   # run "start" instead of "dev"
+```
+
+The `apps` map is optional and only needed for overrides. Packages not listed still auto-discover with names inferred from their `package.json`.
+
+### Precedence
+
+For `name`: CLI `--name` flag > `portless.json` > `package.json` inference.
+
+For `script`: CLI `--script` flag > `portless.json` > default `"dev"`.
+
+For `appPort`: CLI `--app-port` flag > `PORTLESS_APP_PORT` env var > `portless.json` > auto-assigned.
 
 ## Environment variables
 

--- a/apps/docs/src/app/configuration/page.mdx
+++ b/apps/docs/src/app/configuration/page.mdx
@@ -68,10 +68,38 @@ Without a `portless.json`, the name is inferred from `package.json` and the scri
       <td></td>
       <td>Overrides for workspace packages, keyed by relative path.</td>
     </tr>
+    <tr>
+      <td>`turbo`</td>
+      <td>boolean</td>
+      <td>`true`</td>
+      <td>Set `false` to use direct spawning instead of turborepo in multi-app mode.</td>
+    </tr>
   </tbody>
 </table>
 
 Each `apps` entry has the same shape (`name`, `script`, `appPort`, `proxy`). When `apps` is present, top-level fields apply only in single-app mode.
+
+### package.json "portless" key
+
+Instead of a separate `portless.json`, you can add a `"portless"` key to your `package.json`. A string value is shorthand for setting the name:
+
+```json
+{
+  "name": "@myorg/web",
+  "portless": "myapp"
+}
+```
+
+An object supports all per-app fields (`name`, `script`, `appPort`, `proxy`):
+
+```json
+{
+  "name": "@myorg/web",
+  "portless": { "name": "myapp", "script": "dev:app" }
+}
+```
+
+The `package.json` `"portless"` key takes precedence over `portless.json` app entries but is overridden by CLI flags.
 
 ### Monorepo
 
@@ -93,6 +121,8 @@ portless --script start   # run "start" instead of "dev"
 ```
 
 The `apps` map is optional and only needed for overrides. Packages not listed still auto-discover with names inferred from their `package.json`.
+
+Without an `apps` map, hostnames follow the `<package>.<project>.localhost` convention. The project name comes from the most common npm scope across workspace packages (e.g. `@myorg/web` and `@myorg/api` produce project name `myorg`), falling back to the workspace root directory name. If a package's short name matches the project name, it gets the bare `<project>.localhost` without duplication.
 
 ### Turborepo
 
@@ -166,7 +196,7 @@ For `appPort`: CLI `--app-port` flag > `PORTLESS_APP_PORT` env var > `package.js
     <tr>
       <td>`PORTLESS_STATE_DIR`</td>
       <td>Override the state directory</td>
-      <td>see below</td>
+      <td>`~/.portless`</td>
     </tr>
     <tr>
       <td>`PORTLESS`</td>
@@ -178,32 +208,7 @@ For `appPort`: CLI `--app-port` flag > `PORTLESS_APP_PORT` env var > `package.js
 
 ## State directory
 
-Portless stores state (routes, PID file, port file, TLS marker) in a directory that depends on the proxy port:
-
-<table>
-  <thead>
-    <tr>
-      <th>Condition</th>
-      <th>Path</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Port below 1024 (sudo, macOS/Linux)</td>
-      <td>`/tmp/portless`</td>
-    </tr>
-    <tr>
-      <td>Port 1024+ (no sudo)</td>
-      <td>`~/.portless`</td>
-    </tr>
-    <tr>
-      <td>Windows (any port)</td>
-      <td>`~/.portless`</td>
-    </tr>
-  </tbody>
-</table>
-
-Override with `PORTLESS_STATE_DIR`.
+Portless stores state (routes, PID file, port file, TLS marker) in `~/.portless` on all platforms. Override with `PORTLESS_STATE_DIR`.
 
 ## State files
 

--- a/apps/docs/src/app/page.mdx
+++ b/apps/docs/src/app/page.mdx
@@ -25,20 +25,14 @@ npm install -D portless
 
 ## Run your app
 
-The simplest way: create a `portless.json` with the app name, then run `portless`:
-
-**portless.json:**
-
-```json
-{ "name": "myapp" }
-```
+Just run `portless`. It reads the `"dev"` script from `package.json` and runs it through the proxy:
 
 ```bash
 portless
-# -> runs "dev" script, https://myapp.localhost
+# -> runs "dev" script, https://<project>.localhost
 ```
 
-Your `package.json` scripts stay portless-free. If someone doesn't have portless installed, `pnpm dev` still works.
+The app name is inferred from `package.json`, git root, or directory name. Use a `portless.json` to override (e.g. `{ "name": "myapp" }` for `https://myapp.localhost`).
 
 You can also run with an explicit command:
 
@@ -53,7 +47,7 @@ The proxy auto-starts when you run an app. A random port (4000--4999) is assigne
 
 ## Use in package.json
 
-With a `portless.json`, your scripts stay clean:
+Your scripts stay clean:
 
 ```json
 {

--- a/apps/docs/src/app/page.mdx
+++ b/apps/docs/src/app/page.mdx
@@ -25,6 +25,22 @@ npm install -D portless
 
 ## Run your app
 
+The simplest way: create a `portless.json` with the app name, then run `portless`:
+
+```json
+// portless.json
+{ "name": "myapp" }
+```
+
+```bash
+portless
+# -> runs "dev" script, https://myapp.localhost
+```
+
+Your `package.json` scripts stay portless-free. If someone doesn't have portless installed, `pnpm dev` still works.
+
+You can also run with an explicit command:
+
 ```bash
 portless myapp next dev
 # -> https://myapp.localhost
@@ -35,6 +51,20 @@ HTTPS with HTTP/2 is enabled by default. On first run, portless generates a loca
 The proxy auto-starts when you run an app. A random port (4000--4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, Astro, React Router, Angular, Expo, React Native), portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag.
 
 ## Use in package.json
+
+With a `portless.json`, your scripts stay clean:
+
+```json
+{
+  "scripts": {
+    "dev": "next dev"
+  }
+}
+```
+
+Then run `portless` or `portless run` to go through the proxy.
+
+You can also use portless directly in scripts:
 
 ```json
 {

--- a/apps/docs/src/app/page.mdx
+++ b/apps/docs/src/app/page.mdx
@@ -27,8 +27,9 @@ npm install -D portless
 
 The simplest way: create a `portless.json` with the app name, then run `portless`:
 
+**portless.json:**
+
 ```json
-// portless.json
 { "name": "myapp" }
 ```
 

--- a/examples/google-oauth/package.json
+++ b/examples/google-oauth/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "portless myapp.local.mydomain next dev"
+    "dev": "next dev"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/examples/google-oauth/package.json
+++ b/examples/google-oauth/package.json
@@ -1,6 +1,7 @@
 {
   "name": "google-oauth-example",
   "version": "0.0.0",
+  "portless": "google-oauth-example.portless",
   "private": true,
   "scripts": {
     "dev": "next dev"

--- a/packages/portless/src/certs.ts
+++ b/packages/portless/src/certs.ts
@@ -50,6 +50,7 @@ const CA_KEY_FILE = "ca-key.pem";
 const CA_CERT_FILE = "ca.pem";
 const SERVER_KEY_FILE = "server-key.pem";
 const SERVER_CERT_FILE = "server.pem";
+const CA_TRUST_MARKER = "ca.trusted";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -61,6 +62,40 @@ function fileExists(filePath: string): boolean {
     return true;
   } catch {
     return false;
+  }
+}
+
+function caFingerprint(stateDir: string): string | null {
+  const caCertPath = path.join(stateDir, CA_CERT_FILE);
+  try {
+    const pem = fs.readFileSync(caCertPath);
+    return crypto.createHash("sha256").update(pem).digest("hex");
+  } catch {
+    return null;
+  }
+}
+
+function readTrustMarker(stateDir: string): string | null {
+  try {
+    return fs.readFileSync(path.join(stateDir, CA_TRUST_MARKER), "utf-8").trim();
+  } catch {
+    return null;
+  }
+}
+
+function writeTrustMarker(stateDir: string): void {
+  const fp = caFingerprint(stateDir);
+  if (fp) {
+    fs.writeFileSync(path.join(stateDir, CA_TRUST_MARKER), fp + "\n");
+    fixOwnership(path.join(stateDir, CA_TRUST_MARKER));
+  }
+}
+
+function clearTrustMarker(stateDir: string): void {
+  try {
+    fs.unlinkSync(path.join(stateDir, CA_TRUST_MARKER));
+  } catch {
+    // Marker may not exist yet — ignore.
   }
 }
 
@@ -255,6 +290,13 @@ function generateCA(stateDir: string): { certPath: string; keyPath: string } {
   fs.chmodSync(certPath, 0o644);
   fixOwnership(keyPath, certPath);
 
+  // New CA invalidates any previous trust marker.
+  try {
+    fs.unlinkSync(path.join(stateDir, CA_TRUST_MARKER));
+  } catch {
+    // Marker may not exist yet — ignore.
+  }
+
   return { certPath, keyPath };
 }
 
@@ -401,6 +443,13 @@ export function ensureCerts(stateDir: string): {
 export function isCATrusted(stateDir: string): boolean {
   const caCertPath = path.join(stateDir, CA_CERT_FILE);
   if (!fileExists(caCertPath)) return false;
+
+  // Fast path: if we previously trusted this exact CA, skip the OS check.
+  const marker = readTrustMarker(stateDir);
+  if (marker) {
+    const fp = caFingerprint(stateDir);
+    if (fp && marker === fp) return true;
+  }
 
   if (process.platform === "darwin") {
     return isCATrustedMacOS(caCertPath);
@@ -843,6 +892,7 @@ export function trustCA(stateDir: string): { trusted: boolean; error?: string } 
           { stdio: "pipe", timeout: MACOS_SECURITY_AUTH_TIMEOUT_MS }
         );
       }
+      writeTrustMarker(stateDir);
       return { trusted: true };
     } else if (process.platform === "linux") {
       const config = getLinuxCATrustConfig();
@@ -852,12 +902,14 @@ export function trustCA(stateDir: string): { trusted: boolean; error?: string } 
       const dest = path.join(config.certDir, "portless-ca.crt");
       fs.copyFileSync(caCertPath, dest);
       execFileSync(config.updateCommand, [], { stdio: "pipe", timeout: 30_000 });
+      writeTrustMarker(stateDir);
       return { trusted: true };
     } else if (process.platform === "win32") {
       execFileSync("certutil", ["-addstore", "-user", "Root", caCertPath], {
         stdio: "pipe",
         timeout: 30_000,
       });
+      writeTrustMarker(stateDir);
       return { trusted: true };
     }
     return { trusted: false, error: `Unsupported platform: ${process.platform}` };
@@ -894,24 +946,28 @@ export function trustCA(stateDir: string): { trusted: boolean; error?: string } 
 export function untrustCA(stateDir: string): { removed: boolean; error?: string } {
   const caCertPath = path.join(stateDir, CA_CERT_FILE);
   if (!fileExists(caCertPath)) {
+    clearTrustMarker(stateDir);
     return { removed: true };
   }
 
   if (!isCATrusted(stateDir)) {
+    clearTrustMarker(stateDir);
     return { removed: true };
   }
 
   try {
+    let result: { removed: boolean; error?: string };
     if (process.platform === "darwin") {
-      return untrustCAMacOS(caCertPath);
+      result = untrustCAMacOS(caCertPath);
+    } else if (process.platform === "linux") {
+      result = untrustCALinux(stateDir);
+    } else if (process.platform === "win32") {
+      result = untrustCAWindows(caCertPath);
+    } else {
+      result = { removed: false, error: `Unsupported platform: ${process.platform}` };
     }
-    if (process.platform === "linux") {
-      return untrustCALinux(stateDir);
-    }
-    if (process.platform === "win32") {
-      return untrustCAWindows(caCertPath);
-    }
-    return { removed: false, error: `Unsupported platform: ${process.platform}` };
+    if (result.removed) clearTrustMarker(stateDir);
+    return result;
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     return { removed: false, error: message };

--- a/packages/portless/src/certs.ts
+++ b/packages/portless/src/certs.ts
@@ -77,7 +77,8 @@ function caFingerprint(stateDir: string): string | null {
 
 function readTrustMarker(stateDir: string): string | null {
   try {
-    return fs.readFileSync(path.join(stateDir, CA_TRUST_MARKER), "utf-8").trim();
+    const value = fs.readFileSync(path.join(stateDir, CA_TRUST_MARKER), "utf-8").trim();
+    return value || null;
   } catch {
     return null;
   }
@@ -95,7 +96,7 @@ function clearTrustMarker(stateDir: string): void {
   try {
     fs.unlinkSync(path.join(stateDir, CA_TRUST_MARKER));
   } catch {
-    // Marker may not exist yet — ignore.
+    // Marker may not exist yet; ignore.
   }
 }
 
@@ -400,19 +401,17 @@ export function ensureCerts(stateDir: string): {
   const serverKeyPath = path.join(stateDir, SERVER_KEY_FILE);
 
   let caGenerated = false;
-
-  // Ensure CA exists
-  if (
+  const caMissing =
     !fileExists(caCertPath) ||
     !fileExists(caKeyPath) ||
     !isCertValid(caCertPath) ||
-    !isCertSignatureStrong(caCertPath)
-  ) {
+    !isCertSignatureStrong(caCertPath);
+
+  if (caMissing) {
     generateCA(stateDir);
     caGenerated = true;
   }
 
-  // Ensure server cert exists and is valid
   if (
     caGenerated ||
     !fileExists(serverCertPath) ||
@@ -426,7 +425,7 @@ export function ensureCerts(stateDir: string): {
 
   return {
     certPath: serverCertPath,
-    keyPath: path.join(stateDir, SERVER_KEY_FILE),
+    keyPath: serverKeyPath,
     caPath: caCertPath,
     caGenerated,
   };

--- a/packages/portless/src/certs.ts
+++ b/packages/portless/src/certs.ts
@@ -971,7 +971,7 @@ export function untrustCA(stateDir: string): { removed: boolean; error?: string 
 function untrustCAMacOS(caCertPath: string): { removed: boolean; error?: string } {
   const errors: string[] = [];
 
-  const tryExec = (args: string[]) => {
+  const tryExec = (args: string[]): boolean => {
     try {
       execFileSync("security", args, { stdio: "pipe", timeout: MACOS_SECURITY_ROOT_TIMEOUT_MS });
       return true;
@@ -982,15 +982,17 @@ function untrustCAMacOS(caCertPath: string): { removed: boolean; error?: string 
     }
   };
 
-  if (tryExec(["remove-trusted-cert", caCertPath])) {
-    return isCATrustedMacOSAfterAttempt(caCertPath)
-      ? { removed: false, error: errors.join("; ") || "Trust entry may still be present" }
-      : { removed: true };
-  }
+  tryExec(["remove-trusted-cert", caCertPath]);
 
-  const login = loginKeychainPath();
-  tryExec(["delete-certificate", "-c", CA_COMMON_NAME, login]);
-  tryExec(["delete-certificate", "-c", CA_COMMON_NAME, "/Library/Keychains/System.keychain"]);
+  // delete-certificate -c fails when multiple certs share the same CN
+  // ("is ambiguous, matches more than one certificate"). Loop until all
+  // matching certs are removed from each keychain.
+  const keychains = [loginKeychainPath(), "/Library/Keychains/System.keychain"];
+  for (const kc of keychains) {
+    for (let i = 0; i < 20; i++) {
+      if (!tryExec(["delete-certificate", "-c", CA_COMMON_NAME, kc])) break;
+    }
+  }
 
   return isCATrustedMacOSAfterAttempt(caCertPath)
     ? { removed: false, error: errors.join("; ") || "Could not remove CA from keychain (try sudo)" }

--- a/packages/portless/src/certs.ts
+++ b/packages/portless/src/certs.ts
@@ -290,12 +290,7 @@ function generateCA(stateDir: string): { certPath: string; keyPath: string } {
   fs.chmodSync(certPath, 0o644);
   fixOwnership(keyPath, certPath);
 
-  // New CA invalidates any previous trust marker.
-  try {
-    fs.unlinkSync(path.join(stateDir, CA_TRUST_MARKER));
-  } catch {
-    // Marker may not exist yet — ignore.
-  }
+  clearTrustMarker(stateDir);
 
   return { certPath, keyPath };
 }

--- a/packages/portless/src/clean-utils.ts
+++ b/packages/portless/src/clean-utils.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { SYSTEM_STATE_DIR, USER_STATE_DIR } from "./cli-utils.js";
+import { LEGACY_SYSTEM_STATE_DIR, USER_STATE_DIR } from "./cli-utils.js";
 
 /** Filenames portless creates under a state directory (allowlisted for clean). */
 const PORTLESS_STATE_FILES = [
@@ -36,7 +36,7 @@ export function collectStateDirsForCleanup(): string[] {
     if (fs.existsSync(resolved)) dirs.add(resolved);
   };
   add(USER_STATE_DIR);
-  add(SYSTEM_STATE_DIR);
+  add(LEGACY_SYSTEM_STATE_DIR);
   add(process.env.PORTLESS_STATE_DIR);
   return [...dirs];
 }

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -10,9 +10,9 @@ import {
   DEFAULT_TLD,
   FALLBACK_PROXY_PORT,
   INTERNAL_LAN_IP_FLAG,
+  LEGACY_SYSTEM_STATE_DIR,
   PRIVILEGED_PORT_THRESHOLD,
   RISKY_TLDS,
-  SYSTEM_STATE_DIR,
   USER_STATE_DIR,
   discoverState,
   findFreePort,
@@ -139,13 +139,10 @@ describe("isProxyRunning", () => {
 });
 
 describe("resolveStateDir", () => {
-  it.skipIf(process.platform === "win32")("returns system dir for privileged ports", () => {
-    expect(resolveStateDir(80)).toBe(SYSTEM_STATE_DIR);
-    expect(resolveStateDir(443)).toBe(SYSTEM_STATE_DIR);
-    expect(resolveStateDir(1023)).toBe(SYSTEM_STATE_DIR);
-  });
-
-  it("returns user dir for non-privileged ports", () => {
+  it("returns user dir for all ports", () => {
+    expect(resolveStateDir(80)).toBe(USER_STATE_DIR);
+    expect(resolveStateDir(443)).toBe(USER_STATE_DIR);
+    expect(resolveStateDir(1023)).toBe(USER_STATE_DIR);
     expect(resolveStateDir(1024)).toBe(USER_STATE_DIR);
     expect(resolveStateDir(8080)).toBe(USER_STATE_DIR);
     expect(resolveStateDir(3000)).toBe(USER_STATE_DIR);
@@ -161,11 +158,11 @@ describe("constants", () => {
     expect(PRIVILEGED_PORT_THRESHOLD).toBe(1024);
   });
 
-  it("SYSTEM_STATE_DIR is /tmp/portless on Unix, os.tmpdir() on Windows", () => {
+  it("LEGACY_SYSTEM_STATE_DIR is /tmp/portless on Unix, os.tmpdir() on Windows", () => {
     if (process.platform === "win32") {
-      expect(SYSTEM_STATE_DIR).toBe(path.join(os.tmpdir(), "portless"));
+      expect(LEGACY_SYSTEM_STATE_DIR).toBe(path.join(os.tmpdir(), "portless"));
     } else {
-      expect(SYSTEM_STATE_DIR).toBe("/tmp/portless");
+      expect(LEGACY_SYSTEM_STATE_DIR).toBe("/tmp/portless");
     }
   });
 

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -34,14 +34,14 @@ export const INTERNAL_LAN_IP_ENV = "PORTLESS_INTERNAL_LAN_IP";
 export const INTERNAL_LAN_IP_FLAG = "--lan-ip-auto";
 
 /**
- * System-wide state directory (used when proxy needs sudo on Unix).
- * Hardcoded to /tmp/portless rather than os.tmpdir() because macOS returns
- * a per-user dir from os.tmpdir() (/var/folders/...) while sudo (root)
- * gets /tmp, causing the proxy writer and client reader to disagree.
+ * @deprecated No longer used. All state now lives in USER_STATE_DIR.
+ * Kept as a read-only reference for migration and cleanup of old installs.
  */
-export const SYSTEM_STATE_DIR = isWindows ? path.join(os.tmpdir(), "portless") : "/tmp/portless";
+export const LEGACY_SYSTEM_STATE_DIR = isWindows
+  ? path.join(os.tmpdir(), "portless")
+  : "/tmp/portless";
 
-/** Per-user state directory (used when proxy runs without sudo). */
+/** Per-user state directory. All proxy state lives here regardless of port. */
 export const USER_STATE_DIR = path.join(os.homedir(), ".portless");
 
 /** Minimum app port when finding a free port. */
@@ -124,15 +124,11 @@ export function getDefaultPort(tls?: boolean): number {
 
 /**
  * Determine the state directory for a given proxy port.
- * On Unix, privileged ports (< 1024) use the system dir so both root and
- * non-root processes can share state. Unprivileged ports use the user's
- * home directory (~/.portless). On Windows, always use the user dir
- * (no privileged port concept).
+ * Always returns USER_STATE_DIR (~/.portless) unless PORTLESS_STATE_DIR is set.
  */
-export function resolveStateDir(port: number): string {
+export function resolveStateDir(_port?: number): string {
   if (process.env.PORTLESS_STATE_DIR) return process.env.PORTLESS_STATE_DIR;
-  if (isWindows) return USER_STATE_DIR;
-  return port < PRIVILEGED_PORT_THRESHOLD ? SYSTEM_STATE_DIR : USER_STATE_DIR;
+  return USER_STATE_DIR;
 }
 
 /** Read the proxy port from a given state directory. Returns null if unreadable. */
@@ -307,13 +303,12 @@ export function isLanEnvEnabled(): boolean {
 }
 
 /**
- * Read the last-known proxy configuration from state directories on disk.
+ * Read the last-known proxy configuration from the state directory on disk.
  * Unlike {@link discoverState}, this does not check whether the proxy is
  * actually running. It simply reads whatever state files exist so a
  * subsequent auto-start can reuse the previous settings.
  *
- * Checks USER_STATE_DIR first, then SYSTEM_STATE_DIR (or PORTLESS_STATE_DIR
- * if set). Returns null when no prior state is found.
+ * Returns null when no prior state is found.
  */
 export function readPersistedProxyState(): {
   port: number;
@@ -321,21 +316,13 @@ export function readPersistedProxyState(): {
   tld: string;
   lanMode: boolean;
 } | null {
-  const dirs: string[] = [];
-  if (process.env.PORTLESS_STATE_DIR) {
-    dirs.push(process.env.PORTLESS_STATE_DIR);
-  } else {
-    dirs.push(USER_STATE_DIR, SYSTEM_STATE_DIR);
-  }
-
-  for (const dir of dirs) {
-    const port = readPortFromDir(dir);
-    if (port !== null) {
-      const tls = readTlsMarker(dir);
-      const tld = readTldFromDir(dir);
-      const lanIp = readLanMarker(dir);
-      return { port, tls, tld, lanMode: lanIp !== null || tld === "local" };
-    }
+  const dir = process.env.PORTLESS_STATE_DIR || USER_STATE_DIR;
+  const port = readPortFromDir(dir);
+  if (port !== null) {
+    const tls = readTlsMarker(dir);
+    const tld = readTldFromDir(dir);
+    const lanIp = readLanMarker(dir);
+    return { port, tls, tld, lanMode: lanIp !== null || tld === "local" };
   }
 
   return null;
@@ -403,8 +390,8 @@ export function buildProxyStartConfig(options: {
 /**
  * Discover the active proxy's state directory, port, TLS mode, TLD, LAN mode,
  * and current LAN IP when available.
- * Checks the user-level dir first, then the system-level dir.
- * Falls back to the system dir with the default port if nothing is running.
+ * Checks the user-level dir first, then the legacy /tmp/portless dir as a
+ * read-only fallback for proxies started with older versions.
  */
 export async function discoverState(): Promise<{
   dir: string;
@@ -456,16 +443,17 @@ export async function discoverState(): Promise<{
     }
   }
 
-  // Check system-level state (/tmp/portless)
-  const systemPort = readPortFromDir(SYSTEM_STATE_DIR);
-  if (systemPort !== null) {
-    if (await isProxyRunning(systemPort)) {
-      const tls = readTlsMarker(SYSTEM_STATE_DIR);
-      const tld = readTldFromDir(SYSTEM_STATE_DIR);
-      const lanIp = readLanMarker(SYSTEM_STATE_DIR);
+  // Check legacy system-level state (/tmp/portless) for proxies started with
+  // older versions. Read-only: no root operations are performed on this path.
+  const legacyPort = readPortFromDir(LEGACY_SYSTEM_STATE_DIR);
+  if (legacyPort !== null) {
+    if (await isProxyRunning(legacyPort)) {
+      const tls = readTlsMarker(LEGACY_SYSTEM_STATE_DIR);
+      const tld = readTldFromDir(LEGACY_SYSTEM_STATE_DIR);
+      const lanIp = readLanMarker(LEGACY_SYSTEM_STATE_DIR);
       return {
-        dir: SYSTEM_STATE_DIR,
-        port: systemPort,
+        dir: LEGACY_SYSTEM_STATE_DIR,
+        port: legacyPort,
         tls,
         tld,
         lanMode: lanIp !== null || tld === "local",
@@ -474,9 +462,7 @@ export async function discoverState(): Promise<{
     }
   }
 
-  // State files didn't help. Probe well-known ports as a last resort --
-  // privileged-port proxies store state in /tmp which macOS cleans on reboot,
-  // so the daemon may still be alive after the port file is gone.
+  // State files didn't help. Probe well-known ports as a last resort.
   // Standard ports first (443, 80) since those are the new defaults, then the
   // legacy fallback port, then any PORTLESS_PORT override.
   const configuredPort = getDefaultPort();
@@ -485,8 +471,7 @@ export async function discoverState(): Promise<{
     if (await isProxyRunning(port)) {
       const dir = resolveStateDir(port);
       const markerTls = readTlsMarker(dir);
-      // State files in /tmp may have been cleaned while the daemon kept
-      // running.  When the marker is missing, infer TLS from the port:
+      // When the marker is missing, infer TLS from the port:
       // 443 is always HTTPS, 80 is always HTTP.
       const tls = markerTls || port === getProtocolPort(true);
       const tld = readTldFromDir(dir);

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -704,12 +704,12 @@ function collectBinPaths(cwd: string): string[] {
 /**
  * Build a PATH string with `node_modules/.bin` directories prepended.
  */
-function augmentedPath(env: NodeJS.ProcessEnv | undefined): string {
+export function augmentedPath(env: NodeJS.ProcessEnv | undefined, cwd?: string): string {
   const source = env ?? process.env;
   // On Windows, the PATH variable may be stored as "Path" (case-insensitive in
   // process.env but case-sensitive in plain objects created via spread).
   const base = source.PATH ?? source.Path ?? "";
-  const bins = collectBinPaths(process.cwd());
+  const bins = collectBinPaths(cwd ?? process.cwd());
   // Ensure node's own directory is in PATH so .cmd wrappers in node_modules/.bin
   // can locate the node executable (fixes Windows "node not recognized" errors).
   const nodeBin = path.dirname(process.execPath);

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -484,7 +484,11 @@ export async function discoverState(): Promise<{
   for (const port of probePorts) {
     if (await isProxyRunning(port)) {
       const dir = resolveStateDir(port);
-      const tls = readTlsMarker(dir);
+      const markerTls = readTlsMarker(dir);
+      // State files in /tmp may have been cleaned while the daemon kept
+      // running.  When the marker is missing, infer TLS from the port:
+      // 443 is always HTTPS, 80 is always HTTP.
+      const tls = markerTls || port === getProtocolPort(true);
       const tld = readTldFromDir(dir);
       const lanIp = readLanMarker(dir);
       return { dir, port, tls, tld, lanMode: lanIp !== null || tld === "local", lanIp };

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -116,10 +116,16 @@ describe("CLI", () => {
       expect(stdout).toContain("Usage:");
     });
 
-    it("prints help and exits 0 with no args", () => {
-      const { status, stdout } = run([]);
-      expect(status).toBe(0);
-      expect(stdout).toContain("Usage:");
+    it("prints help and exits 0 with no args when no dev script exists", () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-cli-help-"));
+      try {
+        fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ name: "test-app" }));
+        const { status, stdout } = run([], { cwd: tmpDir });
+        expect(status).toBe(0);
+        expect(stdout).toContain("Usage:");
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
     });
   });
 
@@ -283,10 +289,16 @@ describe("CLI", () => {
   });
 
   describe("run subcommand dispatch", () => {
-    it("exits 1 with 'No command provided' when no args follow run", () => {
-      const { status, stderr } = run(["run"]);
-      expect(status).toBe(1);
-      expect(stderr).toContain("No command provided");
+    it("exits 1 with 'No command provided' when no args follow run and no dev script", () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-cli-run-"));
+      try {
+        fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ name: "test-app" }));
+        const { status, stderr } = run(["run"], { cwd: tmpDir });
+        expect(status).toBe(1);
+        expect(stderr).toContain("No command provided");
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
     });
 
     it("does not dispatch 'list' as the global list command", () => {
@@ -1174,15 +1186,17 @@ describe("CLI", () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     });
 
-    it("portless (no args) prints help without portless.json", () => {
-      // Create a package.json with dev script but no portless.json
+    it("portless (no args) runs dev script without portless.json", () => {
       fs.writeFileSync(
         path.join(tmpDir, "package.json"),
         JSON.stringify({ name: "test-app", scripts: { dev: "echo hello" } })
       );
-      const { status, stdout } = run([], { cwd: tmpDir });
+      const { status, stdout } = run([], {
+        cwd: tmpDir,
+        env: { PORTLESS: "0" },
+      });
       expect(status).toBe(0);
-      expect(stdout).toContain("Usage:");
+      expect(stdout).toContain("hello");
     });
 
     it("portless run (no command) with portless.json resolves dev script", () => {
@@ -1198,14 +1212,16 @@ describe("CLI", () => {
       expect(stdout).toContain("config-dev");
     });
 
-    it("portless run (no command) without portless.json errors", () => {
+    it("portless run (no command) without portless.json resolves dev script", () => {
       fs.writeFileSync(
         path.join(tmpDir, "package.json"),
         JSON.stringify({ name: "test-app", scripts: { dev: "echo hello" } })
       );
-      const { status, stderr } = run(["run"], { cwd: tmpDir });
-      expect(status).toBe(1);
-      expect(stderr).toContain("No command provided");
+      const { stdout } = run(["run"], {
+        cwd: tmpDir,
+        env: { PORTLESS: "0" },
+      });
+      expect(stdout).toContain("hello");
     });
 
     it("portless run with explicit command ignores config script", () => {

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -9,8 +9,8 @@ import { fileURLToPath } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_PATH = path.resolve(__dirname, "../dist/cli.js");
 
-/** Run the CLI with the given args and optional env overrides. */
-function run(args: string[], options?: { env?: Record<string, string | undefined> }) {
+/** Run the CLI with the given args and optional env/cwd overrides. */
+function run(args: string[], options?: { env?: Record<string, string | undefined>; cwd?: string }) {
   const env: Record<string, string | undefined> = {
     ...process.env,
     ...options?.env,
@@ -25,6 +25,7 @@ function run(args: string[], options?: { env?: Record<string, string | undefined
     encoding: "utf-8",
     timeout: 10_000,
     env,
+    cwd: options?.cwd,
   });
   return {
     status: result.status,
@@ -1160,5 +1161,150 @@ describe("CLI", () => {
         }
       }
     );
+  });
+
+  describe("portless.json config", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-cli-config-"));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("portless (no args) prints help without portless.json", () => {
+      // Create a package.json with dev script but no portless.json
+      fs.writeFileSync(
+        path.join(tmpDir, "package.json"),
+        JSON.stringify({ name: "test-app", scripts: { dev: "echo hello" } })
+      );
+      const { status, stdout } = run([], { cwd: tmpDir });
+      expect(status).toBe(0);
+      expect(stdout).toContain("Usage:");
+    });
+
+    it("portless run (no command) with portless.json resolves dev script", () => {
+      fs.writeFileSync(
+        path.join(tmpDir, "package.json"),
+        JSON.stringify({ name: "test-app", scripts: { dev: "echo config-dev" } })
+      );
+      fs.writeFileSync(path.join(tmpDir, "portless.json"), JSON.stringify({ name: "myapp" }));
+      const { stdout } = run(["run"], {
+        cwd: tmpDir,
+        env: { PORTLESS: "0" },
+      });
+      expect(stdout).toContain("config-dev");
+    });
+
+    it("portless run (no command) without portless.json errors", () => {
+      fs.writeFileSync(
+        path.join(tmpDir, "package.json"),
+        JSON.stringify({ name: "test-app", scripts: { dev: "echo hello" } })
+      );
+      const { status, stderr } = run(["run"], { cwd: tmpDir });
+      expect(status).toBe(1);
+      expect(stderr).toContain("No command provided");
+    });
+
+    it("portless run with explicit command ignores config script", () => {
+      fs.writeFileSync(
+        path.join(tmpDir, "package.json"),
+        JSON.stringify({ name: "test-app", scripts: { dev: "echo from-config" } })
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, "portless.json"),
+        JSON.stringify({ name: "myapp", script: "dev" })
+      );
+      const { stdout } = run(["run", "echo", "from-cli"], {
+        cwd: tmpDir,
+        env: { PORTLESS: "0" },
+      });
+      expect(stdout).toContain("from-cli");
+      expect(stdout).not.toContain("from-config");
+    });
+
+    it("portless run with portless.json script field uses that script", () => {
+      fs.writeFileSync(
+        path.join(tmpDir, "package.json"),
+        JSON.stringify({
+          name: "test-app",
+          scripts: { dev: "echo from-dev", start: "echo from-start" },
+        })
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, "portless.json"),
+        JSON.stringify({ name: "myapp", script: "start" })
+      );
+      const { stdout } = run(["run"], {
+        cwd: tmpDir,
+        env: { PORTLESS: "0" },
+      });
+      expect(stdout).toContain("from-start");
+    });
+
+    it("--script flag overrides config script field", () => {
+      fs.writeFileSync(
+        path.join(tmpDir, "package.json"),
+        JSON.stringify({
+          name: "test-app",
+          scripts: { dev: "echo from-dev", start: "echo from-start" },
+        })
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, "portless.json"),
+        JSON.stringify({ name: "myapp", script: "dev" })
+      );
+      const { stdout } = run(["--script", "start", "run"], {
+        cwd: tmpDir,
+        env: { PORTLESS: "0" },
+      });
+      expect(stdout).toContain("from-start");
+    });
+
+    it("--name overrides portless.json name", () => {
+      fs.writeFileSync(
+        path.join(tmpDir, "package.json"),
+        JSON.stringify({ name: "test-app", scripts: { dev: "echo hello" } })
+      );
+      fs.writeFileSync(path.join(tmpDir, "portless.json"), JSON.stringify({ name: "config-name" }));
+      // With PORTLESS=0, the name doesn't matter (command runs directly)
+      // but we can verify via the run subcommand help text or named mode.
+      // Let's test it goes through without error.
+      const { stdout } = run(["--name", "override-name", "echo", "works"], {
+        cwd: tmpDir,
+        env: { PORTLESS: "0" },
+      });
+      expect(stdout).toContain("works");
+    });
+
+    it("portless run with missing script errors clearly", () => {
+      fs.writeFileSync(
+        path.join(tmpDir, "package.json"),
+        JSON.stringify({ name: "test-app", scripts: {} })
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, "portless.json"),
+        JSON.stringify({ name: "myapp", script: "nonexistent" })
+      );
+      const { status, stderr } = run(["run"], { cwd: tmpDir });
+      expect(status).toBe(1);
+      expect(stderr).toContain("No command provided");
+    });
+
+    it("portless.json validation rejects invalid appPort", () => {
+      fs.writeFileSync(
+        path.join(tmpDir, "package.json"),
+        JSON.stringify({ name: "test-app", scripts: { dev: "echo hello" } })
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, "portless.json"),
+        JSON.stringify({ appPort: "not-a-number" })
+      );
+      const { status, stderr } = run(["run"], { cwd: tmpDir });
+      expect(status).toBe(1);
+      expect(stderr).toContain("appPort");
+    });
   });
 });

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1163,8 +1163,8 @@ ${colors.bold("portless run")} - Infer project name and run through the proxy.
 ${colors.bold("Usage:")}
   ${colors.cyan("portless run [options] [command...]")}
 
-  When no command is given and a portless.json exists, runs the configured
-  script (default: "dev") from package.json.
+  When no command is given, runs the configured script (default: "dev")
+  from package.json.
 
 ${colors.bold("Options:")}
   --name <name>          Override the inferred base name (worktree prefix still applies)
@@ -1183,7 +1183,7 @@ ${colors.bold("Name inference (in order):")}
   (e.g. feature-auth.myapp.localhost).
 
 ${colors.bold("Examples:")}
-  portless run                        # With portless.json: run dev script
+  portless run                        # Run dev script through proxy
   portless run next dev               # -> https://<project>.localhost
   portless run --name myapp next dev  # -> https://myapp.localhost
   portless run vite dev               # -> https://<project>.localhost
@@ -1289,9 +1289,9 @@ ${colors.bold("Install:")}
   ${colors.cyan("npm install -D portless")}          Project dev dependency
 
 ${colors.bold("Usage:")}
-  ${colors.cyan("portless")}                         Run dev script through proxy (needs portless.json)
+  ${colors.cyan("portless")}                         Run dev script through proxy
   ${colors.cyan("portless")}                         From monorepo root: run all workspace packages
-  ${colors.cyan("portless run")}                     Same as above (with portless.json or --script)
+  ${colors.cyan("portless run")}                     Same as above
   ${colors.cyan("portless run <cmd>")}               Run a command through the proxy
   ${colors.cyan("portless <name> <cmd>")}            Run with an explicit app name
   ${colors.cyan("portless proxy start")}             Start the proxy (HTTPS on port 443, daemon)
@@ -1306,7 +1306,7 @@ ${colors.bold("Usage:")}
   ${colors.cyan("portless hosts clean")}             Remove portless entries from ${HOSTS_DISPLAY}
 
 ${colors.bold("Examples:")}
-  portless                            # Run dev script (with portless.json)
+  portless                            # Run dev script through proxy
   portless                            # From monorepo root: start all apps
   portless --script start             # Run "start" script instead of "dev"
   portless myapp next dev             # -> https://myapp.localhost
@@ -1315,13 +1315,12 @@ ${colors.bold("Examples:")}
   portless get backend                # -> https://backend.localhost
 
 ${colors.bold("Configuration (portless.json):")}
-  Create a portless.json to enable zero-arg mode. Your package.json
-  scripts stay portless-free. Config is optional; portless infers
-  the name from package.json and defaults to the "dev" script.
+  Optional. Portless works out of the box by running the "dev" script
+  from package.json. Use portless.json to override defaults.
 
-  Single app:  { "name": "myapp" }
-  Custom script: { "name": "myapp", "script": "start" }
-  Monorepo:    { "apps": { "apps/web": { "name": "myapp" } } }
+  Override name:   { "name": "myapp" }
+  Override script: { "name": "myapp", "script": "start" }
+  Monorepo:        { "apps": { "apps/web": { "name": "myapp" } } }
 
 ${colors.bold("In package.json:")}
   {
@@ -1329,8 +1328,8 @@ ${colors.bold("In package.json:")}
       "dev": "next dev"
     }
   }
-  Then run: portless          (with portless.json)
-  Or:       portless run      (with portless.json)
+  Then run: portless
+  Or:       portless run
   Or:       portless run next dev
 
 ${colors.bold("How it works:")}
@@ -2345,15 +2344,16 @@ function loadAppConfig(cwd: string = process.cwd()): AppConfig | null {
  *
  * Activates when:
  * - At a workspace root (pnpm, npm, yarn, or bun) -> multi-app mode
- * - Has a portless.json or --script flag -> single-app mode
- * Without config, bare `portless` still prints help for backwards compat.
+ * - In any directory with a package.json that has the target script -> single-app mode
+ * Config (portless.json / package.json "portless" key) is loaded for overrides
+ * but is not required.
  */
 async function handleDefaultMode(globalScript?: string): Promise<boolean> {
   const cwd = process.cwd();
 
   // Workspace root: multi-app mode, but only when at least one package
   // has the target script. Otherwise fall through to single-app mode so
-  // a workspace root with its own portless.json + dev script still works.
+  // a workspace root with its own dev script still works.
   const wsRoot = findWorkspaceRoot(cwd);
   if (wsRoot === cwd) {
     const packages = discoverWorkspacePackages(cwd);
@@ -2374,10 +2374,7 @@ async function handleDefaultMode(globalScript?: string): Promise<boolean> {
     }
   }
 
-  // Single-app mode requires portless.json or --script to activate.
   const appConfig = loadAppConfig(cwd);
-  if (!appConfig && !globalScript) return false;
-
   const scriptName = globalScript ?? appConfig?.script ?? "dev";
   if (hasScript(scriptName, cwd)) {
     await handleDefaultSingle(cwd, scriptName, appConfig);
@@ -2445,7 +2442,10 @@ async function handleDefaultSingle(
  */
 interface MultiAppEntry {
   pkg: WorkspacePackage;
+  /** Portless hostname (e.g. "web.json-render") */
   name: string;
+  /** Human-readable package label for display (e.g. "web") */
+  label: string;
   commandArgs: string[];
   appPort?: number;
   proxied: boolean;
@@ -2676,11 +2676,13 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
     const proxied = appOverride.proxy ?? isServerCommand(rawScript);
 
     let name: string;
+    let label: string;
     if (appOverride.name) {
       name = appOverride.name
         .split(".")
-        .map((label) => truncateLabel(label))
+        .map((l) => truncateLabel(l))
         .join(".");
+      label = appOverride.name;
     } else {
       let pkgLabel: string;
       if (pkg.name) {
@@ -2690,9 +2692,10 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
         pkgLabel = rel.replace(/\//g, "-");
       }
       name = pkgLabel === projectName ? projectName : `${pkgLabel}.${projectName}`;
+      label = pkg.scope ? `@${pkg.scope}/${pkg.name}` : (pkg.name ?? rel);
     }
 
-    apps.push({ pkg, name, commandArgs, appPort: appOverride.appPort, proxied });
+    apps.push({ pkg, name, label, commandArgs, appPort: appOverride.appPort, proxied });
   }
 
   if (apps.length === 0) {
@@ -2700,6 +2703,7 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
     process.exit(1);
   }
 
+  apps.sort((a, b) => a.label.localeCompare(b.label));
   const proxiedApps = apps.filter((a) => a.proxied);
   const taskApps = apps.filter((a) => !a.proxied);
 
@@ -2756,12 +2760,12 @@ async function runWithTurbo(
 
   const manifest: Record<string, ManifestEntry> = {};
   const routes: { hostname: string }[] = [];
-  const appUrls: { name: string; url: string }[] = [];
+  const appUrls: { label: string; url: string }[] = [];
 
   for (const app of proxiedApps) {
     const usesPortless = app.commandArgs[0] === "portless";
     if (usesPortless) {
-      appUrls.push({ name: app.name, url: "(managed by portless)" });
+      appUrls.push({ label: app.label, url: "(managed by portless)" });
       continue;
     }
 
@@ -2770,7 +2774,7 @@ async function runWithTurbo(
     const portSuffix =
       (tls && proxyPort === 443) || (!tls && proxyPort === 80) ? "" : `:${proxyPort}`;
     const url = `${protocol}://${app.name}.${tld}${portSuffix}`;
-    appUrls.push({ name: app.name, url });
+    appUrls.push({ label: app.label, url });
 
     const hostname = parseHostname(app.name, tld);
     store.addRoute(hostname, appPort, process.pid);
@@ -2793,17 +2797,19 @@ async function runWithTurbo(
   ensureEnvLoader();
   writeManifest(manifest);
 
-  if (appUrls.length > 0) {
-    const maxName = Math.max(...appUrls.map((a) => a.name.length));
-    for (const { name, url } of appUrls) {
-      const pad = " ".repeat(maxName - name.length);
-      console.log(`  ${chalk.bold(name)}${pad}  ${chalk.cyan(url)}`);
-    }
-  }
-  if (taskApps.length > 0) {
-    console.log("");
-    for (const app of taskApps) {
-      console.log(`  ${chalk.gray(app.name)}  ${chalk.gray(app.commandArgs.join(" "))}`);
+  const allApps = [
+    ...appUrls.map(({ label, url }) => ({ label, url })),
+    ...taskApps.map((app) => ({ label: app.label, url: undefined })),
+  ];
+  if (allApps.length > 0) {
+    const maxLabel = Math.max(...allApps.map((a) => a.label.length));
+    for (const { label, url } of allApps) {
+      const pad = " ".repeat(maxLabel - label.length);
+      if (url) {
+        console.log(`  ${label}${pad}  ${chalk.dim(url)}`);
+      } else {
+        console.log(`  ${chalk.dim(label)}`);
+      }
     }
   }
   console.log("");
@@ -2881,7 +2887,7 @@ async function runWithDirectSpawn(
 ): Promise<void> {
   const children: ReturnType<typeof spawn>[] = [];
   const exitCodes = new Map<string, number | null>();
-  const appUrls: { name: string; url: string; cmd: string }[] = [];
+  const appUrls: { label: string; url: string }[] = [];
   const routeEntries: { store: RouteStore; hostname: string }[] = [];
 
   // Sequential: each spawnProxiedApp calls findFreePort() which binds/releases
@@ -2897,27 +2903,29 @@ async function runWithDirectSpawn(
     );
     children.push(child);
     if (route) routeEntries.push(route);
-    appUrls.push({ name: app.name, url: displayUrl, cmd: app.commandArgs.join(" ") });
+    appUrls.push({ label: app.label, url: displayUrl });
   }
 
-  const taskNames: { name: string; cmd: string }[] = [];
+  const taskLabels: string[] = [];
   for (const app of taskApps) {
     children.push(spawnTaskApp(app, exitCodes));
-    taskNames.push({ name: app.name, cmd: app.commandArgs.join(" ") });
+    taskLabels.push(app.label);
   }
 
   // Print a clean summary after all processes are spawned.
-  if (appUrls.length > 0) {
-    const maxName = Math.max(...appUrls.map((a) => a.name.length));
-    for (const { name, url, cmd } of appUrls) {
-      const pad = " ".repeat(maxName - name.length);
-      console.log(`  ${chalk.bold(name)}${pad}  ${chalk.cyan(url)}  ${chalk.gray(cmd)}`);
-    }
-  }
-  if (taskNames.length > 0) {
-    console.log("");
-    for (const { name, cmd } of taskNames) {
-      console.log(`  ${chalk.gray(name)}  ${chalk.gray(cmd)}`);
+  const allApps = [
+    ...appUrls.map(({ label, url }) => ({ label, url })),
+    ...taskLabels.map((label) => ({ label, url: undefined as string | undefined })),
+  ];
+  if (allApps.length > 0) {
+    const maxLabel = Math.max(...allApps.map((a) => a.label.length));
+    for (const { label, url } of allApps) {
+      const pad = " ".repeat(maxLabel - label.length);
+      if (url) {
+        console.log(`  ${label}${pad}  ${chalk.dim(url)}`);
+      } else {
+        console.log(`  ${chalk.dim(label)}`);
+      }
     }
   }
   console.log("");
@@ -2985,10 +2993,7 @@ async function handleRunMode(args: string[], globalScript?: string): Promise<voi
 
   const appConfig = loadAppConfig();
 
-  // Script/command fallback: only resolve from config when a portless.json
-  // exists or --script was passed. Without config, `portless run` with no
-  // args still errors (backwards compatible).
-  if (parsed.commandArgs.length === 0 && (appConfig || globalScript)) {
+  if (parsed.commandArgs.length === 0) {
     const scriptName = globalScript ?? appConfig?.script ?? "dev";
     const resolved = resolveScriptCommand(scriptName, process.cwd());
     if (resolved) {
@@ -3226,17 +3231,17 @@ async function main() {
     process.env.PORTLESS === "skip";
   if (
     skipPortless &&
-    (isRunCommand || (args.length >= 2 && args[0] !== "proxy" && args[0] !== "clean"))
+    (isRunCommand ||
+      args.length === 0 ||
+      (args.length >= 2 && args[0] !== "proxy" && args[0] !== "clean"))
   ) {
     const parsed = isRunCommand ? parseRunArgs(args) : parseAppArgs(args);
     let commandArgs = parsed.commandArgs;
-    if (commandArgs.length === 0 && isRunCommand) {
+    if (commandArgs.length === 0 && (isRunCommand || args.length === 0)) {
       const appConfig = loadAppConfig();
-      if (appConfig || globalScript) {
-        const scriptName = globalScript ?? appConfig?.script ?? "dev";
-        const resolved = resolveScriptCommand(scriptName, process.cwd());
-        if (resolved) commandArgs = resolved;
-      }
+      const scriptName = globalScript ?? appConfig?.script ?? "dev";
+      const resolved = resolveScriptCommand(scriptName, process.cwd());
+      if (resolved) commandArgs = resolved;
     }
     if (commandArgs.length === 0) {
       console.error(colors.red("Error: No command provided."));

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -76,6 +76,14 @@ import {
 import type { AppConfig } from "./config.js";
 import { findWorkspaceRoot, discoverWorkspacePackages } from "./workspace.js";
 import type { WorkspacePackage } from "./workspace.js";
+import {
+  ensureEnvLoader,
+  writeManifest,
+  removeManifest,
+  buildNodeOptions,
+  hasTurboConfig,
+} from "./turbo.js";
+import type { ManifestEntry } from "./turbo.js";
 
 const chalk = colors;
 
@@ -2718,6 +2726,150 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
     }
   }
 
+  const useTurbo = loaded?.config.turbo !== false && hasTurboConfig(wsRoot);
+
+  if (useTurbo) {
+    await runWithTurbo(wsRoot, dir, port, tls, tld, scriptName, proxiedApps, taskApps);
+  } else {
+    await runWithDirectSpawn(dir, port, tls, tld, proxiedApps, taskApps);
+  }
+}
+
+async function runWithTurbo(
+  wsRoot: string,
+  stateDir: string,
+  proxyPort: number,
+  tls: boolean,
+  tld: string,
+  scriptName: string,
+  proxiedApps: MultiAppEntry[],
+  taskApps: MultiAppEntry[]
+): Promise<void> {
+  const store = new RouteStore(stateDir, {
+    onWarning: (msg: string) => console.warn(colors.yellow(msg)),
+  });
+
+  const manifest: Record<string, ManifestEntry> = {};
+  const routes: { hostname: string }[] = [];
+  const appUrls: { name: string; url: string }[] = [];
+
+  for (const app of proxiedApps) {
+    const usesPortless = app.commandArgs[0] === "portless";
+    if (usesPortless) {
+      appUrls.push({ name: app.name, url: "(managed by portless)" });
+      continue;
+    }
+
+    const appPort = app.appPort ?? (await findFreePort());
+    const protocol = tls ? "https" : "http";
+    const portSuffix =
+      (tls && proxyPort === 443) || (!tls && proxyPort === 80) ? "" : `:${proxyPort}`;
+    const url = `${protocol}://${app.name}.${tld}${portSuffix}`;
+    appUrls.push({ name: app.name, url });
+
+    const hostname = parseHostname(app.name, tld);
+    store.addRoute(hostname, appPort, process.pid);
+    routes.push({ hostname });
+
+    const entry: ManifestEntry = {
+      PORT: String(appPort),
+      HOST: "127.0.0.1",
+      PORTLESS_URL: url,
+    };
+    if (tls) {
+      const caPath = path.join(stateDir, "ca.pem");
+      if (fs.existsSync(caPath)) {
+        entry.NODE_EXTRA_CA_CERTS = caPath;
+      }
+    }
+    manifest[app.pkg.dir] = entry;
+  }
+
+  ensureEnvLoader();
+  writeManifest(manifest);
+
+  if (appUrls.length > 0) {
+    const maxName = Math.max(...appUrls.map((a) => a.name.length));
+    for (const { name, url } of appUrls) {
+      const pad = " ".repeat(maxName - name.length);
+      console.log(`  ${chalk.bold(name)}${pad}  ${chalk.cyan(url)}`);
+    }
+  }
+  if (taskApps.length > 0) {
+    console.log("");
+    for (const app of taskApps) {
+      console.log(`  ${chalk.gray(app.name)}  ${chalk.gray(app.commandArgs.join(" "))}`);
+    }
+  }
+  console.log("");
+
+  const pm = detectPackageManager(wsRoot);
+  const turboArgs =
+    pm === "npm"
+      ? ["npx", "turbo", "run", scriptName]
+      : pm === "bun"
+        ? ["bunx", "turbo", "run", scriptName]
+        : [pm, "exec", "turbo", "run", scriptName];
+
+  const turboChild = spawn(turboArgs[0], turboArgs.slice(1), {
+    stdio: "inherit",
+    cwd: wsRoot,
+    env: {
+      ...process.env,
+      NODE_OPTIONS: buildNodeOptions(),
+    },
+  });
+
+  const SIGKILL_TIMEOUT_MS = 5_000;
+
+  const cleanup = () => {
+    try {
+      turboChild.kill("SIGTERM");
+    } catch {
+      // already dead
+    }
+    setTimeout(() => {
+      if (turboChild.exitCode === null && !turboChild.killed) {
+        try {
+          turboChild.kill("SIGKILL");
+        } catch {
+          // already dead
+        }
+      }
+    }, SIGKILL_TIMEOUT_MS).unref();
+
+    for (const { hostname } of routes) {
+      try {
+        store.removeRoute(hostname);
+      } catch {
+        // non-fatal
+      }
+    }
+    removeManifest();
+  };
+
+  process.on("SIGINT", cleanup);
+  process.on("SIGTERM", cleanup);
+
+  const exitCode = await new Promise<number | null>((resolve) => {
+    turboChild.on("exit", (code) => resolve(code));
+  });
+
+  cleanup();
+
+  if (exitCode !== 0 && exitCode !== null) {
+    process.exit(exitCode);
+  }
+}
+
+async function runWithDirectSpawn(
+  stateDir: string,
+  proxyPort: number,
+  tls: boolean,
+  tld: string,
+  proxiedApps: MultiAppEntry[],
+  taskApps: MultiAppEntry[]
+): Promise<void> {
   const children: ReturnType<typeof spawn>[] = [];
   const exitCodes = new Map<string, number | null>();
   const appUrls: { name: string; url: string; cmd: string }[] = [];
@@ -2725,7 +2877,14 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
   // Sequential: each spawnProxiedApp calls findFreePort() which binds/releases
   // a port, so parallel spawning could cause port collisions.
   for (const app of proxiedApps) {
-    const { child, displayUrl } = await spawnProxiedApp(app, dir, port, tls, tld, exitCodes);
+    const { child, displayUrl } = await spawnProxiedApp(
+      app,
+      stateDir,
+      proxyPort,
+      tls,
+      tld,
+      exitCodes
+    );
     children.push(child);
     appUrls.push({ name: app.name, url: displayUrl, cmd: app.commandArgs.join(" ") });
   }

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -2475,7 +2475,7 @@ function prefixStream(
     buffer += decoder.write(data);
     let idx: number;
     while ((idx = buffer.indexOf("\n")) !== -1) {
-      const line = buffer.slice(0, idx);
+      const line = buffer.slice(0, idx).replace(/\r$/, "");
       buffer = buffer.slice(idx + 1);
       output.write(`${prefix} ${line}\n`);
     }
@@ -2498,7 +2498,11 @@ async function spawnProxiedApp(
   tls: boolean,
   tld: string,
   exitCodes: Map<string, number | null>
-): Promise<{ child: ReturnType<typeof spawn>; displayUrl: string }> {
+): Promise<{
+  child: ReturnType<typeof spawn>;
+  displayUrl: string;
+  route: { store: RouteStore; hostname: string } | null;
+}> {
   const usesPortless = app.commandArgs[0] === "portless";
 
   const pkgEnv: Record<string, string | undefined> = { ...process.env };
@@ -2563,7 +2567,8 @@ async function spawnProxiedApp(
     }
   });
 
-  return { child, displayUrl };
+  const route = store && hostname ? { store, hostname } : null;
+  return { child, displayUrl, route };
 }
 
 function spawnTaskApp(
@@ -2822,7 +2827,11 @@ async function runWithTurbo(
 
   const SIGKILL_TIMEOUT_MS = 5_000;
 
+  let cleanedUp = false;
   const cleanup = () => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+
     try {
       turboChild.kill("SIGTERM");
     } catch {
@@ -2873,11 +2882,12 @@ async function runWithDirectSpawn(
   const children: ReturnType<typeof spawn>[] = [];
   const exitCodes = new Map<string, number | null>();
   const appUrls: { name: string; url: string; cmd: string }[] = [];
+  const routeEntries: { store: RouteStore; hostname: string }[] = [];
 
   // Sequential: each spawnProxiedApp calls findFreePort() which binds/releases
   // a port, so parallel spawning could cause port collisions.
   for (const app of proxiedApps) {
-    const { child, displayUrl } = await spawnProxiedApp(
+    const { child, displayUrl, route } = await spawnProxiedApp(
       app,
       stateDir,
       proxyPort,
@@ -2886,6 +2896,7 @@ async function runWithDirectSpawn(
       exitCodes
     );
     children.push(child);
+    if (route) routeEntries.push(route);
     appUrls.push({ name: app.name, url: displayUrl, cmd: app.commandArgs.join(" ") });
   }
 
@@ -2913,7 +2924,11 @@ async function runWithDirectSpawn(
 
   const SIGKILL_TIMEOUT_MS = 5_000;
 
+  let cleanedUp = false;
   const cleanup = () => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+
     for (const child of children) {
       try {
         child.kill("SIGTERM");
@@ -2932,6 +2947,14 @@ async function runWithDirectSpawn(
         }
       }
     }, SIGKILL_TIMEOUT_MS).unref();
+
+    for (const { store, hostname } of routeEntries) {
+      try {
+        store.removeRoute(hostname);
+      } catch {
+        // non-fatal
+      }
+    }
   };
 
   process.on("SIGINT", cleanup);

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -922,10 +922,11 @@ async function ensureProxyRunning(
       console.error(colors.gray(`Logs: ${logPath}`));
     }
     process.exit(1);
+    return { started: false }; // unreachable; helps TypeScript narrow `discovered`
   }
 
   console.log(colors.green("Proxy started in background"));
-  return { started: true, state: discovered! };
+  return { started: true, state: discovered };
 }
 
 async function runApp(
@@ -2389,7 +2390,7 @@ async function handleDefaultMode(globalScript?: string): Promise<boolean> {
 
   const scriptName = globalScript ?? appConfig?.script ?? "dev";
   if (hasScript(scriptName, cwd)) {
-    await handleDefaultSingle(cwd, scriptName);
+    await handleDefaultSingle(cwd, scriptName, appConfig);
     return true;
   }
 
@@ -2399,9 +2400,11 @@ async function handleDefaultMode(globalScript?: string): Promise<boolean> {
 /**
  * Single-app mode: run one package through the proxy.
  */
-async function handleDefaultSingle(cwd: string, scriptName: string): Promise<void> {
-  const appConfig = loadAppConfig(cwd);
-
+async function handleDefaultSingle(
+  cwd: string,
+  scriptName: string,
+  appConfig: AppConfig | null
+): Promise<void> {
   const resolved = resolveScript(scriptName, cwd);
   if (!resolved) {
     console.error(colors.red(`Error: No "${scriptName}" script found in package.json.`));
@@ -2623,10 +2626,10 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
     const rootOverride = loaded ? resolveAppConfig(loaded.config, loaded.configDir, pkg.dir) : null;
     const pkgConfig = loadPackagePortlessConfig(pkg.dir);
 
-    // Merge: root apps map > package.json "portless" key > defaults
+    // Merge (closest wins): package.json "portless" > portless.json app entry > defaults
     const appOverride: AppConfig = {
-      ...pkgConfig,
       ...Object.fromEntries(Object.entries(rootOverride ?? {}).filter(([, v]) => v !== undefined)),
+      ...Object.fromEntries(Object.entries(pkgConfig ?? {}).filter(([, v]) => v !== undefined)),
     };
 
     const effectiveScript = appOverride.script ?? scriptName;
@@ -2635,7 +2638,7 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
     const resolved = resolveScript(effectiveScript, pkg.dir);
     if (!resolved) continue;
 
-    const proxied = isServerCommand(resolved);
+    const proxied = appOverride.proxy ?? isServerCommand(resolved);
 
     let name: string;
     if (appOverride.name) {
@@ -2682,6 +2685,8 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
 
   const children: ReturnType<typeof spawn>[] = [];
 
+  // Sequential: each spawnProxiedApp calls findFreePort() which binds/releases
+  // a port, so parallel spawning could cause port collisions.
   for (const app of proxiedApps) {
     children.push(await spawnProxiedApp(app, dir, port, tls, tld));
   }

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -2399,6 +2399,23 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
 
   const scriptName = globalScript ?? loaded?.config.script ?? "dev";
 
+  // Infer the monorepo project name for use as the base domain.
+  // Config name > common npm scope > workspace root inference.
+  let projectName: string;
+  if (loaded?.config.name) {
+    projectName = loaded.config.name
+      .split(".")
+      .map((label) => truncateLabel(label))
+      .join(".");
+  } else {
+    const commonScope = packages.find((p) => p.scope)?.scope;
+    if (commonScope) {
+      projectName = sanitizeForHostname(commonScope) || inferProjectName(wsRoot).name;
+    } else {
+      projectName = inferProjectName(wsRoot).name;
+    }
+  }
+
   interface AppEntry {
     pkg: WorkspacePackage;
     name: string;
@@ -2424,11 +2441,15 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
         .split(".")
         .map((label) => truncateLabel(label))
         .join(".");
-    } else if (pkg.name) {
-      const sanitized = sanitizeForHostname(pkg.name);
-      name = sanitized || rel.replace(/\//g, "-");
     } else {
-      name = rel.replace(/\//g, "-");
+      let pkgLabel: string;
+      if (pkg.name) {
+        const sanitized = sanitizeForHostname(pkg.name);
+        pkgLabel = sanitized || rel.replace(/\//g, "-");
+      } else {
+        pkgLabel = rel.replace(/\//g, "-");
+      }
+      name = `${pkgLabel}.${projectName}`;
     }
 
     apps.push({ pkg, name, commandArgs: resolved, appPort: appOverride?.appPort });

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -40,7 +40,6 @@ import {
   isLanEnvEnabled,
   isProxyRunning,
   isWindows,
-  prompt,
   readLanMarker,
   readPersistedProxyState,
   readTldFromDir,
@@ -66,10 +65,11 @@ import {
 import {
   loadConfig,
   resolveAppConfig,
-  resolveScript,
   resolveScriptCommand,
   hasScript,
   isServerCommand,
+  splitCommand,
+  detectPackageManager,
   loadPackagePortlessConfig,
   ConfigValidationError,
 } from "./config.js";
@@ -767,8 +767,7 @@ function listRoutes(store: RouteStore, proxyPort: number, tls: boolean): void {
 
 type EnsureProxyResult =
   | { started: true; state: Awaited<ReturnType<typeof discoverState>> }
-  | { started: false; skipped: true }
-  | { started: false; skipped?: false };
+  | { started: false };
 
 interface ProxyDesiredState {
   explicit: ProxyConfigExplicitness;
@@ -803,17 +802,13 @@ function resolveProxyDesiredState(lanMode: boolean): ProxyDesiredState {
 
 /**
  * Check if the proxy is running and auto-start it if needed.
- * Returns the discovered state after start, or `{ skipped: true }` when the
- * user chose to skip, or `{ started: false }` when the proxy was already up.
- *
- * When `onSkip` is provided and the user chooses "skip", calls `onSkip`
- * and returns `{ skipped: true }`. Pass null to disable the skip option.
+ * Returns the discovered state after start, or `{ started: false }` when
+ * the proxy was already up.
  */
 async function ensureProxyRunning(
   proxyPort: number,
   tls: boolean,
-  desired: ProxyDesiredState,
-  onSkip: (() => void) | null
+  desired: ProxyDesiredState
 ): Promise<EnsureProxyResult> {
   const { explicit, desiredConfig } = desired;
 
@@ -865,29 +860,7 @@ async function ensureProxyRunning(
     process.exit(1);
   }
 
-  if (needsSudo) {
-    const answer = await prompt(colors.yellow("Proxy not running. Start it? [Y/n/skip] "));
-
-    if (answer === "n" || answer === "no") {
-      console.log(colors.gray("Cancelled."));
-      process.exit(0);
-    }
-
-    if (onSkip && (answer === "s" || answer === "skip")) {
-      onSkip();
-      return { started: false, skipped: true };
-    }
-  }
-
-  if (persisted && startPort !== undefined) {
-    console.log(
-      colors.yellow(
-        `Starting proxy with previous configuration (port ${startPort}, ${startConfig.useHttps ? "HTTPS" : "HTTP"})...`
-      )
-    );
-  } else {
-    console.log(colors.yellow("Starting proxy..."));
-  }
+  console.log(colors.gray("Starting proxy..."));
   const proxyStartConfig = buildProxyStartConfig({
     useHttps: startConfig.useHttps,
     customCertPath: startConfig.customCertPath,
@@ -932,7 +905,6 @@ async function ensureProxyRunning(
     return { started: false }; // unreachable; helps TypeScript narrow `discovered`
   }
 
-  console.log(colors.green("Proxy started in background"));
   return { started: true, state: discovered };
 }
 
@@ -964,14 +936,7 @@ async function runApp(
   // Validate the hostname before we try to auto-start the proxy.
   parseHostname(name, tld);
 
-  const ensureResult = await ensureProxyRunning(proxyPort, tls, desired, () => {
-    console.log(colors.gray("Skipping proxy, running command directly...\n"));
-    spawnCommand(commandArgs);
-  });
-
-  if (ensureResult.started === false && ensureResult.skipped) {
-    return;
-  }
+  const ensureResult = await ensureProxyRunning(proxyPort, tls, desired);
 
   if (ensureResult.started) {
     proxyPort = ensureResult.state.port;
@@ -2522,8 +2487,7 @@ async function spawnProxiedApp(
   tls: boolean,
   tld: string,
   exitCodes: Map<string, number | null>
-): Promise<ReturnType<typeof spawn>> {
-  const displayStr = app.commandArgs.join(" ");
+): Promise<{ child: ReturnType<typeof spawn>; displayUrl: string }> {
   const usesPortless = app.commandArgs[0] === "portless";
 
   const pkgEnv: Record<string, string | undefined> = { ...process.env };
@@ -2567,12 +2531,6 @@ async function spawnProxiedApp(
     }
   }
 
-  console.log(
-    chalk.cyan(`  ${app.name}`),
-    chalk.gray(`-> ${displayUrl}`),
-    chalk.gray(`(${displayStr})`)
-  );
-
   const child = spawnChildProcess(app.commandArgs, env, app.pkg.dir);
   pipeOutput(child, chalk.cyan(`[${app.name}]`));
 
@@ -2594,18 +2552,15 @@ async function spawnProxiedApp(
     }
   });
 
-  return child;
+  return { child, displayUrl };
 }
 
 function spawnTaskApp(
   app: MultiAppEntry,
   exitCodes: Map<string, number | null>
 ): ReturnType<typeof spawn> {
-  const displayStr = app.commandArgs.join(" ");
   const pkgEnv: Record<string, string | undefined> = { ...process.env };
   pkgEnv.PATH = augmentedPath(pkgEnv, app.pkg.dir);
-
-  console.log(chalk.gray(`  ${app.name}`), chalk.gray(`(${displayStr})`));
 
   const child = spawnChildProcess(app.commandArgs, pkgEnv, app.pkg.dir);
   pipeOutput(child, chalk.gray(`[${app.name}]`));
@@ -2675,7 +2630,16 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
   for (const pkg of packages) {
     const rel = path.relative(wsRoot, pkg.dir).replace(/\\/g, "/");
     const rootOverride = loaded ? resolveAppConfig(loaded.config, loaded.configDir, pkg.dir) : null;
-    const pkgConfig = loadPackagePortlessConfig(pkg.dir);
+    let pkgConfig: AppConfig | null;
+    try {
+      pkgConfig = loadPackagePortlessConfig(pkg.dir);
+    } catch (err) {
+      if (err instanceof ConfigValidationError) {
+        console.error(colors.red(`Error: ${err.message}`));
+        process.exit(1);
+      }
+      throw err;
+    }
 
     // Merge (closest wins): package.json "portless" > portless.json app entry > defaults
     const appOverride: AppConfig = {
@@ -2684,13 +2648,14 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
     };
 
     const effectiveScript = appOverride.script ?? scriptName;
-    if (!pkg.scripts[effectiveScript]) continue;
+    const scriptValue = pkg.scripts[effectiveScript];
+    if (!scriptValue) continue;
 
-    const rawScript = resolveScript(effectiveScript, pkg.dir);
-    if (!rawScript) continue;
+    const rawScript = splitCommand(scriptValue);
+    if (rawScript.length === 0) continue;
 
-    const commandArgs = resolveScriptCommand(effectiveScript, pkg.dir);
-    if (!commandArgs) continue;
+    const pm = detectPackageManager(pkg.dir);
+    const commandArgs = [pm, "run", effectiveScript];
 
     const proxied = appOverride.proxy ?? isServerCommand(rawScript);
 
@@ -2723,7 +2688,6 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
   const taskApps = apps.filter((a) => !a.proxied);
 
   console.log(chalk.blue.bold(`\nportless\n`));
-  console.log(chalk.gray(`Starting ${apps.length} app${apps.length === 1 ? "" : "s"}...\n`));
 
   let { dir, port, tls, tld } = await discoverState();
 
@@ -2735,35 +2699,50 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
       console.error(colors.red(`Error: ${(err as Error).message}`));
       process.exit(1);
     }
-    const ensureResult = await ensureProxyRunning(port, tls, multiDesired, null);
+    const ensureResult = await ensureProxyRunning(port, tls, multiDesired);
     if (ensureResult.started) {
       dir = ensureResult.state.dir;
       port = ensureResult.state.port;
       tls = ensureResult.state.tls;
       tld = ensureResult.state.tld;
-    } else if (!("skipped" in ensureResult && ensureResult.skipped)) {
-      // Proxy was already running -- re-discover to pick up current state
-      // (markers may have been recreated since the first call).
+    } else {
+      // Proxy was already running; re-discover to pick up current state.
       ({ dir, port, tls, tld } = await discoverState());
     }
   }
 
   const children: ReturnType<typeof spawn>[] = [];
   const exitCodes = new Map<string, number | null>();
+  const appUrls: { name: string; url: string; cmd: string }[] = [];
 
   // Sequential: each spawnProxiedApp calls findFreePort() which binds/releases
   // a port, so parallel spawning could cause port collisions.
   for (const app of proxiedApps) {
-    children.push(await spawnProxiedApp(app, dir, port, tls, tld, exitCodes));
+    const { child, displayUrl } = await spawnProxiedApp(app, dir, port, tls, tld, exitCodes);
+    children.push(child);
+    appUrls.push({ name: app.name, url: displayUrl, cmd: app.commandArgs.join(" ") });
   }
 
-  if (taskApps.length > 0) {
-    console.log(chalk.gray(`\n  Tasks:\n`));
-  }
+  const taskNames: { name: string; cmd: string }[] = [];
   for (const app of taskApps) {
     children.push(spawnTaskApp(app, exitCodes));
+    taskNames.push({ name: app.name, cmd: app.commandArgs.join(" ") });
   }
 
+  // Print a clean summary after all processes are spawned.
+  if (appUrls.length > 0) {
+    const maxName = Math.max(...appUrls.map((a) => a.name.length));
+    for (const { name, url, cmd } of appUrls) {
+      const pad = " ".repeat(maxName - name.length);
+      console.log(`  ${chalk.bold(name)}${pad}  ${chalk.cyan(url)}  ${chalk.gray(cmd)}`);
+    }
+  }
+  if (taskNames.length > 0) {
+    console.log("");
+    for (const { name, cmd } of taskNames) {
+      console.log(`  ${chalk.gray(name)}  ${chalk.gray(cmd)}`);
+    }
+  }
   console.log("");
 
   const SIGKILL_TIMEOUT_MS = 5_000;

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -948,6 +948,9 @@ async function runApp(
     store = new RouteStore(stateDir, {
       onWarning: (msg: string) => console.warn(colors.yellow(msg)),
     });
+    if (tls && !isCATrusted(stateDir)) {
+      await handleTrust();
+    }
   } else {
     const runningConfig = readCurrentProxyConfig(stateDir);
 
@@ -2708,6 +2711,10 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
     } else {
       // Proxy was already running; re-discover to pick up current state.
       ({ dir, port, tls, tld } = await discoverState());
+    }
+
+    if (tls && !isCATrusted(dir)) {
+      await handleTrust();
     }
   }
 

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -6,6 +6,7 @@ import colors from "./colors.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { spawn, spawnSync } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
 import { createSNICallback, ensureCerts, isCATrusted, trustCA, untrustCA } from "./certs.js";
 import { createHttpRedirectServer, createProxyServer } from "./proxy.js";
 import { fixOwnership, formatUrl, isErrnoException, parseHostname } from "./utils.js";
@@ -2374,11 +2375,27 @@ function loadAppConfig(cwd: string = process.cwd()): AppConfig | null {
 async function handleDefaultMode(globalScript?: string): Promise<boolean> {
   const cwd = process.cwd();
 
-  // Workspace root: multi-app mode
+  // Workspace root: multi-app mode, but only when at least one package
+  // has the target script. Otherwise fall through to single-app mode so
+  // a workspace root with its own portless.json + dev script still works.
   const wsRoot = findWorkspaceRoot(cwd);
   if (wsRoot === cwd) {
-    await handleDefaultMulti(cwd, globalScript);
-    return true;
+    const packages = discoverWorkspacePackages(cwd);
+    let wsScriptName: string;
+    try {
+      wsScriptName = globalScript ?? loadConfig(cwd)?.config.script ?? "dev";
+    } catch (err) {
+      if (err instanceof ConfigValidationError) {
+        console.error(colors.red(`Error: ${err.message}`));
+        process.exit(1);
+      }
+      throw err;
+    }
+    const hasMatchingPackages = packages.some((p) => p.scripts[wsScriptName]);
+    if (hasMatchingPackages) {
+      await handleDefaultMulti(cwd, globalScript);
+      return true;
+    }
   }
 
   // Single-app mode requires portless.json or --script to activate.
@@ -2476,19 +2493,20 @@ function prefixStream(
   prefix: string
 ): void {
   if (!stream) return;
+  const decoder = new StringDecoder("utf8");
   let buffer = "";
   stream.on("data", (data: Buffer) => {
-    buffer += data.toString();
+    buffer += decoder.write(data);
     let idx: number;
     while ((idx = buffer.indexOf("\n")) !== -1) {
       const line = buffer.slice(0, idx);
       buffer = buffer.slice(idx + 1);
-      if (line) output.write(`${prefix} ${line}\n`);
+      output.write(`${prefix} ${line}\n`);
     }
   });
   stream.on("end", () => {
+    buffer += decoder.end();
     if (buffer) output.write(`${prefix} ${buffer}\n`);
-    buffer = "";
   });
 }
 
@@ -2748,6 +2766,8 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
 
   console.log("");
 
+  const SIGKILL_TIMEOUT_MS = 5_000;
+
   const cleanup = () => {
     for (const child of children) {
       try {
@@ -2756,6 +2776,17 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
         // already dead
       }
     }
+    setTimeout(() => {
+      for (const child of children) {
+        if (child.exitCode === null && !child.killed) {
+          try {
+            child.kill("SIGKILL");
+          } catch {
+            // already dead
+          }
+        }
+      }
+    }, SIGKILL_TIMEOUT_MS).unref();
   };
 
   process.on("SIGINT", cleanup);

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -62,7 +62,7 @@ import {
   unpublish,
   cleanupAll as cleanupMdns,
 } from "./mdns.js";
-import { loadConfig, resolveAppConfig, resolveScript, hasScript } from "./config.js";
+import { loadConfig, resolveAppConfig, resolveScript, hasScript, isServerCommand, loadPackagePortlessConfig } from "./config.js";
 import type { AppConfig } from "./config.js";
 import { findWorkspaceRoot, discoverWorkspacePackages } from "./workspace.js";
 import type { WorkspacePackage } from "./workspace.js";
@@ -2422,6 +2422,8 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
     name: string;
     commandArgs: string[];
     appPort?: number;
+    /** Whether this app should be proxied. False for build-only tools. */
+    proxied: boolean;
   }
 
   const apps: AppEntry[] = [];
@@ -2430,14 +2432,28 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
     if (!pkg.scripts[scriptName]) continue;
 
     const rel = path.relative(wsRoot, pkg.dir).replace(/\\/g, "/");
-    const appOverride = loaded ? resolveAppConfig(loaded.config, loaded.configDir, pkg.dir) : null;
+    const rootOverride = loaded ? resolveAppConfig(loaded.config, loaded.configDir, pkg.dir) : null;
+    const pkgConfig = loadPackagePortlessConfig(pkg.dir);
 
-    const effectiveScript = appOverride?.script ?? scriptName;
+    // Merge: root apps map > package.json "portless" key > defaults
+    const appOverride: AppConfig = {
+      ...pkgConfig,
+      ...Object.fromEntries(
+        Object.entries(rootOverride ?? {}).filter(([, v]) => v !== undefined)
+      ),
+    };
+
+    const effectiveScript = appOverride.script ?? scriptName;
     const resolved = resolveScript(effectiveScript, pkg.dir);
     if (!resolved) continue;
 
+    // Determine if this app should be proxied.
+    // Explicit config wins, then check if the command is a known build tool.
+    const proxied =
+      appOverride.proxy !== undefined ? appOverride.proxy : isServerCommand(resolved);
+
     let name: string;
-    if (appOverride?.name) {
+    if (appOverride.name) {
       name = appOverride.name
         .split(".")
         .map((label) => truncateLabel(label))
@@ -2453,13 +2469,16 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
       name = pkgLabel === projectName ? projectName : `${pkgLabel}.${projectName}`;
     }
 
-    apps.push({ pkg, name, commandArgs: resolved, appPort: appOverride?.appPort });
+    apps.push({ pkg, name, commandArgs: resolved, appPort: appOverride.appPort, proxied });
   }
 
   if (apps.length === 0) {
     console.error(colors.yellow(`No workspace packages have a "${scriptName}" script.`));
     process.exit(1);
   }
+
+  const proxiedApps = apps.filter((a) => a.proxied);
+  const taskApps = apps.filter((a) => !a.proxied);
 
   console.log(chalk.blue.bold(`\nportless\n`));
   console.log(chalk.gray(`Starting ${apps.length} app${apps.length === 1 ? "" : "s"}...\n`));
@@ -2470,7 +2489,8 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
   // For multi-app, we spawn each as a separate child process.
   const children: ReturnType<typeof spawn>[] = [];
 
-  for (const app of apps) {
+  // Print proxied apps first, then tasks.
+  for (const app of proxiedApps) {
     const commandStr = app.commandArgs.join(" ");
     const usesPortless = app.commandArgs[0] === "portless";
 
@@ -2557,6 +2577,46 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
         } catch {
           // non-fatal
         }
+      }
+    });
+
+    children.push(child);
+  }
+
+  // Spawn task apps (build watchers etc.) — no proxy route, just run the command.
+  if (taskApps.length > 0) {
+    console.log(chalk.gray(`\n  Tasks:\n`));
+  }
+  for (const app of taskApps) {
+    const commandStr = app.commandArgs.join(" ");
+    const pkgEnv = { ...process.env };
+    pkgEnv.PATH = augmentedPath(pkgEnv, app.pkg.dir);
+
+    console.log(chalk.gray(`  ${app.name}`), chalk.gray(`(${commandStr})`));
+
+    const child = isWindows
+      ? spawn("cmd.exe", ["/d", "/s", "/c", commandStr], {
+          stdio: ["ignore", "pipe", "pipe"],
+          env: pkgEnv,
+          cwd: app.pkg.dir,
+        })
+      : spawn("/bin/sh", ["-c", commandStr], {
+          stdio: ["ignore", "pipe", "pipe"],
+          env: pkgEnv,
+          cwd: app.pkg.dir,
+        });
+
+    const prefix = chalk.gray(`[${app.name}]`);
+
+    child.stdout?.on("data", (data: Buffer) => {
+      for (const line of data.toString().split("\n")) {
+        if (line) process.stdout.write(`${prefix} ${line}\n`);
+      }
+    });
+
+    child.stderr?.on("data", (data: Buffer) => {
+      for (const line of data.toString().split("\n")) {
+        if (line) process.stderr.write(`${prefix} ${line}\n`);
       }
     });
 

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -70,6 +70,7 @@ import {
   hasScript,
   isServerCommand,
   loadPackagePortlessConfig,
+  ConfigValidationError,
 } from "./config.js";
 import type { AppConfig } from "./config.js";
 import { findWorkspaceRoot, discoverWorkspacePackages } from "./workspace.js";
@@ -768,28 +769,14 @@ type EnsureProxyResult =
   | { started: false; skipped: true }
   | { started: false; skipped?: false };
 
-/**
- * Check if the proxy is running and auto-start it if needed.
- * Returns the discovered state after start, or `{ skipped: true }` when the
- * user chose to skip, or `{ started: false }` when the proxy was already up.
- *
- * When `onSkip` is provided and the user chooses "skip", calls `onSkip`
- * and returns `{ skipped: true }`. Pass null to disable the skip option.
- */
-async function ensureProxyRunning(
-  proxyPort: number,
-  tls: boolean,
-  lanMode: boolean,
-  onSkip: (() => void) | null
-): Promise<EnsureProxyResult> {
-  let envTld: string;
-  try {
-    envTld = getDefaultTld();
-  } catch (err) {
-    console.error(colors.red(`Error: ${(err as Error).message}`));
-    process.exit(1);
-  }
+interface ProxyDesiredState {
+  explicit: ProxyConfigExplicitness;
+  desiredConfig: ReturnType<typeof resolveProxyConfig>;
+  envTld: string;
+}
 
+function resolveProxyDesiredState(lanMode: boolean): ProxyDesiredState {
+  const envTld = getDefaultTld();
   const explicit: ProxyConfigExplicitness = {
     useHttps: process.env.PORTLESS_HTTPS !== undefined,
     customCert: false,
@@ -810,6 +797,24 @@ async function ensureProxyRunning(
     tld: envTld,
     useWildcard: isWildcardEnvEnabled(),
   });
+  return { explicit, desiredConfig, envTld };
+}
+
+/**
+ * Check if the proxy is running and auto-start it if needed.
+ * Returns the discovered state after start, or `{ skipped: true }` when the
+ * user chose to skip, or `{ started: false }` when the proxy was already up.
+ *
+ * When `onSkip` is provided and the user chooses "skip", calls `onSkip`
+ * and returns `{ skipped: true }`. Pass null to disable the skip option.
+ */
+async function ensureProxyRunning(
+  proxyPort: number,
+  tls: boolean,
+  desired: ProxyDesiredState,
+  onSkip: (() => void) | null
+): Promise<EnsureProxyResult> {
+  const { explicit, desiredConfig } = desired;
 
   const proxyResponsive = await isProxyRunning(proxyPort, tls);
   const proxyListeningFromStateDir =
@@ -947,9 +952,9 @@ async function runApp(
   let store = initialStore;
   console.log(chalk.blue.bold(`\nportless\n`));
 
-  let envTld: string;
+  let desired: ProxyDesiredState;
   try {
-    envTld = getDefaultTld();
+    desired = resolveProxyDesiredState(lanMode);
   } catch (err) {
     console.error(colors.red(`Error: ${(err as Error).message}`));
     process.exit(1);
@@ -958,7 +963,7 @@ async function runApp(
   // Validate the hostname before we try to auto-start the proxy.
   parseHostname(name, tld);
 
-  const ensureResult = await ensureProxyRunning(proxyPort, tls, lanMode, () => {
+  const ensureResult = await ensureProxyRunning(proxyPort, tls, desired, () => {
     console.log(colors.gray("Skipping proxy, running command directly...\n"));
     spawnCommand(commandArgs);
   });
@@ -980,30 +985,13 @@ async function runApp(
   } else {
     const runningConfig = readCurrentProxyConfig(stateDir);
 
-    const explicit: ProxyConfigExplicitness = {
-      useHttps: process.env.PORTLESS_HTTPS !== undefined,
-      customCert: false,
-      lanMode: process.env.PORTLESS_LAN !== undefined,
-      lanIp: process.env.PORTLESS_LAN_IP !== undefined,
-      tld: process.env.PORTLESS_TLD !== undefined,
-      useWildcard: process.env.PORTLESS_WILDCARD !== undefined,
-    };
-    const desiredConfig = resolveProxyConfig({
-      persistedLanMode: lanMode,
-      explicit,
-      defaultTld: envTld,
-      useHttps: !isHttpsEnvDisabled(),
-      customCertPath: null,
-      customKeyPath: null,
-      lanMode: isLanEnvEnabled(),
-      lanIp: process.env.PORTLESS_LAN_IP || null,
-      tld: envTld,
-      useWildcard: isWildcardEnvEnabled(),
-    });
-
-    const mismatchMessages = getProxyConfigMismatchMessages(desiredConfig, runningConfig, explicit);
+    const mismatchMessages = getProxyConfigMismatchMessages(
+      desired.desiredConfig,
+      runningConfig,
+      desired.explicit
+    );
     if (mismatchMessages.length > 0) {
-      printProxyConfigMismatch(proxyPort, desiredConfig, mismatchMessages);
+      printProxyConfigMismatch(proxyPort, desired.desiredConfig, mismatchMessages);
     }
     lanMode = runningConfig.lanMode;
     lanIp = runningConfig.lanIp;
@@ -1014,10 +1002,10 @@ async function runApp(
   // (e.g. --lan changes tld from "localhost" to "local")
   const hostname = parseHostname(name, tld);
 
-  if (envTld !== DEFAULT_TLD && envTld !== tld) {
+  if (desired.envTld !== DEFAULT_TLD && desired.envTld !== tld) {
     console.warn(
       chalk.yellow(
-        `Warning: PORTLESS_TLD=${envTld} but the running proxy uses .${tld}. Using .${tld}.`
+        `Warning: PORTLESS_TLD=${desired.envTld} but the running proxy uses .${tld}. Using .${tld}.`
       )
     );
   }
@@ -2361,9 +2349,17 @@ ${colors.bold("LAN mode (--lan):")}
  * Handles both single-app (top-level fields) and monorepo (apps map) configs.
  */
 function loadAppConfig(cwd: string = process.cwd()): AppConfig | null {
-  const loaded = loadConfig(cwd);
-  if (!loaded) return null;
-  return resolveAppConfig(loaded.config, loaded.configDir, cwd);
+  try {
+    const loaded = loadConfig(cwd);
+    if (!loaded) return null;
+    return resolveAppConfig(loaded.config, loaded.configDir, cwd);
+  } catch (err) {
+    if (err instanceof ConfigValidationError) {
+      console.error(colors.red(`Error: ${err.message}`));
+      process.exit(1);
+    }
+    throw err;
+  }
 }
 
 /**
@@ -2371,7 +2367,7 @@ function loadAppConfig(cwd: string = process.cwd()): AppConfig | null {
  * Returns true if handled, false to fall through to help text.
  *
  * Activates when:
- * - At a workspace root (has pnpm-workspace.yaml in cwd) -> multi-app mode
+ * - At a workspace root (pnpm, npm, yarn, or bun) -> multi-app mode
  * - Has a portless.json or --script flag -> single-app mode
  * Without config, bare `portless` still prints help for backwards compat.
  */
@@ -2462,35 +2458,43 @@ interface MultiAppEntry {
   proxied: boolean;
 }
 
-function spawnShellCommand(
-  commandStr: string,
+function spawnChildProcess(
+  commandArgs: string[],
   env: Record<string, string | undefined>,
   cwd: string
 ): ReturnType<typeof spawn> {
-  return isWindows
-    ? spawn("cmd.exe", ["/d", "/s", "/c", commandStr], {
-        stdio: ["ignore", "pipe", "pipe"],
-        env,
-        cwd,
-      })
-    : spawn("/bin/sh", ["-c", commandStr], {
-        stdio: ["ignore", "pipe", "pipe"],
-        env,
-        cwd,
-      });
+  return spawn(commandArgs[0], commandArgs.slice(1), {
+    stdio: ["ignore", "pipe", "pipe"],
+    env,
+    cwd,
+  });
+}
+
+function prefixStream(
+  stream: NodeJS.ReadableStream | null,
+  output: NodeJS.WritableStream,
+  prefix: string
+): void {
+  if (!stream) return;
+  let buffer = "";
+  stream.on("data", (data: Buffer) => {
+    buffer += data.toString();
+    let idx: number;
+    while ((idx = buffer.indexOf("\n")) !== -1) {
+      const line = buffer.slice(0, idx);
+      buffer = buffer.slice(idx + 1);
+      if (line) output.write(`${prefix} ${line}\n`);
+    }
+  });
+  stream.on("end", () => {
+    if (buffer) output.write(`${prefix} ${buffer}\n`);
+    buffer = "";
+  });
 }
 
 function pipeOutput(child: ReturnType<typeof spawn>, prefix: string): void {
-  child.stdout?.on("data", (data: Buffer) => {
-    for (const line of data.toString().split("\n")) {
-      if (line) process.stdout.write(`${prefix} ${line}\n`);
-    }
-  });
-  child.stderr?.on("data", (data: Buffer) => {
-    for (const line of data.toString().split("\n")) {
-      if (line) process.stderr.write(`${prefix} ${line}\n`);
-    }
-  });
+  prefixStream(child.stdout, process.stdout, prefix);
+  prefixStream(child.stderr, process.stderr, prefix);
 }
 
 async function spawnProxiedApp(
@@ -2498,9 +2502,10 @@ async function spawnProxiedApp(
   stateDir: string,
   proxyPort: number,
   tls: boolean,
-  tld: string
+  tld: string,
+  exitCodes: Map<string, number | null>
 ): Promise<ReturnType<typeof spawn>> {
-  const commandStr = app.commandArgs.join(" ");
+  const displayStr = app.commandArgs.join(" ");
   const usesPortless = app.commandArgs[0] === "portless";
 
   const pkgEnv: Record<string, string | undefined> = { ...process.env };
@@ -2547,15 +2552,21 @@ async function spawnProxiedApp(
   console.log(
     chalk.cyan(`  ${app.name}`),
     chalk.gray(`-> ${displayUrl}`),
-    chalk.gray(`(${commandStr})`)
+    chalk.gray(`(${displayStr})`)
   );
 
-  const child = spawnShellCommand(commandStr, env, app.pkg.dir);
+  const child = spawnChildProcess(app.commandArgs, env, app.pkg.dir);
   pipeOutput(child, chalk.cyan(`[${app.name}]`));
 
   const capturedStore = store;
   const capturedHostname = hostname;
-  child.on("exit", () => {
+  child.on("exit", (code, signal) => {
+    exitCodes.set(app.name, code);
+    if (code !== 0 && code !== null) {
+      console.error(colors.red(`[${app.name}] exited with code ${code}`));
+    } else if (signal) {
+      console.error(colors.yellow(`[${app.name}] killed by ${signal}`));
+    }
     if (capturedStore && capturedHostname) {
       try {
         capturedStore.removeRoute(capturedHostname);
@@ -2568,21 +2579,42 @@ async function spawnProxiedApp(
   return child;
 }
 
-function spawnTaskApp(app: MultiAppEntry): ReturnType<typeof spawn> {
-  const commandStr = app.commandArgs.join(" ");
+function spawnTaskApp(
+  app: MultiAppEntry,
+  exitCodes: Map<string, number | null>
+): ReturnType<typeof spawn> {
+  const displayStr = app.commandArgs.join(" ");
   const pkgEnv: Record<string, string | undefined> = { ...process.env };
   pkgEnv.PATH = augmentedPath(pkgEnv, app.pkg.dir);
 
-  console.log(chalk.gray(`  ${app.name}`), chalk.gray(`(${commandStr})`));
+  console.log(chalk.gray(`  ${app.name}`), chalk.gray(`(${displayStr})`));
 
-  const child = spawnShellCommand(commandStr, pkgEnv, app.pkg.dir);
+  const child = spawnChildProcess(app.commandArgs, pkgEnv, app.pkg.dir);
   pipeOutput(child, chalk.gray(`[${app.name}]`));
+
+  child.on("exit", (code, signal) => {
+    exitCodes.set(app.name, code);
+    if (code !== 0 && code !== null) {
+      console.error(colors.red(`[${app.name}] exited with code ${code}`));
+    } else if (signal) {
+      console.error(colors.yellow(`[${app.name}] killed by ${signal}`));
+    }
+  });
 
   return child;
 }
 
 async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promise<void> {
-  const loaded = loadConfig(wsRoot);
+  let loaded: ReturnType<typeof loadConfig>;
+  try {
+    loaded = loadConfig(wsRoot);
+  } catch (err) {
+    if (err instanceof ConfigValidationError) {
+      console.error(colors.red(`Error: ${err.message}`));
+      process.exit(1);
+    }
+    throw err;
+  }
   const packages = discoverWorkspacePackages(wsRoot);
 
   if (packages.length === 0) {
@@ -2678,7 +2710,14 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
   let { dir, port, tls, tld } = await discoverState();
 
   if (proxiedApps.length > 0) {
-    const ensureResult = await ensureProxyRunning(port, tls, false, null);
+    let multiDesired: ProxyDesiredState;
+    try {
+      multiDesired = resolveProxyDesiredState(false);
+    } catch (err) {
+      console.error(colors.red(`Error: ${(err as Error).message}`));
+      process.exit(1);
+    }
+    const ensureResult = await ensureProxyRunning(port, tls, multiDesired, null);
     if (ensureResult.started) {
       dir = ensureResult.state.dir;
       port = ensureResult.state.port;
@@ -2692,18 +2731,19 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
   }
 
   const children: ReturnType<typeof spawn>[] = [];
+  const exitCodes = new Map<string, number | null>();
 
   // Sequential: each spawnProxiedApp calls findFreePort() which binds/releases
   // a port, so parallel spawning could cause port collisions.
   for (const app of proxiedApps) {
-    children.push(await spawnProxiedApp(app, dir, port, tls, tld));
+    children.push(await spawnProxiedApp(app, dir, port, tls, tld, exitCodes));
   }
 
   if (taskApps.length > 0) {
     console.log(chalk.gray(`\n  Tasks:\n`));
   }
   for (const app of taskApps) {
-    children.push(spawnTaskApp(app));
+    children.push(spawnTaskApp(app, exitCodes));
   }
 
   console.log("");
@@ -2721,7 +2761,6 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
   process.on("SIGINT", cleanup);
   process.on("SIGTERM", cleanup);
 
-  // Wait for all children to exit
   await Promise.all(
     children.map(
       (child) =>
@@ -2730,6 +2769,16 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
         })
     )
   );
+
+  const failed = [...exitCodes.entries()].filter(([, code]) => code !== 0 && code !== null);
+  if (failed.length > 0) {
+    console.error(
+      colors.red(
+        `\n${failed.length} app${failed.length === 1 ? "" : "s"} exited with errors: ${failed.map(([name, code]) => `${name} (${code})`).join(", ")}`
+      )
+    );
+    process.exit(1);
+  }
 }
 
 async function handleRunMode(args: string[], globalScript?: string): Promise<void> {

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -2470,37 +2470,50 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
   const children: ReturnType<typeof spawn>[] = [];
 
   for (const app of apps) {
-    const store = new RouteStore(dir, {
-      onWarning: (msg) => console.warn(colors.yellow(`[${app.name}] ${msg}`)),
-    });
+    const commandStr = app.commandArgs.join(" ");
+    const usesPortless = app.commandArgs[0] === "portless";
 
-    const appPort = app.appPort ?? (await findFreePort());
-    const protocol = tls ? "https" : "http";
-    const portSuffix = (tls && port === 443) || (!tls && port === 80) ? "" : `:${port}`;
-    const url = `${protocol}://${app.name}.${tld}${portSuffix}`;
+    let env: Record<string, string | undefined>;
+    let store: RouteStore | null = null;
+    let hostname: string | null = null;
+    let displayUrl: string;
 
-    const hostname = parseHostname(app.name, tld);
+    if (usesPortless) {
+      // Script already invokes portless — let it handle its own routing.
+      env = { ...process.env };
+      displayUrl = "(managed by portless)";
+    } else {
+      store = new RouteStore(dir, {
+        onWarning: (msg) => console.warn(colors.yellow(`[${app.name}] ${msg}`)),
+      });
 
-    store.addRoute(hostname, appPort, process.pid);
+      const appPort = app.appPort ?? (await findFreePort());
+      const protocol = tls ? "https" : "http";
+      const portSuffix = (tls && port === 443) || (!tls && port === 80) ? "" : `:${port}`;
+      const url = `${protocol}://${app.name}.${tld}${portSuffix}`;
+      displayUrl = url;
 
-    const env: Record<string, string | undefined> = {
-      ...process.env,
-      PORT: String(appPort),
-      HOST: "127.0.0.1",
-      PORTLESS_URL: url,
-    };
+      hostname = parseHostname(app.name, tld);
+      store.addRoute(hostname, appPort, process.pid);
 
-    if (tls) {
-      const caPath = path.join(dir, "ca.pem");
-      if (fs.existsSync(caPath)) {
-        env.NODE_EXTRA_CA_CERTS = caPath;
+      env = {
+        ...process.env,
+        PORT: String(appPort),
+        HOST: "127.0.0.1",
+        PORTLESS_URL: url,
+      };
+
+      if (tls) {
+        const caPath = path.join(dir, "ca.pem");
+        if (fs.existsSync(caPath)) {
+          env.NODE_EXTRA_CA_CERTS = caPath;
+        }
       }
     }
 
-    const commandStr = app.commandArgs.join(" ");
     console.log(
       chalk.cyan(`  ${app.name}`),
-      chalk.gray(`-> ${url}`),
+      chalk.gray(`-> ${displayUrl}`),
       chalk.gray(`(${commandStr})`)
     );
 
@@ -2530,11 +2543,15 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
       }
     });
 
+    const capturedStore = store;
+    const capturedHostname = hostname;
     child.on("exit", () => {
-      try {
-        store.removeRoute(hostname);
-      } catch {
-        // non-fatal
+      if (capturedStore && capturedHostname) {
+        try {
+          capturedStore.removeRoute(capturedHostname);
+        } catch {
+          // non-fatal
+        }
       }
     });
 

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -2348,7 +2348,10 @@ function loadAppConfig(cwd: string = process.cwd()): AppConfig | null {
  * Config (portless.json / package.json "portless" key) is loaded for overrides
  * but is not required.
  */
-async function handleDefaultMode(globalScript?: string): Promise<boolean> {
+async function handleDefaultMode(
+  globalScript?: string,
+  extraArgs: string[] = []
+): Promise<boolean> {
   const cwd = process.cwd();
 
   // Workspace root: multi-app mode, but only when at least one package
@@ -2369,7 +2372,7 @@ async function handleDefaultMode(globalScript?: string): Promise<boolean> {
     }
     const hasMatchingPackages = packages.some((p) => p.scripts[wsScriptName]);
     if (hasMatchingPackages) {
-      await handleDefaultMulti(cwd, globalScript);
+      await handleDefaultMulti(cwd, globalScript, extraArgs);
       return true;
     }
   }
@@ -2593,7 +2596,11 @@ function spawnTaskApp(
   return child;
 }
 
-async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promise<void> {
+async function handleDefaultMulti(
+  wsRoot: string,
+  globalScript?: string,
+  extraArgs: string[] = []
+): Promise<void> {
   let loaded: ReturnType<typeof loadConfig>;
   try {
     loaded = loadConfig(wsRoot);
@@ -2738,7 +2745,7 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
   const useTurbo = loaded?.config.turbo !== false && hasTurboConfig(wsRoot);
 
   if (useTurbo) {
-    await runWithTurbo(wsRoot, dir, port, tls, tld, scriptName, proxiedApps, taskApps);
+    await runWithTurbo(wsRoot, dir, port, tls, tld, scriptName, proxiedApps, taskApps, extraArgs);
   } else {
     await runWithDirectSpawn(dir, port, tls, tld, proxiedApps, taskApps);
   }
@@ -2752,7 +2759,8 @@ async function runWithTurbo(
   tld: string,
   scriptName: string,
   proxiedApps: MultiAppEntry[],
-  taskApps: MultiAppEntry[]
+  taskApps: MultiAppEntry[],
+  extraArgs: string[] = []
 ): Promise<void> {
   const store = new RouteStore(stateDir, {
     onWarning: (msg: string) => console.warn(colors.yellow(msg)),
@@ -2797,30 +2805,24 @@ async function runWithTurbo(
   ensureEnvLoader();
   writeManifest(manifest);
 
-  const allApps = [
-    ...appUrls.map(({ label, url }) => ({ label, url })),
-    ...taskApps.map((app) => ({ label: app.label, url: undefined })),
-  ];
-  if (allApps.length > 0) {
-    const maxLabel = Math.max(...allApps.map((a) => a.label.length));
-    for (const { label, url } of allApps) {
+  if (appUrls.length > 0) {
+    const maxLabel = Math.max(...appUrls.map((a) => a.label.length));
+    for (const { label, url } of appUrls) {
       const pad = " ".repeat(maxLabel - label.length);
-      if (url) {
-        console.log(`  ${label}${pad}  ${chalk.dim(url)}`);
-      } else {
-        console.log(`  ${chalk.dim(label)}`);
-      }
+      console.log(`  ${label}${pad}  ${chalk.dim(url)}`);
     }
   }
   console.log("");
 
   const pm = detectPackageManager(wsRoot);
-  const turboArgs =
-    pm === "npm"
-      ? ["npx", "turbo", "run", scriptName]
+  const useRootScript = hasScript(scriptName, wsRoot);
+  const turboArgs = useRootScript
+    ? [pm, "run", scriptName, ...extraArgs]
+    : pm === "npm"
+      ? ["npx", "turbo", "run", scriptName, ...extraArgs]
       : pm === "bun"
-        ? ["bunx", "turbo", "run", scriptName]
-        : [pm, "exec", "turbo", "run", scriptName];
+        ? ["bunx", "turbo", "run", scriptName, ...extraArgs]
+        : [pm, "exec", "turbo", "run", scriptName, ...extraArgs];
 
   const turboChild = spawn(turboArgs[0], turboArgs.slice(1), {
     stdio: "inherit",
@@ -2913,19 +2915,11 @@ async function runWithDirectSpawn(
   }
 
   // Print a clean summary after all processes are spawned.
-  const allApps = [
-    ...appUrls.map(({ label, url }) => ({ label, url })),
-    ...taskLabels.map((label) => ({ label, url: undefined as string | undefined })),
-  ];
-  if (allApps.length > 0) {
-    const maxLabel = Math.max(...allApps.map((a) => a.label.length));
-    for (const { label, url } of allApps) {
+  if (appUrls.length > 0) {
+    const maxLabel = Math.max(...appUrls.map((a) => a.label.length));
+    for (const { label, url } of appUrls) {
       const pad = " ".repeat(maxLabel - label.length);
-      if (url) {
-        console.log(`  ${label}${pad}  ${chalk.dim(url)}`);
-      } else {
-        console.log(`  ${chalk.dim(label)}`);
-      }
+      console.log(`  ${label}${pad}  ${chalk.dim(url)}`);
     }
   }
   console.log("");
@@ -3259,8 +3253,9 @@ async function main() {
       printHelp();
       return;
     }
-    if (args.length === 0) {
-      const handled = await handleDefaultMode(globalScript);
+    if (args.length === 0 || args[0] === "--") {
+      const extraArgs = args[0] === "--" ? args.slice(1) : [];
+      const handled = await handleDefaultMode(globalScript, extraArgs);
       if (handled) return;
       printHelp();
       return;

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -62,7 +62,14 @@ import {
   unpublish,
   cleanupAll as cleanupMdns,
 } from "./mdns.js";
-import { loadConfig, resolveAppConfig, resolveScript, hasScript, isServerCommand, loadPackagePortlessConfig } from "./config.js";
+import {
+  loadConfig,
+  resolveAppConfig,
+  resolveScript,
+  hasScript,
+  isServerCommand,
+  loadPackagePortlessConfig,
+} from "./config.js";
 import type { AppConfig } from "./config.js";
 import { findWorkspaceRoot, discoverWorkspacePackages } from "./workspace.js";
 import type { WorkspacePackage } from "./workspace.js";
@@ -755,23 +762,25 @@ function listRoutes(store: RouteStore, proxyPort: number, tls: boolean): void {
   console.log();
 }
 
-async function runApp(
-  initialStore: RouteStore,
-  proxyPort: number,
-  stateDir: string,
-  name: string,
-  commandArgs: string[],
-  tls: boolean,
-  tld: string,
-  force: boolean,
-  autoInfo?: { nameSource: string; prefix?: string; prefixSource?: string },
-  desiredPort?: number,
-  lanMode = false,
-  lanIp?: string | null
-) {
-  let store = initialStore;
-  console.log(chalk.blue.bold(`\nportless\n`));
+type EnsureProxyResult =
+  | { started: true; state: Awaited<ReturnType<typeof discoverState>> }
+  | { started: false; skipped: true }
+  | { started: false; skipped?: false };
 
+/**
+ * Check if the proxy is running and auto-start it if needed.
+ * Returns the discovered state after start, or `{ skipped: true }` when the
+ * user chose to skip, or `{ started: false }` when the proxy was already up.
+ *
+ * When `onSkip` is provided and the user chooses "skip", calls `onSkip`
+ * and returns `{ skipped: true }`. Pass null to disable the skip option.
+ */
+async function ensureProxyRunning(
+  proxyPort: number,
+  tls: boolean,
+  lanMode: boolean,
+  onSkip: (() => void) | null
+): Promise<EnsureProxyResult> {
   let envTld: string;
   try {
     envTld = getDefaultTld();
@@ -801,143 +810,195 @@ async function runApp(
     useWildcard: isWildcardEnvEnabled(),
   });
 
-  // Validate the hostname before we try to auto-start the proxy.
-  parseHostname(name, tld);
-
-  // Check if proxy is running, auto-start if possible.
-  // The proxy start command handles sudo elevation and fallback internally,
-  // so we just spawn it and then re-discover state to find the actual port.
   const proxyResponsive = await isProxyRunning(proxyPort, tls);
   const proxyListeningFromStateDir =
     !!process.env.PORTLESS_STATE_DIR && (await isPortListening(proxyPort));
 
-  if (!proxyResponsive && !proxyListeningFromStateDir) {
-    // Merge persisted state from a previous proxy run so auto-start reuses
-    // the same port/TLS/TLD instead of falling back to defaults (#225).
-    const persisted = readPersistedProxyState();
-    const startConfig = { ...desiredConfig };
-    let startPort: number | undefined;
+  if (proxyResponsive || proxyListeningFromStateDir) {
+    return { started: false };
+  }
 
-    if (persisted) {
-      if (!explicit.useHttps && persisted.tls !== desiredConfig.useHttps) {
-        startConfig.useHttps = persisted.tls;
-      }
-      if (!explicit.tld && persisted.tld !== desiredConfig.tld) {
-        startConfig.tld = persisted.tld;
-      }
-      if (!explicit.lanMode && persisted.lanMode !== desiredConfig.lanMode) {
-        startConfig.lanMode = persisted.lanMode;
-      }
-      const envPort = getDefaultPort(startConfig.useHttps);
-      if (persisted.port !== envPort) {
-        startPort = persisted.port;
-      }
+  const persisted = readPersistedProxyState();
+  const startConfig = { ...desiredConfig };
+  let startPort: number | undefined;
+
+  if (persisted) {
+    if (!explicit.useHttps && persisted.tls !== desiredConfig.useHttps) {
+      startConfig.useHttps = persisted.tls;
+    }
+    if (!explicit.tld && persisted.tld !== desiredConfig.tld) {
+      startConfig.tld = persisted.tld;
+    }
+    if (!explicit.lanMode && persisted.lanMode !== desiredConfig.lanMode) {
+      startConfig.lanMode = persisted.lanMode;
+    }
+    const envPort = getDefaultPort(startConfig.useHttps);
+    if (persisted.port !== envPort) {
+      startPort = persisted.port;
+    }
+  }
+
+  const effectivePort = startPort ?? getDefaultPort(startConfig.useHttps);
+  const needsSudo = !isWindows && effectivePort < PRIVILEGED_PORT_THRESHOLD;
+  const manualStartCommand = formatProxyStartCommand(effectivePort, startConfig);
+  const fallbackStartCommand = formatProxyStartCommand(FALLBACK_PROXY_PORT, startConfig);
+
+  const isInteractive = !!process.stdin.isTTY && !process.env.CI;
+
+  if (needsSudo && !isInteractive) {
+    console.error(colors.red("Proxy is not running and no TTY is available for sudo."));
+    console.error(colors.blue("Option 1: start the proxy in a terminal (will prompt for sudo):"));
+    console.error(colors.cyan(`  ${manualStartCommand}`));
+    console.error(
+      colors.blue(
+        `Option 2: use an unprivileged port (no sudo needed, URLs will include :${FALLBACK_PROXY_PORT}):`
+      )
+    );
+    console.error(colors.cyan(`  ${fallbackStartCommand}`));
+    process.exit(1);
+  }
+
+  if (needsSudo) {
+    const answer = await prompt(colors.yellow("Proxy not running. Start it? [Y/n/skip] "));
+
+    if (answer === "n" || answer === "no") {
+      console.log(colors.gray("Cancelled."));
+      process.exit(0);
     }
 
-    const effectivePort = startPort ?? getDefaultPort(startConfig.useHttps);
-    const needsSudo = !isWindows && effectivePort < PRIVILEGED_PORT_THRESHOLD;
-    const manualStartCommand = formatProxyStartCommand(effectivePort, startConfig);
-    const fallbackStartCommand = formatProxyStartCommand(FALLBACK_PROXY_PORT, startConfig);
-
-    // Detect non-interactive environments: no TTY, CI runners, or task
-    // runners like turborepo that pipe stdin (#224).
-    const isInteractive = !!process.stdin.isTTY && !process.env.CI;
-
-    if (needsSudo && !isInteractive) {
-      console.error(colors.red("Proxy is not running and no TTY is available for sudo."));
-      console.error(colors.blue("Option 1: start the proxy in a terminal (will prompt for sudo):"));
-      console.error(colors.cyan(`  ${manualStartCommand}`));
-      console.error(
-        colors.blue(
-          `Option 2: use an unprivileged port (no sudo needed, URLs will include :${FALLBACK_PROXY_PORT}):`
-        )
-      );
-      console.error(colors.cyan(`  ${fallbackStartCommand}`));
-      process.exit(1);
+    if (onSkip && (answer === "s" || answer === "skip")) {
+      onSkip();
+      return { started: false, skipped: true };
     }
+  }
 
-    if (needsSudo) {
-      const answer = await prompt(colors.yellow("Proxy not running. Start it? [Y/n/skip] "));
+  if (persisted && startPort !== undefined) {
+    console.log(
+      colors.yellow(
+        `Starting proxy with previous configuration (port ${startPort}, ${startConfig.useHttps ? "HTTPS" : "HTTP"})...`
+      )
+    );
+  } else {
+    console.log(colors.yellow("Starting proxy..."));
+  }
+  const proxyStartConfig = buildProxyStartConfig({
+    useHttps: startConfig.useHttps,
+    customCertPath: startConfig.customCertPath,
+    customKeyPath: startConfig.customKeyPath,
+    lanMode: startConfig.lanMode,
+    lanIp: startConfig.lanIpExplicit ? startConfig.lanIp : null,
+    lanIpExplicit: startConfig.lanIpExplicit,
+    tld: startConfig.tld,
+    useWildcard: startConfig.useWildcard,
+    includePort: startPort !== undefined,
+    proxyPort: startPort,
+  });
+  const startArgs = [getEntryScript(), "proxy", "start", ...proxyStartConfig.args];
 
-      if (answer === "n" || answer === "no") {
-        console.log(colors.gray("Cancelled."));
-        process.exit(0);
-      }
+  const result = spawnSync(process.execPath, startArgs, {
+    stdio: "inherit",
+    timeout: SUDO_SPAWN_TIMEOUT_MS,
+  });
 
-      if (answer === "s" || answer === "skip") {
-        console.log(colors.gray("Skipping proxy, running command directly...\n"));
-        spawnCommand(commandArgs);
-        return;
-      }
-    }
-
-    if (persisted && startPort !== undefined) {
-      console.log(
-        colors.yellow(
-          `Starting proxy with previous configuration (port ${startPort}, ${startConfig.useHttps ? "HTTPS" : "HTTP"})...`
-        )
-      );
-    } else {
-      console.log(colors.yellow("Starting proxy..."));
-    }
-    const proxyStartConfig = buildProxyStartConfig({
-      useHttps: startConfig.useHttps,
-      customCertPath: startConfig.customCertPath,
-      customKeyPath: startConfig.customKeyPath,
-      lanMode: startConfig.lanMode,
-      lanIp: startConfig.lanIpExplicit ? startConfig.lanIp : null,
-      lanIpExplicit: startConfig.lanIpExplicit,
-      tld: startConfig.tld,
-      useWildcard: startConfig.useWildcard,
-      includePort: startPort !== undefined,
-      proxyPort: startPort,
-    });
-    const startArgs = [getEntryScript(), "proxy", "start", ...proxyStartConfig.args];
-
-    const result = spawnSync(process.execPath, startArgs, {
-      stdio: "inherit",
-      timeout: SUDO_SPAWN_TIMEOUT_MS,
-    });
-
-    // Poll discoverState + isProxyRunning until the daemon is reachable.
-    // The proxy may bind 443, fall back to 1355, or use another port, so we
-    // re-discover on each attempt instead of waiting on a single port.
-    let discovered: Awaited<ReturnType<typeof discoverState>> | null = null;
-    if (!result.signal) {
-      for (let i = 0; i < WAIT_FOR_PROXY_MAX_ATTEMPTS; i++) {
-        await new Promise((r) => setTimeout(r, WAIT_FOR_PROXY_INTERVAL_MS));
-        const state = await discoverState();
-        if (await isProxyRunning(state.port)) {
-          discovered = state;
-          break;
-        }
+  let discovered: Awaited<ReturnType<typeof discoverState>> | null = null;
+  if (!result.signal) {
+    for (let i = 0; i < WAIT_FOR_PROXY_MAX_ATTEMPTS; i++) {
+      await new Promise((r) => setTimeout(r, WAIT_FOR_PROXY_INTERVAL_MS));
+      const state = await discoverState();
+      if (await isProxyRunning(state.port)) {
+        discovered = state;
+        break;
       }
     }
+  }
 
-    if (!discovered) {
-      console.error(colors.red("Failed to start proxy."));
-      const fallbackDir = resolveStateDir(effectivePort);
-      const logPath = path.join(fallbackDir, "proxy.log");
-      console.error(colors.blue("Try starting it manually:"));
-      console.error(colors.cyan(`  ${manualStartCommand}`));
-      if (fs.existsSync(logPath)) {
-        console.error(colors.gray(`Logs: ${logPath}`));
-      }
-      process.exit(1);
-      return; // unreachable, but helps TypeScript narrow `discovered`
+  if (!discovered) {
+    console.error(colors.red("Failed to start proxy."));
+    const fallbackDir = resolveStateDir(effectivePort);
+    const logPath = path.join(fallbackDir, "proxy.log");
+    console.error(colors.blue("Try starting it manually:"));
+    console.error(colors.cyan(`  ${manualStartCommand}`));
+    if (fs.existsSync(logPath)) {
+      console.error(colors.gray(`Logs: ${logPath}`));
     }
-    proxyPort = discovered.port;
-    stateDir = discovered.dir;
-    tld = discovered.tld;
-    tls = discovered.tls;
-    lanMode = discovered.lanMode;
-    lanIp = discovered.lanIp;
+    process.exit(1);
+  }
+
+  console.log(colors.green("Proxy started in background"));
+  return { started: true, state: discovered! };
+}
+
+async function runApp(
+  initialStore: RouteStore,
+  proxyPort: number,
+  stateDir: string,
+  name: string,
+  commandArgs: string[],
+  tls: boolean,
+  tld: string,
+  force: boolean,
+  autoInfo?: { nameSource: string; prefix?: string; prefixSource?: string },
+  desiredPort?: number,
+  lanMode = false,
+  lanIp?: string | null
+) {
+  let store = initialStore;
+  console.log(chalk.blue.bold(`\nportless\n`));
+
+  let envTld: string;
+  try {
+    envTld = getDefaultTld();
+  } catch (err) {
+    console.error(colors.red(`Error: ${(err as Error).message}`));
+    process.exit(1);
+  }
+
+  // Validate the hostname before we try to auto-start the proxy.
+  parseHostname(name, tld);
+
+  const ensureResult = await ensureProxyRunning(proxyPort, tls, lanMode, () => {
+    console.log(colors.gray("Skipping proxy, running command directly...\n"));
+    spawnCommand(commandArgs);
+  });
+
+  if (ensureResult.started === false && ensureResult.skipped) {
+    return;
+  }
+
+  if (ensureResult.started) {
+    proxyPort = ensureResult.state.port;
+    stateDir = ensureResult.state.dir;
+    tld = ensureResult.state.tld;
+    tls = ensureResult.state.tls;
+    lanMode = ensureResult.state.lanMode;
+    lanIp = ensureResult.state.lanIp;
     store = new RouteStore(stateDir, {
       onWarning: (msg: string) => console.warn(colors.yellow(msg)),
     });
-    console.log(colors.green("Proxy started in background"));
   } else {
     const runningConfig = readCurrentProxyConfig(stateDir);
+
+    const explicit: ProxyConfigExplicitness = {
+      useHttps: process.env.PORTLESS_HTTPS !== undefined,
+      customCert: false,
+      lanMode: process.env.PORTLESS_LAN !== undefined,
+      lanIp: process.env.PORTLESS_LAN_IP !== undefined,
+      tld: process.env.PORTLESS_TLD !== undefined,
+      useWildcard: process.env.PORTLESS_WILDCARD !== undefined,
+    };
+    const desiredConfig = resolveProxyConfig({
+      persistedLanMode: lanMode,
+      explicit,
+      defaultTld: envTld,
+      useHttps: !isHttpsEnvDisabled(),
+      customCertPath: null,
+      customKeyPath: null,
+      lanMode: isLanEnvEnabled(),
+      lanIp: process.env.PORTLESS_LAN_IP || null,
+      tld: envTld,
+      useWildcard: isWildcardEnvEnabled(),
+    });
+
     const mismatchMessages = getProxyConfigMismatchMessages(desiredConfig, runningConfig, explicit);
     if (mismatchMessages.length > 0) {
       printProxyConfigMismatch(proxyPort, desiredConfig, mismatchMessages);
@@ -2389,6 +2450,133 @@ async function handleDefaultSingle(cwd: string, scriptName: string): Promise<voi
  * Multi-app mode: discover workspace packages and run all that have
  * the target script through the proxy concurrently.
  */
+interface MultiAppEntry {
+  pkg: WorkspacePackage;
+  name: string;
+  commandArgs: string[];
+  appPort?: number;
+  proxied: boolean;
+}
+
+function spawnShellCommand(
+  commandStr: string,
+  env: Record<string, string | undefined>,
+  cwd: string
+): ReturnType<typeof spawn> {
+  return isWindows
+    ? spawn("cmd.exe", ["/d", "/s", "/c", commandStr], {
+        stdio: ["ignore", "pipe", "pipe"],
+        env,
+        cwd,
+      })
+    : spawn("/bin/sh", ["-c", commandStr], {
+        stdio: ["ignore", "pipe", "pipe"],
+        env,
+        cwd,
+      });
+}
+
+function pipeOutput(child: ReturnType<typeof spawn>, prefix: string): void {
+  child.stdout?.on("data", (data: Buffer) => {
+    for (const line of data.toString().split("\n")) {
+      if (line) process.stdout.write(`${prefix} ${line}\n`);
+    }
+  });
+  child.stderr?.on("data", (data: Buffer) => {
+    for (const line of data.toString().split("\n")) {
+      if (line) process.stderr.write(`${prefix} ${line}\n`);
+    }
+  });
+}
+
+async function spawnProxiedApp(
+  app: MultiAppEntry,
+  stateDir: string,
+  proxyPort: number,
+  tls: boolean,
+  tld: string
+): Promise<ReturnType<typeof spawn>> {
+  const commandStr = app.commandArgs.join(" ");
+  const usesPortless = app.commandArgs[0] === "portless";
+
+  const pkgEnv: Record<string, string | undefined> = { ...process.env };
+  pkgEnv.PATH = augmentedPath(pkgEnv, app.pkg.dir);
+
+  let env: Record<string, string | undefined>;
+  let store: RouteStore | null = null;
+  let hostname: string | null = null;
+  let displayUrl: string;
+
+  if (usesPortless) {
+    env = pkgEnv;
+    displayUrl = "(managed by portless)";
+  } else {
+    store = new RouteStore(stateDir, {
+      onWarning: (msg) => console.warn(colors.yellow(`[${app.name}] ${msg}`)),
+    });
+
+    const appPort = app.appPort ?? (await findFreePort());
+    const protocol = tls ? "https" : "http";
+    const portSuffix =
+      (tls && proxyPort === 443) || (!tls && proxyPort === 80) ? "" : `:${proxyPort}`;
+    const url = `${protocol}://${app.name}.${tld}${portSuffix}`;
+    displayUrl = url;
+
+    hostname = parseHostname(app.name, tld);
+    store.addRoute(hostname, appPort, process.pid);
+
+    env = {
+      ...pkgEnv,
+      PORT: String(appPort),
+      HOST: "127.0.0.1",
+      PORTLESS_URL: url,
+    };
+
+    if (tls) {
+      const caPath = path.join(stateDir, "ca.pem");
+      if (fs.existsSync(caPath)) {
+        env.NODE_EXTRA_CA_CERTS = caPath;
+      }
+    }
+  }
+
+  console.log(
+    chalk.cyan(`  ${app.name}`),
+    chalk.gray(`-> ${displayUrl}`),
+    chalk.gray(`(${commandStr})`)
+  );
+
+  const child = spawnShellCommand(commandStr, env, app.pkg.dir);
+  pipeOutput(child, chalk.cyan(`[${app.name}]`));
+
+  const capturedStore = store;
+  const capturedHostname = hostname;
+  child.on("exit", () => {
+    if (capturedStore && capturedHostname) {
+      try {
+        capturedStore.removeRoute(capturedHostname);
+      } catch {
+        // non-fatal
+      }
+    }
+  });
+
+  return child;
+}
+
+function spawnTaskApp(app: MultiAppEntry): ReturnType<typeof spawn> {
+  const commandStr = app.commandArgs.join(" ");
+  const pkgEnv: Record<string, string | undefined> = { ...process.env };
+  pkgEnv.PATH = augmentedPath(pkgEnv, app.pkg.dir);
+
+  console.log(chalk.gray(`  ${app.name}`), chalk.gray(`(${commandStr})`));
+
+  const child = spawnShellCommand(commandStr, pkgEnv, app.pkg.dir);
+  pipeOutput(child, chalk.gray(`[${app.name}]`));
+
+  return child;
+}
+
 async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promise<void> {
   const loaded = loadConfig(wsRoot);
   const packages = discoverWorkspacePackages(wsRoot);
@@ -2409,7 +2597,18 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
       .map((label) => truncateLabel(label))
       .join(".");
   } else {
-    const commonScope = packages.find((p) => p.scope)?.scope;
+    const scopeCounts = new Map<string, number>();
+    for (const p of packages) {
+      if (p.scope) scopeCounts.set(p.scope, (scopeCounts.get(p.scope) ?? 0) + 1);
+    }
+    let commonScope: string | undefined;
+    let maxCount = 0;
+    for (const [scope, count] of scopeCounts) {
+      if (count > maxCount) {
+        commonScope = scope;
+        maxCount = count;
+      }
+    }
     if (commonScope) {
       projectName = sanitizeForHostname(commonScope) || inferProjectName(wsRoot).name;
     } else {
@@ -2417,20 +2616,9 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
     }
   }
 
-  interface AppEntry {
-    pkg: WorkspacePackage;
-    name: string;
-    commandArgs: string[];
-    appPort?: number;
-    /** Whether this app should be proxied. False for build-only tools. */
-    proxied: boolean;
-  }
-
-  const apps: AppEntry[] = [];
+  const apps: MultiAppEntry[] = [];
 
   for (const pkg of packages) {
-    if (!pkg.scripts[scriptName]) continue;
-
     const rel = path.relative(wsRoot, pkg.dir).replace(/\\/g, "/");
     const rootOverride = loaded ? resolveAppConfig(loaded.config, loaded.configDir, pkg.dir) : null;
     const pkgConfig = loadPackagePortlessConfig(pkg.dir);
@@ -2438,19 +2626,16 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
     // Merge: root apps map > package.json "portless" key > defaults
     const appOverride: AppConfig = {
       ...pkgConfig,
-      ...Object.fromEntries(
-        Object.entries(rootOverride ?? {}).filter(([, v]) => v !== undefined)
-      ),
+      ...Object.fromEntries(Object.entries(rootOverride ?? {}).filter(([, v]) => v !== undefined)),
     };
 
     const effectiveScript = appOverride.script ?? scriptName;
+    if (!pkg.scripts[effectiveScript]) continue;
+
     const resolved = resolveScript(effectiveScript, pkg.dir);
     if (!resolved) continue;
 
-    // Determine if this app should be proxied.
-    // Explicit config wins, then check if the command is a known build tool.
-    const proxied =
-      appOverride.proxy !== undefined ? appOverride.proxy : isServerCommand(resolved);
+    const proxied = isServerCommand(resolved);
 
     let name: string;
     if (appOverride.name) {
@@ -2483,144 +2668,29 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
   console.log(chalk.blue.bold(`\nportless\n`));
   console.log(chalk.gray(`Starting ${apps.length} app${apps.length === 1 ? "" : "s"}...\n`));
 
-  const { dir, port, tls, tld } = await discoverState();
+  let { dir, port, tls, tld } = await discoverState();
 
-  // Auto-start proxy if needed (reuse the first app to trigger auto-start via runApp)
-  // For multi-app, we spawn each as a separate child process.
-  const children: ReturnType<typeof spawn>[] = [];
-
-  // Print proxied apps first, then tasks.
-  for (const app of proxiedApps) {
-    const commandStr = app.commandArgs.join(" ");
-    const usesPortless = app.commandArgs[0] === "portless";
-
-    let env: Record<string, string | undefined>;
-    let store: RouteStore | null = null;
-    let hostname: string | null = null;
-    let displayUrl: string;
-
-    // Augment PATH so local binaries (next, tsup, vite, etc.) are found.
-    const pkgEnv = { ...process.env };
-    pkgEnv.PATH = augmentedPath(pkgEnv, app.pkg.dir);
-
-    if (usesPortless) {
-      // Script already invokes portless — let it handle its own routing.
-      env = pkgEnv;
-      displayUrl = "(managed by portless)";
-    } else {
-      store = new RouteStore(dir, {
-        onWarning: (msg) => console.warn(colors.yellow(`[${app.name}] ${msg}`)),
-      });
-
-      const appPort = app.appPort ?? (await findFreePort());
-      const protocol = tls ? "https" : "http";
-      const portSuffix = (tls && port === 443) || (!tls && port === 80) ? "" : `:${port}`;
-      const url = `${protocol}://${app.name}.${tld}${portSuffix}`;
-      displayUrl = url;
-
-      hostname = parseHostname(app.name, tld);
-      store.addRoute(hostname, appPort, process.pid);
-
-      env = {
-        ...pkgEnv,
-        PORT: String(appPort),
-        HOST: "127.0.0.1",
-        PORTLESS_URL: url,
-      };
-
-      if (tls) {
-        const caPath = path.join(dir, "ca.pem");
-        if (fs.existsSync(caPath)) {
-          env.NODE_EXTRA_CA_CERTS = caPath;
-        }
-      }
+  if (proxiedApps.length > 0) {
+    const ensureResult = await ensureProxyRunning(port, tls, false, null);
+    if (ensureResult.started) {
+      dir = ensureResult.state.dir;
+      port = ensureResult.state.port;
+      tls = ensureResult.state.tls;
+      tld = ensureResult.state.tld;
     }
-
-    console.log(
-      chalk.cyan(`  ${app.name}`),
-      chalk.gray(`-> ${displayUrl}`),
-      chalk.gray(`(${commandStr})`)
-    );
-
-    const child = isWindows
-      ? spawn("cmd.exe", ["/d", "/s", "/c", commandStr], {
-          stdio: ["ignore", "pipe", "pipe"],
-          env,
-          cwd: app.pkg.dir,
-        })
-      : spawn("/bin/sh", ["-c", commandStr], {
-          stdio: ["ignore", "pipe", "pipe"],
-          env,
-          cwd: app.pkg.dir,
-        });
-
-    const prefix = chalk.cyan(`[${app.name}]`);
-
-    child.stdout?.on("data", (data: Buffer) => {
-      for (const line of data.toString().split("\n")) {
-        if (line) process.stdout.write(`${prefix} ${line}\n`);
-      }
-    });
-
-    child.stderr?.on("data", (data: Buffer) => {
-      for (const line of data.toString().split("\n")) {
-        if (line) process.stderr.write(`${prefix} ${line}\n`);
-      }
-    });
-
-    const capturedStore = store;
-    const capturedHostname = hostname;
-    child.on("exit", () => {
-      if (capturedStore && capturedHostname) {
-        try {
-          capturedStore.removeRoute(capturedHostname);
-        } catch {
-          // non-fatal
-        }
-      }
-    });
-
-    children.push(child);
   }
 
-  // Spawn task apps (build watchers etc.) — no proxy route, just run the command.
+  const children: ReturnType<typeof spawn>[] = [];
+
+  for (const app of proxiedApps) {
+    children.push(await spawnProxiedApp(app, dir, port, tls, tld));
+  }
+
   if (taskApps.length > 0) {
     console.log(chalk.gray(`\n  Tasks:\n`));
   }
   for (const app of taskApps) {
-    const commandStr = app.commandArgs.join(" ");
-    const pkgEnv = { ...process.env };
-    pkgEnv.PATH = augmentedPath(pkgEnv, app.pkg.dir);
-
-    console.log(chalk.gray(`  ${app.name}`), chalk.gray(`(${commandStr})`));
-
-    const child = isWindows
-      ? spawn("cmd.exe", ["/d", "/s", "/c", commandStr], {
-          stdio: ["ignore", "pipe", "pipe"],
-          env: pkgEnv,
-          cwd: app.pkg.dir,
-        })
-      : spawn("/bin/sh", ["-c", commandStr], {
-          stdio: ["ignore", "pipe", "pipe"],
-          env: pkgEnv,
-          cwd: app.pkg.dir,
-        });
-
-    const prefix = chalk.gray(`[${app.name}]`);
-
-    child.stdout?.on("data", (data: Buffer) => {
-      for (const line of data.toString().split("\n")) {
-        if (line) process.stdout.write(`${prefix} ${line}\n`);
-      }
-    });
-
-    child.stderr?.on("data", (data: Buffer) => {
-      for (const line of data.toString().split("\n")) {
-        if (line) process.stderr.write(`${prefix} ${line}\n`);
-      }
-    });
-
-    children.push(child);
+    children.push(spawnTaskApp(app));
   }
 
   console.log("");

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -66,6 +66,7 @@ import {
   loadConfig,
   resolveAppConfig,
   resolveScript,
+  resolveScriptCommand,
   hasScript,
   isServerCommand,
   loadPackagePortlessConfig,
@@ -2405,7 +2406,7 @@ async function handleDefaultSingle(
   scriptName: string,
   appConfig: AppConfig | null
 ): Promise<void> {
-  const resolved = resolveScript(scriptName, cwd);
+  const resolved = resolveScriptCommand(scriptName, cwd);
   if (!resolved) {
     console.error(colors.red(`Error: No "${scriptName}" script found in package.json.`));
     process.exit(1);
@@ -2635,10 +2636,13 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
     const effectiveScript = appOverride.script ?? scriptName;
     if (!pkg.scripts[effectiveScript]) continue;
 
-    const resolved = resolveScript(effectiveScript, pkg.dir);
-    if (!resolved) continue;
+    const rawScript = resolveScript(effectiveScript, pkg.dir);
+    if (!rawScript) continue;
 
-    const proxied = appOverride.proxy ?? isServerCommand(resolved);
+    const commandArgs = resolveScriptCommand(effectiveScript, pkg.dir);
+    if (!commandArgs) continue;
+
+    const proxied = appOverride.proxy ?? isServerCommand(rawScript);
 
     let name: string;
     if (appOverride.name) {
@@ -2657,7 +2661,7 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
       name = pkgLabel === projectName ? projectName : `${pkgLabel}.${projectName}`;
     }
 
-    apps.push({ pkg, name, commandArgs: resolved, appPort: appOverride.appPort, proxied });
+    apps.push({ pkg, name, commandArgs, appPort: appOverride.appPort, proxied });
   }
 
   if (apps.length === 0) {
@@ -2680,6 +2684,10 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
       port = ensureResult.state.port;
       tls = ensureResult.state.tls;
       tld = ensureResult.state.tld;
+    } else if (!("skipped" in ensureResult && ensureResult.skipped)) {
+      // Proxy was already running -- re-discover to pick up current state
+      // (markers may have been recreated since the first call).
+      ({ dir, port, tls, tld } = await discoverState());
     }
   }
 
@@ -2734,7 +2742,7 @@ async function handleRunMode(args: string[], globalScript?: string): Promise<voi
   // args still errors (backwards compatible).
   if (parsed.commandArgs.length === 0 && (appConfig || globalScript)) {
     const scriptName = globalScript ?? appConfig?.script ?? "dev";
-    const resolved = resolveScript(scriptName, process.cwd());
+    const resolved = resolveScriptCommand(scriptName, process.cwd());
     if (resolved) {
       parsed.commandArgs = resolved;
     }
@@ -2978,7 +2986,7 @@ async function main() {
       const appConfig = loadAppConfig();
       if (appConfig || globalScript) {
         const scriptName = globalScript ?? appConfig?.script ?? "dev";
-        const resolved = resolveScript(scriptName, process.cwd());
+        const resolved = resolveScriptCommand(scriptName, process.cwd());
         if (resolved) commandArgs = resolved;
       }
     }

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -46,6 +46,7 @@ import {
   readTlsMarker,
   resolveStateDir,
   spawnCommand,
+  augmentedPath,
   validateTld,
   waitForProxy,
   writeLanMarker,
@@ -2449,7 +2450,7 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
       } else {
         pkgLabel = rel.replace(/\//g, "-");
       }
-      name = `${pkgLabel}.${projectName}`;
+      name = pkgLabel === projectName ? projectName : `${pkgLabel}.${projectName}`;
     }
 
     apps.push({ pkg, name, commandArgs: resolved, appPort: appOverride?.appPort });
@@ -2478,9 +2479,13 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
     let hostname: string | null = null;
     let displayUrl: string;
 
+    // Augment PATH so local binaries (next, tsup, vite, etc.) are found.
+    const pkgEnv = { ...process.env };
+    pkgEnv.PATH = augmentedPath(pkgEnv, app.pkg.dir);
+
     if (usesPortless) {
       // Script already invokes portless — let it handle its own routing.
-      env = { ...process.env };
+      env = pkgEnv;
       displayUrl = "(managed by portless)";
     } else {
       store = new RouteStore(dir, {
@@ -2497,7 +2502,7 @@ async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promis
       store.addRoute(hostname, appPort, process.pid);
 
       env = {
-        ...process.env,
+        ...pkgEnv,
         PORT: String(appPort),
         HOST: "127.0.0.1",
         PORTLESS_URL: url,

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -11,7 +11,12 @@ import { createHttpRedirectServer, createProxyServer } from "./proxy.js";
 import { fixOwnership, formatUrl, isErrnoException, parseHostname } from "./utils.js";
 import { syncHostsFile, cleanHostsFile, shouldAutoSyncHosts } from "./hosts.js";
 import { FILE_MODE, RouteConflictError, RouteStore } from "./routes.js";
-import { inferProjectName, detectWorktreePrefix, truncateLabel } from "./auto.js";
+import {
+  inferProjectName,
+  detectWorktreePrefix,
+  truncateLabel,
+  sanitizeForHostname,
+} from "./auto.js";
 import {
   buildProxyStartConfig,
   DEFAULT_TLD,
@@ -56,6 +61,10 @@ import {
   unpublish,
   cleanupAll as cleanupMdns,
 } from "./mdns.js";
+import { loadConfig, resolveAppConfig, resolveScript, hasScript } from "./config.js";
+import type { AppConfig } from "./config.js";
+import { findWorkspaceRoot, discoverWorkspacePackages } from "./workspace.js";
+import type { WorkspacePackage } from "./workspace.js";
 
 const chalk = colors;
 
@@ -1123,7 +1132,10 @@ function parseRunArgs(args: string[]): ParsedRunArgs {
 ${colors.bold("portless run")} - Infer project name and run through the proxy.
 
 ${colors.bold("Usage:")}
-  ${colors.cyan("portless run [options] <command...>")}
+  ${colors.cyan("portless run [options] [command...]")}
+
+  When no command is given and a portless.json exists, runs the configured
+  script (default: "dev") from package.json.
 
 ${colors.bold("Options:")}
   --name <name>          Override the inferred base name (worktree prefix still applies)
@@ -1132,15 +1144,17 @@ ${colors.bold("Options:")}
   --help, -h             Show this help
 
 ${colors.bold("Name inference (in order):")}
-  1. package.json "name" field (walks up directories)
-  2. Git repo root directory name
-  3. Current directory basename
+  1. portless.json "name" field
+  2. package.json "name" field (walks up directories)
+  3. Git repo root directory name
+  4. Current directory basename
 
   Use --name to override the inferred name while keeping worktree prefixes.
   In git worktrees, the branch name is prepended as a subdomain prefix
   (e.g. feature-auth.myapp.localhost).
 
 ${colors.bold("Examples:")}
+  portless run                        # With portless.json: run dev script
   portless run next dev               # -> https://<project>.localhost
   portless run --name myapp next dev  # -> https://myapp.localhost
   portless run vite dev               # -> https://<project>.localhost
@@ -1246,13 +1260,13 @@ ${colors.bold("Install:")}
   ${colors.cyan("npm install -D portless")}          Project dev dependency
 
 ${colors.bold("Usage:")}
+  ${colors.cyan("portless")}                         Run dev script through proxy (needs portless.json)
+  ${colors.cyan("portless")}                         From monorepo root: run all workspace packages
+  ${colors.cyan("portless run")}                     Same as above (with portless.json or --script)
+  ${colors.cyan("portless run <cmd>")}               Run a command through the proxy
+  ${colors.cyan("portless <name> <cmd>")}            Run with an explicit app name
   ${colors.cyan("portless proxy start")}             Start the proxy (HTTPS on port 443, daemon)
-  ${colors.cyan("portless proxy start --no-tls")}    Start without HTTPS (port 80)
-  ${colors.cyan("portless proxy start --lan")}       Start in LAN mode (mDNS for real device testing)
-  ${colors.cyan("portless proxy start -p 1355")}     Start on a custom port (no sudo)
   ${colors.cyan("portless proxy stop")}              Stop the proxy
-  ${colors.cyan("portless <name> <cmd>")}            Run your app through the proxy
-  ${colors.cyan("portless run <cmd>")}               Infer name from project, run through proxy
   ${colors.cyan("portless get <name>")}              Print URL for a service (for cross-service refs)
   ${colors.cyan("portless alias <name> <port>")}     Register a static route (e.g. for Docker)
   ${colors.cyan("portless alias --remove <name>")}   Remove a static route
@@ -1263,22 +1277,32 @@ ${colors.bold("Usage:")}
   ${colors.cyan("portless hosts clean")}             Remove portless entries from ${HOSTS_DISPLAY}
 
 ${colors.bold("Examples:")}
-  portless proxy start                # Start HTTPS proxy on port 443
-  portless proxy start --no-tls       # Start HTTP proxy on port 80
+  portless                            # Run dev script (with portless.json)
+  portless                            # From monorepo root: start all apps
+  portless --script start             # Run "start" script instead of "dev"
   portless myapp next dev             # -> https://myapp.localhost
-  portless myapp vite dev             # -> https://myapp.localhost
-  portless api.myapp pnpm start       # -> https://api.myapp.localhost
   portless run next dev               # -> https://<project>.localhost
   portless run next dev               # in worktree -> https://<worktree>.<project>.localhost
-  portless get backend                 # -> https://backend.localhost (for cross-service refs)
-  # Wildcard subdomains: tenant.myapp.localhost also routes to myapp
+  portless get backend                # -> https://backend.localhost
+
+${colors.bold("Configuration (portless.json):")}
+  Create a portless.json to enable zero-arg mode. Your package.json
+  scripts stay portless-free. Config is optional; portless infers
+  the name from package.json and defaults to the "dev" script.
+
+  Single app:  { "name": "myapp" }
+  Custom script: { "name": "myapp", "script": "start" }
+  Monorepo:    { "apps": { "apps/web": { "name": "myapp" } } }
 
 ${colors.bold("In package.json:")}
   {
     "scripts": {
-      "dev": "portless run next dev"
+      "dev": "next dev"
     }
   }
+  Then run: portless          (with portless.json)
+  Or:       portless run      (with portless.json)
+  Or:       portless run next dev
 
 ${colors.bold("How it works:")}
   1. Start the proxy once (HTTPS on port 443 by default, auto-elevates with sudo)
@@ -1314,6 +1338,7 @@ ${colors.bold("LAN mode:")}
 ${colors.bold("Options:")}
   run [--name <name>] <cmd>      Infer project name (or override with --name)
                                 Adds worktree prefix in git worktrees
+  --script <name>               Run a specific package.json script (default: dev)
   -p, --port <number>           Port for the proxy (default: 443, or 80 with --no-tls)
                                 Standard ports auto-elevate with sudo on macOS/Linux
   --no-tls                      Disable HTTPS (use plain HTTP on port 80)
@@ -2267,8 +2292,275 @@ ${colors.bold("LAN mode (--lan):")}
   }
 }
 
-async function handleRunMode(args: string[]): Promise<void> {
+/**
+ * Load the effective AppConfig for the current directory from portless.json.
+ * Handles both single-app (top-level fields) and monorepo (apps map) configs.
+ */
+function loadAppConfig(cwd: string = process.cwd()): AppConfig | null {
+  const loaded = loadConfig(cwd);
+  if (!loaded) return null;
+  return resolveAppConfig(loaded.config, loaded.configDir, cwd);
+}
+
+/**
+ * Zero-arg dispatch: `portless` with no arguments.
+ * Returns true if handled, false to fall through to help text.
+ *
+ * Activates when:
+ * - At a workspace root (has pnpm-workspace.yaml in cwd) -> multi-app mode
+ * - Has a portless.json or --script flag -> single-app mode
+ * Without config, bare `portless` still prints help for backwards compat.
+ */
+async function handleDefaultMode(globalScript?: string): Promise<boolean> {
+  const cwd = process.cwd();
+
+  // Workspace root: multi-app mode
+  const wsRoot = findWorkspaceRoot(cwd);
+  if (wsRoot === cwd) {
+    await handleDefaultMulti(cwd, globalScript);
+    return true;
+  }
+
+  // Single-app mode requires portless.json or --script to activate.
+  const appConfig = loadAppConfig(cwd);
+  if (!appConfig && !globalScript) return false;
+
+  const scriptName = globalScript ?? appConfig?.script ?? "dev";
+  if (hasScript(scriptName, cwd)) {
+    await handleDefaultSingle(cwd, scriptName);
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Single-app mode: run one package through the proxy.
+ */
+async function handleDefaultSingle(cwd: string, scriptName: string): Promise<void> {
+  const appConfig = loadAppConfig(cwd);
+
+  const resolved = resolveScript(scriptName, cwd);
+  if (!resolved) {
+    console.error(colors.red(`Error: No "${scriptName}" script found in package.json.`));
+    process.exit(1);
+  }
+
+  let baseName: string;
+  let nameSource: string;
+
+  if (appConfig?.name) {
+    baseName = appConfig.name
+      .split(".")
+      .map((label) => truncateLabel(label))
+      .join(".");
+    nameSource = "portless.json";
+  } else {
+    const inferred = inferProjectName(cwd);
+    baseName = inferred.name;
+    nameSource = inferred.source;
+  }
+
+  const worktree = detectWorktreePrefix(cwd);
+  const effectiveName = worktree ? `${worktree.prefix}.${baseName}` : baseName;
+
+  const { dir, port, tls, tld, lanMode, lanIp } = await discoverState();
+  const store = new RouteStore(dir, {
+    onWarning: (msg) => console.warn(colors.yellow(msg)),
+  });
+  await runApp(
+    store,
+    port,
+    dir,
+    effectiveName,
+    resolved,
+    tls,
+    tld,
+    false,
+    { nameSource, prefix: worktree?.prefix, prefixSource: worktree?.source },
+    appConfig?.appPort,
+    lanMode,
+    lanIp
+  );
+}
+
+/**
+ * Multi-app mode: discover workspace packages and run all that have
+ * the target script through the proxy concurrently.
+ */
+async function handleDefaultMulti(wsRoot: string, globalScript?: string): Promise<void> {
+  const loaded = loadConfig(wsRoot);
+  const packages = discoverWorkspacePackages(wsRoot);
+
+  if (packages.length === 0) {
+    console.error(colors.red("Error: No workspace packages found."));
+    process.exit(1);
+  }
+
+  const scriptName = globalScript ?? loaded?.config.script ?? "dev";
+
+  interface AppEntry {
+    pkg: WorkspacePackage;
+    name: string;
+    commandArgs: string[];
+    appPort?: number;
+  }
+
+  const apps: AppEntry[] = [];
+
+  for (const pkg of packages) {
+    if (!pkg.scripts[scriptName]) continue;
+
+    const rel = path.relative(wsRoot, pkg.dir).replace(/\\/g, "/");
+    const appOverride = loaded ? resolveAppConfig(loaded.config, loaded.configDir, pkg.dir) : null;
+
+    const effectiveScript = appOverride?.script ?? scriptName;
+    const resolved = resolveScript(effectiveScript, pkg.dir);
+    if (!resolved) continue;
+
+    let name: string;
+    if (appOverride?.name) {
+      name = appOverride.name
+        .split(".")
+        .map((label) => truncateLabel(label))
+        .join(".");
+    } else if (pkg.name) {
+      const sanitized = sanitizeForHostname(pkg.name);
+      name = sanitized || rel.replace(/\//g, "-");
+    } else {
+      name = rel.replace(/\//g, "-");
+    }
+
+    apps.push({ pkg, name, commandArgs: resolved, appPort: appOverride?.appPort });
+  }
+
+  if (apps.length === 0) {
+    console.error(colors.yellow(`No workspace packages have a "${scriptName}" script.`));
+    process.exit(1);
+  }
+
+  console.log(chalk.blue.bold(`\nportless\n`));
+  console.log(chalk.gray(`Starting ${apps.length} app${apps.length === 1 ? "" : "s"}...\n`));
+
+  const { dir, port, tls, tld } = await discoverState();
+
+  // Auto-start proxy if needed (reuse the first app to trigger auto-start via runApp)
+  // For multi-app, we spawn each as a separate child process.
+  const children: ReturnType<typeof spawn>[] = [];
+
+  for (const app of apps) {
+    const store = new RouteStore(dir, {
+      onWarning: (msg) => console.warn(colors.yellow(`[${app.name}] ${msg}`)),
+    });
+
+    const appPort = app.appPort ?? (await findFreePort());
+    const protocol = tls ? "https" : "http";
+    const portSuffix = (tls && port === 443) || (!tls && port === 80) ? "" : `:${port}`;
+    const url = `${protocol}://${app.name}.${tld}${portSuffix}`;
+
+    const hostname = parseHostname(app.name, tld);
+
+    store.addRoute(hostname, appPort, process.pid);
+
+    const env: Record<string, string | undefined> = {
+      ...process.env,
+      PORT: String(appPort),
+      HOST: "127.0.0.1",
+      PORTLESS_URL: url,
+    };
+
+    if (tls) {
+      const caPath = path.join(dir, "ca.pem");
+      if (fs.existsSync(caPath)) {
+        env.NODE_EXTRA_CA_CERTS = caPath;
+      }
+    }
+
+    const commandStr = app.commandArgs.join(" ");
+    console.log(
+      chalk.cyan(`  ${app.name}`),
+      chalk.gray(`-> ${url}`),
+      chalk.gray(`(${commandStr})`)
+    );
+
+    const child = isWindows
+      ? spawn("cmd.exe", ["/d", "/s", "/c", commandStr], {
+          stdio: ["ignore", "pipe", "pipe"],
+          env,
+          cwd: app.pkg.dir,
+        })
+      : spawn("/bin/sh", ["-c", commandStr], {
+          stdio: ["ignore", "pipe", "pipe"],
+          env,
+          cwd: app.pkg.dir,
+        });
+
+    const prefix = chalk.cyan(`[${app.name}]`);
+
+    child.stdout?.on("data", (data: Buffer) => {
+      for (const line of data.toString().split("\n")) {
+        if (line) process.stdout.write(`${prefix} ${line}\n`);
+      }
+    });
+
+    child.stderr?.on("data", (data: Buffer) => {
+      for (const line of data.toString().split("\n")) {
+        if (line) process.stderr.write(`${prefix} ${line}\n`);
+      }
+    });
+
+    child.on("exit", () => {
+      try {
+        store.removeRoute(hostname);
+      } catch {
+        // non-fatal
+      }
+    });
+
+    children.push(child);
+  }
+
+  console.log("");
+
+  const cleanup = () => {
+    for (const child of children) {
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        // already dead
+      }
+    }
+  };
+
+  process.on("SIGINT", cleanup);
+  process.on("SIGTERM", cleanup);
+
+  // Wait for all children to exit
+  await Promise.all(
+    children.map(
+      (child) =>
+        new Promise<void>((resolve) => {
+          child.on("exit", () => resolve());
+        })
+    )
+  );
+}
+
+async function handleRunMode(args: string[], globalScript?: string): Promise<void> {
   const parsed = parseRunArgs(args);
+
+  const appConfig = loadAppConfig();
+
+  // Script/command fallback: only resolve from config when a portless.json
+  // exists or --script was passed. Without config, `portless run` with no
+  // args still errors (backwards compatible).
+  if (parsed.commandArgs.length === 0 && (appConfig || globalScript)) {
+    const scriptName = globalScript ?? appConfig?.script ?? "dev";
+    const resolved = resolveScript(scriptName, process.cwd());
+    if (resolved) {
+      parsed.commandArgs = resolved;
+    }
+  }
 
   if (parsed.commandArgs.length === 0) {
     console.error(colors.red("Error: No command provided."));
@@ -2290,10 +2582,20 @@ async function handleRunMode(args: string[]): Promise<void> {
       .map((label) => truncateLabel(label))
       .join(".");
     nameSource = "--name flag";
+  } else if (appConfig?.name) {
+    baseName = appConfig.name
+      .split(".")
+      .map((label) => truncateLabel(label))
+      .join(".");
+    nameSource = "portless.json";
   } else {
     const inferred = inferProjectName();
     baseName = inferred.name;
     nameSource = inferred.source;
+  }
+
+  if (!parsed.appPort && appConfig?.appPort) {
+    parsed.appPort = appConfig.appPort;
   }
 
   const worktree = detectWorktreePrefix();
@@ -2329,6 +2631,13 @@ async function handleNamedMode(args: string[]): Promise<void> {
     console.error(colors.blue("Example:"));
     console.error(colors.cyan("  portless myapp next dev"));
     process.exit(1);
+  }
+
+  if (!parsed.appPort) {
+    const appConfig = loadAppConfig();
+    if (appConfig?.appPort) {
+      parsed.appPort = appConfig.appPort;
+    }
   }
 
   // Truncate individual labels that exceed the DNS limit, same as handleRunMode.
@@ -2435,6 +2744,15 @@ async function main() {
     process.env.PORTLESS_LAN = "1";
   }
 
+  // --script flag: override the default "dev" script for zero-arg mode.
+  const scriptResult = stripGlobalFlag("--script", true);
+  if (scriptResult === false) {
+    console.error(colors.red("Error: --script requires a script name."));
+    console.error(colors.cyan("  portless --script start"));
+    process.exit(1);
+  }
+  const globalScript = typeof scriptResult === "string" ? scriptResult : undefined;
+
   // --name flag: treat the next arg as an explicit app name, bypassing
   // subcommand dispatch. Useful when the app name collides with a reserved
   // subcommand (run, alias, hosts, list, trust, clean, proxy).
@@ -2476,7 +2794,16 @@ async function main() {
     skipPortless &&
     (isRunCommand || (args.length >= 2 && args[0] !== "proxy" && args[0] !== "clean"))
   ) {
-    const { commandArgs } = isRunCommand ? parseRunArgs(args) : parseAppArgs(args);
+    const parsed = isRunCommand ? parseRunArgs(args) : parseAppArgs(args);
+    let commandArgs = parsed.commandArgs;
+    if (commandArgs.length === 0 && isRunCommand) {
+      const appConfig = loadAppConfig();
+      if (appConfig || globalScript) {
+        const scriptName = globalScript ?? appConfig?.script ?? "dev";
+        const resolved = resolveScript(scriptName, process.cwd());
+        if (resolved) commandArgs = resolved;
+      }
+    }
     if (commandArgs.length === 0) {
       console.error(colors.red("Error: No command provided."));
       process.exit(1);
@@ -2489,7 +2816,13 @@ async function main() {
   // When `run` is used, skip these so args like "list" or "--help" are treated
   // as child-command tokens, not portless subcommands.
   if (!isRunCommand) {
-    if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+    if (args[0] === "--help" || args[0] === "-h") {
+      printHelp();
+      return;
+    }
+    if (args.length === 0) {
+      const handled = await handleDefaultMode(globalScript);
+      if (handled) return;
       printHelp();
       return;
     }
@@ -2529,7 +2862,7 @@ async function main() {
 
   // Run app (either `portless run <cmd>` or `portless <name> <cmd>`)
   if (isRunCommand) {
-    await handleRunMode(args);
+    await handleRunMode(args, globalScript);
   } else {
     await handleNamedMode(args);
   }

--- a/packages/portless/src/colors.ts
+++ b/packages/portless/src/colors.ts
@@ -16,9 +16,9 @@ const identity = (s: string) => s;
 const bold = wrap("1", "22");
 const dim = wrap("2", "22");
 
-const red = bold;
+const red = wrap("31", "39");
 const green = identity;
-const yellow = dim;
+const yellow = wrap("33", "39");
 const blue = Object.assign(identity, { bold } as { bold: (s: string) => string });
 const cyan = Object.assign(identity, { bold } as { bold: (s: string) => string });
 const white = identity;

--- a/packages/portless/src/colors.ts
+++ b/packages/portless/src/colors.ts
@@ -11,17 +11,17 @@ const wrap = (open: string, close: string) => {
   return (s: string) => `\x1b[${open}m${s}\x1b[${close}m`;
 };
 
-const bold = wrap("1", "22");
-const red = wrap("31", "39");
-const green = wrap("32", "39");
-const yellow = wrap("33", "39");
-const blue = Object.assign(wrap("34", "39"), {
-  bold: enabled ? (s: string) => `\x1b[34;1m${s}\x1b[22;39m` : (s: string) => s,
-});
-const cyan = Object.assign(wrap("36", "39"), {
-  bold: enabled ? (s: string) => `\x1b[36;1m${s}\x1b[22;39m` : (s: string) => s,
-});
-const white = wrap("37", "39");
-const gray = wrap("90", "39");
+const identity = (s: string) => s;
 
-export default { bold, red, green, yellow, blue, cyan, white, gray };
+const bold = wrap("1", "22");
+const dim = wrap("2", "22");
+
+const red = bold;
+const green = identity;
+const yellow = dim;
+const blue = Object.assign(identity, { bold } as { bold: (s: string) => string });
+const cyan = Object.assign(identity, { bold } as { bold: (s: string) => string });
+const white = identity;
+const gray = dim;
+
+export default { bold, dim, red, green, yellow, blue, cyan, white, gray };

--- a/packages/portless/src/config.test.ts
+++ b/packages/portless/src/config.test.ts
@@ -63,6 +63,22 @@ describe("splitCommand", () => {
   it("handles quotes within a token", () => {
     expect(splitCommand("--flag='some value'")).toEqual(["--flag=some value"]);
   });
+
+  it("handles backslash-escaped double quotes", () => {
+    expect(splitCommand('echo \\"hello\\"')).toEqual(["echo", '"hello"']);
+  });
+
+  it("handles backslash-escaped single quotes", () => {
+    expect(splitCommand("echo \\'hello\\'")).toEqual(["echo", "'hello'"]);
+  });
+
+  it("handles escaped backslash", () => {
+    expect(splitCommand("echo \\\\path")).toEqual(["echo", "\\path"]);
+  });
+
+  it("handles backslash-escaped spaces", () => {
+    expect(splitCommand("path\\ with\\ spaces arg")).toEqual(["path with spaces", "arg"]);
+  });
 });
 
 describe("loadConfig", () => {
@@ -100,6 +116,15 @@ describe("loadConfig", () => {
     fs.writeFileSync(path.join(tmpDir, "portless.json"), JSON.stringify(config));
     const result = loadConfig(tmpDir);
     expect(result!.config).toEqual(config);
+  });
+
+  it("loads config with proxy field", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "portless.json"),
+      JSON.stringify({ name: "myapp", proxy: false })
+    );
+    const result = loadConfig(tmpDir);
+    expect(result!.config.proxy).toBe(false);
   });
 
   it("loads config with apps map", () => {
@@ -257,13 +282,38 @@ describe("loadConfig validation", () => {
     expect(() => loadConfig(tmpDir)).toThrow("process.exit");
     mockExit.mockRestore();
   });
+
+  it("exits when proxy is not a boolean", () => {
+    fs.writeFileSync(path.join(tmpDir, "portless.json"), JSON.stringify({ proxy: "false" }));
+    const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    expect(() => loadConfig(tmpDir)).toThrow("process.exit");
+    mockExit.mockRestore();
+  });
 });
 
 describe("resolveAppConfig", () => {
   it("returns top-level fields when no apps key", () => {
     const config = { name: "myapp", script: "dev" };
     const result = resolveAppConfig(config, "/repo", "/repo");
-    expect(result).toEqual({ name: "myapp", script: "dev" });
+    expect(result).toEqual({ name: "myapp", script: "dev", appPort: undefined, proxy: undefined });
+  });
+
+  it("returns proxy field from top-level config", () => {
+    const config = { name: "myapp", proxy: false };
+    const result = resolveAppConfig(config, "/repo", "/repo");
+    expect(result.proxy).toBe(false);
+  });
+
+  it("returns proxy field from apps entry", () => {
+    const config = {
+      apps: {
+        "apps/gen": { name: "gen", proxy: false },
+      },
+    };
+    const result = resolveAppConfig(config, "/repo", "/repo/apps/gen");
+    expect(result.proxy).toBe(false);
   });
 
   it("matches exact path in apps map", () => {

--- a/packages/portless/src/config.test.ts
+++ b/packages/portless/src/config.test.ts
@@ -2,7 +2,15 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import { loadConfig, resolveAppConfig, resolveScript, hasScript, splitCommand } from "./config.js";
+import {
+  loadConfig,
+  resolveAppConfig,
+  resolveScript,
+  hasScript,
+  splitCommand,
+  isServerCommand,
+  loadPackagePortlessConfig,
+} from "./config.js";
 
 function createTmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), "portless-config-test-"));
@@ -92,6 +100,67 @@ describe("loadConfig", () => {
     const result = loadConfig(tmpDir);
     expect(result).not.toBeNull();
     expect(result!.config).toEqual({});
+  });
+
+  it("loads config from package.json portless key", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", portless: { name: "myapp", script: "dev" } })
+    );
+    const result = loadConfig(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result!.config.name).toBe("myapp");
+    expect(result!.config.script).toBe("dev");
+    expect(result!.configDir).toBe(tmpDir);
+  });
+
+  it("loads string shorthand from package.json portless key", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", portless: "myapp" })
+    );
+    const result = loadConfig(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result!.config.name).toBe("myapp");
+  });
+
+  it("ignores empty string portless key", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", portless: "" })
+    );
+    expect(loadConfig(tmpDir)).toBeNull();
+  });
+
+  it("prefers portless.json over package.json portless key", () => {
+    fs.writeFileSync(path.join(tmpDir, "portless.json"), JSON.stringify({ name: "from-file" }));
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", portless: { name: "from-pkg" } })
+    );
+    const result = loadConfig(tmpDir);
+    expect(result!.config.name).toBe("from-file");
+  });
+
+  it("ignores package.json without portless key", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", scripts: { dev: "next dev" } })
+    );
+    expect(loadConfig(tmpDir)).toBeNull();
+  });
+
+  it("walks up to find package.json portless key", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", portless: { name: "root-app" } })
+    );
+    const subDir = path.join(tmpDir, "packages", "web");
+    fs.mkdirSync(subDir, { recursive: true });
+    const result = loadConfig(subDir);
+    expect(result).not.toBeNull();
+    expect(result!.config.name).toBe("root-app");
+    expect(result!.configDir).toBe(tmpDir);
   });
 });
 
@@ -315,6 +384,78 @@ describe("hasScript", () => {
   it("returns false when scripts object is missing", () => {
     fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ name: "test" }));
     expect(hasScript("dev", tmpDir)).toBe(false);
+  });
+});
+
+describe("loadPackagePortlessConfig", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    cleanupDir(tmpDir);
+  });
+
+  it("returns config from package.json portless key", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", portless: { name: "myapp", proxy: false } })
+    );
+    const result = loadPackagePortlessConfig(tmpDir);
+    expect(result).toEqual({ name: "myapp", proxy: false });
+  });
+
+  it("returns config from string shorthand", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", portless: "myapp" })
+    );
+    const result = loadPackagePortlessConfig(tmpDir);
+    expect(result).toEqual({ name: "myapp" });
+  });
+
+  it("returns null for empty string shorthand", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", portless: "" })
+    );
+    expect(loadPackagePortlessConfig(tmpDir)).toBeNull();
+  });
+
+  it("returns null when no portless key", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test" })
+    );
+    expect(loadPackagePortlessConfig(tmpDir)).toBeNull();
+  });
+
+  it("returns null when no package.json", () => {
+    expect(loadPackagePortlessConfig(tmpDir)).toBeNull();
+  });
+});
+
+describe("isServerCommand", () => {
+  it("returns true for web server commands", () => {
+    expect(isServerCommand(["next", "dev"])).toBe(true);
+    expect(isServerCommand(["vite"])).toBe(true);
+    expect(isServerCommand(["node", "server.js"])).toBe(true);
+    expect(isServerCommand(["remix", "dev"])).toBe(true);
+  });
+
+  it("returns false for build-only commands", () => {
+    expect(isServerCommand(["tsup", "--watch"])).toBe(false);
+    expect(isServerCommand(["tsc", "--watch"])).toBe(false);
+    expect(isServerCommand(["esbuild", "src/index.ts"])).toBe(false);
+    expect(isServerCommand(["rollup", "-c", "-w"])).toBe(false);
+    expect(isServerCommand(["swc", "src", "-d", "dist", "-w"])).toBe(false);
+    expect(isServerCommand(["unbuild"])).toBe(false);
+  });
+
+  it("returns false for empty args", () => {
+    expect(isServerCommand([])).toBe(false);
   });
 });
 

--- a/packages/portless/src/config.test.ts
+++ b/packages/portless/src/config.test.ts
@@ -267,6 +267,20 @@ describe("loadConfig validation", () => {
     expect(() => loadConfig(tmpDir)).toThrow(ConfigValidationError);
   });
 
+  it("accepts turbo as a boolean", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "portless.json"),
+      JSON.stringify({ name: "test", turbo: false })
+    );
+    const result = loadConfig(tmpDir);
+    expect(result?.config.turbo).toBe(false);
+  });
+
+  it("throws when turbo is not a boolean", () => {
+    fs.writeFileSync(path.join(tmpDir, "portless.json"), JSON.stringify({ turbo: "yes" }));
+    expect(() => loadConfig(tmpDir)).toThrow(ConfigValidationError);
+  });
+
   it("warns on unknown top-level keys", () => {
     const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
     fs.writeFileSync(

--- a/packages/portless/src/config.test.ts
+++ b/packages/portless/src/config.test.ts
@@ -12,6 +12,7 @@ import {
   splitCommand,
   isServerCommand,
   loadPackagePortlessConfig,
+  ConfigValidationError,
 } from "./config.js";
 
 function createTmpDir(): string {
@@ -219,79 +220,47 @@ describe("loadConfig validation", () => {
     cleanupDir(tmpDir);
   });
 
-  it("exits on invalid JSON", () => {
+  it("throws on invalid JSON", () => {
     fs.writeFileSync(path.join(tmpDir, "portless.json"), "not json");
-    const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
-      throw new Error("process.exit");
-    });
-    expect(() => loadConfig(tmpDir)).toThrow("process.exit");
-    mockExit.mockRestore();
+    expect(() => loadConfig(tmpDir)).toThrow(ConfigValidationError);
   });
 
-  it("exits when config is an array", () => {
+  it("throws when config is an array", () => {
     fs.writeFileSync(path.join(tmpDir, "portless.json"), "[]");
-    const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
-      throw new Error("process.exit");
-    });
-    expect(() => loadConfig(tmpDir)).toThrow("process.exit");
-    mockExit.mockRestore();
+    expect(() => loadConfig(tmpDir)).toThrow(ConfigValidationError);
   });
 
-  it("exits when name is a number", () => {
+  it("throws when name is a number", () => {
     fs.writeFileSync(path.join(tmpDir, "portless.json"), JSON.stringify({ name: 42 }));
-    const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
-      throw new Error("process.exit");
-    });
-    expect(() => loadConfig(tmpDir)).toThrow("process.exit");
-    mockExit.mockRestore();
+    expect(() => loadConfig(tmpDir)).toThrow(ConfigValidationError);
   });
 
-  it("exits when name is empty string", () => {
+  it("throws when name is empty string", () => {
     fs.writeFileSync(path.join(tmpDir, "portless.json"), JSON.stringify({ name: "" }));
-    const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
-      throw new Error("process.exit");
-    });
-    expect(() => loadConfig(tmpDir)).toThrow("process.exit");
-    mockExit.mockRestore();
+    expect(() => loadConfig(tmpDir)).toThrow(ConfigValidationError);
   });
 
-  it("exits when appPort is out of range", () => {
+  it("throws when appPort is out of range", () => {
     fs.writeFileSync(path.join(tmpDir, "portless.json"), JSON.stringify({ appPort: 99999 }));
-    const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
-      throw new Error("process.exit");
-    });
-    expect(() => loadConfig(tmpDir)).toThrow("process.exit");
-    mockExit.mockRestore();
+    expect(() => loadConfig(tmpDir)).toThrow(ConfigValidationError);
   });
 
-  it("exits when appPort is a string", () => {
+  it("throws when appPort is a string", () => {
     fs.writeFileSync(path.join(tmpDir, "portless.json"), JSON.stringify({ appPort: "3000" }));
-    const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
-      throw new Error("process.exit");
-    });
-    expect(() => loadConfig(tmpDir)).toThrow("process.exit");
-    mockExit.mockRestore();
+    expect(() => loadConfig(tmpDir)).toThrow(ConfigValidationError);
   });
 
-  it("exits when apps entry is not an object", () => {
+  it("throws when apps entry is not an object", () => {
     fs.writeFileSync(
       path.join(tmpDir, "portless.json"),
       JSON.stringify({ apps: { "apps/web": "bad" } })
     );
-    const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
-      throw new Error("process.exit");
-    });
-    expect(() => loadConfig(tmpDir)).toThrow("process.exit");
-    mockExit.mockRestore();
+    expect(() => loadConfig(tmpDir)).toThrow(ConfigValidationError);
   });
 
-  it("exits when proxy is not a boolean", () => {
+  it("throws when proxy is not a boolean", () => {
     fs.writeFileSync(path.join(tmpDir, "portless.json"), JSON.stringify({ proxy: "false" }));
-    const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
-      throw new Error("process.exit");
-    });
-    expect(() => loadConfig(tmpDir)).toThrow("process.exit");
-    mockExit.mockRestore();
+    expect(() => loadConfig(tmpDir)).toThrow(ConfigValidationError);
   });
 });
 
@@ -627,6 +596,3 @@ describe("resolveScriptCommand", () => {
     expect(resolveScriptCommand("dev", tmpDir)).toEqual(["yarn", "run", "dev"]);
   });
 });
-
-// Vitest provides vi globally
-import { vi } from "vitest";

--- a/packages/portless/src/config.test.ts
+++ b/packages/portless/src/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
@@ -81,6 +81,10 @@ describe("splitCommand", () => {
 
   it("handles backslash-escaped spaces", () => {
     expect(splitCommand("path\\ with\\ spaces arg")).toEqual(["path with spaces", "arg"]);
+  });
+
+  it("preserves backslash inside single quotes (POSIX behavior)", () => {
+    expect(splitCommand("echo 'hello\\nworld'")).toEqual(["echo", "hello\\nworld"]);
   });
 });
 
@@ -261,6 +265,28 @@ describe("loadConfig validation", () => {
   it("throws when proxy is not a boolean", () => {
     fs.writeFileSync(path.join(tmpDir, "portless.json"), JSON.stringify({ proxy: "false" }));
     expect(() => loadConfig(tmpDir)).toThrow(ConfigValidationError);
+  });
+
+  it("warns on unknown top-level keys", () => {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    fs.writeFileSync(
+      path.join(tmpDir, "portless.json"),
+      JSON.stringify({ name: "myapp", typo: true })
+    );
+    loadConfig(tmpDir);
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('"typo"'));
+    spy.mockRestore();
+  });
+
+  it("warns on unknown keys in apps entries", () => {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    fs.writeFileSync(
+      path.join(tmpDir, "portless.json"),
+      JSON.stringify({ apps: { "apps/web": { name: "web", port: 3000 } } })
+    );
+    loadConfig(tmpDir);
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('"apps.apps/web.port"'));
+    spy.mockRestore();
   });
 });
 
@@ -469,6 +495,14 @@ describe("loadPackagePortlessConfig", () => {
 
   it("returns null when no package.json", () => {
     expect(loadPackagePortlessConfig(tmpDir)).toBeNull();
+  });
+
+  it("throws ConfigValidationError for invalid portless config", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", portless: { appPort: "bad" } })
+    );
+    expect(() => loadPackagePortlessConfig(tmpDir)).toThrow(ConfigValidationError);
   });
 });
 

--- a/packages/portless/src/config.test.ts
+++ b/packages/portless/src/config.test.ts
@@ -40,6 +40,29 @@ describe("splitCommand", () => {
   it("returns empty array for empty string", () => {
     expect(splitCommand("")).toEqual([]);
   });
+
+  it("preserves single-quoted arguments", () => {
+    expect(splitCommand("NODE_OPTIONS='--max-old-space-size=4096' next dev")).toEqual([
+      "NODE_OPTIONS=--max-old-space-size=4096",
+      "next",
+      "dev",
+    ]);
+  });
+
+  it("preserves double-quoted arguments", () => {
+    expect(splitCommand('echo "hello world"')).toEqual(["echo", "hello world"]);
+  });
+
+  it("handles mixed quotes", () => {
+    expect(splitCommand(`KEY='val with spaces' CMD="another arg"`)).toEqual([
+      "KEY=val with spaces",
+      "CMD=another arg",
+    ]);
+  });
+
+  it("handles quotes within a token", () => {
+    expect(splitCommand("--flag='some value'")).toEqual(["--flag=some value"]);
+  });
 });
 
 describe("loadConfig", () => {
@@ -65,14 +88,11 @@ describe("loadConfig", () => {
     expect(result!.configDir).toBe(tmpDir);
   });
 
-  it("walks up from a subdirectory", () => {
+  it("does not walk up from a subdirectory", () => {
     fs.writeFileSync(path.join(tmpDir, "portless.json"), JSON.stringify({ name: "myapp" }));
     const subDir = path.join(tmpDir, "src", "components");
     fs.mkdirSync(subDir, { recursive: true });
-    const result = loadConfig(subDir);
-    expect(result).not.toBeNull();
-    expect(result!.config.name).toBe("myapp");
-    expect(result!.configDir).toBe(tmpDir);
+    expect(loadConfig(subDir)).toBeNull();
   });
 
   it("loads config with all fields", () => {
@@ -150,17 +170,14 @@ describe("loadConfig", () => {
     expect(loadConfig(tmpDir)).toBeNull();
   });
 
-  it("walks up to find package.json portless key", () => {
+  it("does not walk up to find package.json portless key", () => {
     fs.writeFileSync(
       path.join(tmpDir, "package.json"),
       JSON.stringify({ name: "test", portless: { name: "root-app" } })
     );
     const subDir = path.join(tmpDir, "packages", "web");
     fs.mkdirSync(subDir, { recursive: true });
-    const result = loadConfig(subDir);
-    expect(result).not.toBeNull();
-    expect(result!.config.name).toBe("root-app");
-    expect(result!.configDir).toBe(tmpDir);
+    expect(loadConfig(subDir)).toBeNull();
   });
 });
 
@@ -401,10 +418,10 @@ describe("loadPackagePortlessConfig", () => {
   it("returns config from package.json portless key", () => {
     fs.writeFileSync(
       path.join(tmpDir, "package.json"),
-      JSON.stringify({ name: "test", portless: { name: "myapp", proxy: false } })
+      JSON.stringify({ name: "test", portless: { name: "myapp", script: "start" } })
     );
     const result = loadPackagePortlessConfig(tmpDir);
-    expect(result).toEqual({ name: "myapp", proxy: false });
+    expect(result).toEqual({ name: "myapp", script: "start" });
   });
 
   it("returns config from string shorthand", () => {
@@ -425,10 +442,7 @@ describe("loadPackagePortlessConfig", () => {
   });
 
   it("returns null when no portless key", () => {
-    fs.writeFileSync(
-      path.join(tmpDir, "package.json"),
-      JSON.stringify({ name: "test" })
-    );
+    fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ name: "test" }));
     expect(loadPackagePortlessConfig(tmpDir)).toBeNull();
   });
 

--- a/packages/portless/src/config.test.ts
+++ b/packages/portless/src/config.test.ts
@@ -6,6 +6,8 @@ import {
   loadConfig,
   resolveAppConfig,
   resolveScript,
+  resolveScriptCommand,
+  detectPackageManager,
   hasScript,
   splitCommand,
   isServerCommand,
@@ -520,6 +522,109 @@ describe("isServerCommand", () => {
 
   it("returns false for empty args", () => {
     expect(isServerCommand([])).toBe(false);
+  });
+});
+
+describe("detectPackageManager", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    cleanupDir(tmpDir);
+  });
+
+  it("detects pnpm from pnpm-lock.yaml", () => {
+    fs.writeFileSync(path.join(tmpDir, "pnpm-lock.yaml"), "");
+    expect(detectPackageManager(tmpDir)).toBe("pnpm");
+  });
+
+  it("detects yarn from yarn.lock", () => {
+    fs.writeFileSync(path.join(tmpDir, "yarn.lock"), "");
+    expect(detectPackageManager(tmpDir)).toBe("yarn");
+  });
+
+  it("detects bun from bun.lockb", () => {
+    fs.writeFileSync(path.join(tmpDir, "bun.lockb"), "");
+    expect(detectPackageManager(tmpDir)).toBe("bun");
+  });
+
+  it("detects npm from package-lock.json", () => {
+    fs.writeFileSync(path.join(tmpDir, "package-lock.json"), "{}");
+    expect(detectPackageManager(tmpDir)).toBe("npm");
+  });
+
+  it("reads packageManager field from package.json", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", packageManager: "pnpm@9.15.4" })
+    );
+    expect(detectPackageManager(tmpDir)).toBe("pnpm");
+  });
+
+  it("prefers packageManager field over lock file", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", packageManager: "yarn@4.0.0" })
+    );
+    fs.writeFileSync(path.join(tmpDir, "pnpm-lock.yaml"), "");
+    expect(detectPackageManager(tmpDir)).toBe("yarn");
+  });
+
+  it("walks up to find lock file in parent", () => {
+    fs.writeFileSync(path.join(tmpDir, "pnpm-lock.yaml"), "");
+    const subDir = path.join(tmpDir, "packages", "web");
+    fs.mkdirSync(subDir, { recursive: true });
+    expect(detectPackageManager(subDir)).toBe("pnpm");
+  });
+
+  it("defaults to npm when nothing found", () => {
+    expect(detectPackageManager(tmpDir)).toBe("npm");
+  });
+});
+
+describe("resolveScriptCommand", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    cleanupDir(tmpDir);
+  });
+
+  it("returns PM-delegated command when script exists", () => {
+    fs.writeFileSync(path.join(tmpDir, "pnpm-lock.yaml"), "");
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ scripts: { dev: "next dev" } })
+    );
+    expect(resolveScriptCommand("dev", tmpDir)).toEqual(["pnpm", "run", "dev"]);
+  });
+
+  it("returns null when script is missing", () => {
+    fs.writeFileSync(path.join(tmpDir, "pnpm-lock.yaml"), "");
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ scripts: { build: "next build" } })
+    );
+    expect(resolveScriptCommand("dev", tmpDir)).toBeNull();
+  });
+
+  it("returns null when package.json is missing", () => {
+    expect(resolveScriptCommand("dev", tmpDir)).toBeNull();
+  });
+
+  it("uses detected package manager", () => {
+    fs.writeFileSync(path.join(tmpDir, "yarn.lock"), "");
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ scripts: { dev: "next dev" } })
+    );
+    expect(resolveScriptCommand("dev", tmpDir)).toEqual(["yarn", "run", "dev"]);
   });
 });
 

--- a/packages/portless/src/config.test.ts
+++ b/packages/portless/src/config.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { loadConfig, resolveAppConfig, resolveScript, hasScript, splitCommand } from "./config.js";
+
+function createTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "portless-config-test-"));
+}
+
+function cleanupDir(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+describe("splitCommand", () => {
+  it("splits on whitespace", () => {
+    expect(splitCommand("next dev")).toEqual(["next", "dev"]);
+  });
+
+  it("handles multiple spaces", () => {
+    expect(splitCommand("next   dev")).toEqual(["next", "dev"]);
+  });
+
+  it("trims leading/trailing whitespace", () => {
+    expect(splitCommand("  next dev  ")).toEqual(["next", "dev"]);
+  });
+
+  it("handles single-word command", () => {
+    expect(splitCommand("vitest")).toEqual(["vitest"]);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(splitCommand("")).toEqual([]);
+  });
+});
+
+describe("loadConfig", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    cleanupDir(tmpDir);
+  });
+
+  it("returns null when no portless.json exists", () => {
+    expect(loadConfig(tmpDir)).toBeNull();
+  });
+
+  it("loads portless.json from cwd", () => {
+    fs.writeFileSync(path.join(tmpDir, "portless.json"), JSON.stringify({ name: "myapp" }));
+    const result = loadConfig(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result!.config.name).toBe("myapp");
+    expect(result!.configDir).toBe(tmpDir);
+  });
+
+  it("walks up from a subdirectory", () => {
+    fs.writeFileSync(path.join(tmpDir, "portless.json"), JSON.stringify({ name: "myapp" }));
+    const subDir = path.join(tmpDir, "src", "components");
+    fs.mkdirSync(subDir, { recursive: true });
+    const result = loadConfig(subDir);
+    expect(result).not.toBeNull();
+    expect(result!.config.name).toBe("myapp");
+    expect(result!.configDir).toBe(tmpDir);
+  });
+
+  it("loads config with all fields", () => {
+    const config = { name: "myapp", script: "start", appPort: 3000 };
+    fs.writeFileSync(path.join(tmpDir, "portless.json"), JSON.stringify(config));
+    const result = loadConfig(tmpDir);
+    expect(result!.config).toEqual(config);
+  });
+
+  it("loads config with apps map", () => {
+    const config = {
+      apps: {
+        "apps/web": { name: "web" },
+        "apps/api": { name: "api", script: "start" },
+      },
+    };
+    fs.writeFileSync(path.join(tmpDir, "portless.json"), JSON.stringify(config));
+    const result = loadConfig(tmpDir);
+    expect(result!.config.apps).toBeDefined();
+    expect(Object.keys(result!.config.apps!)).toHaveLength(2);
+  });
+
+  it("loads empty object config", () => {
+    fs.writeFileSync(path.join(tmpDir, "portless.json"), "{}");
+    const result = loadConfig(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result!.config).toEqual({});
+  });
+});
+
+describe("loadConfig validation", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    cleanupDir(tmpDir);
+  });
+
+  it("exits on invalid JSON", () => {
+    fs.writeFileSync(path.join(tmpDir, "portless.json"), "not json");
+    const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    expect(() => loadConfig(tmpDir)).toThrow("process.exit");
+    mockExit.mockRestore();
+  });
+
+  it("exits when config is an array", () => {
+    fs.writeFileSync(path.join(tmpDir, "portless.json"), "[]");
+    const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    expect(() => loadConfig(tmpDir)).toThrow("process.exit");
+    mockExit.mockRestore();
+  });
+
+  it("exits when name is a number", () => {
+    fs.writeFileSync(path.join(tmpDir, "portless.json"), JSON.stringify({ name: 42 }));
+    const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    expect(() => loadConfig(tmpDir)).toThrow("process.exit");
+    mockExit.mockRestore();
+  });
+
+  it("exits when name is empty string", () => {
+    fs.writeFileSync(path.join(tmpDir, "portless.json"), JSON.stringify({ name: "" }));
+    const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    expect(() => loadConfig(tmpDir)).toThrow("process.exit");
+    mockExit.mockRestore();
+  });
+
+  it("exits when appPort is out of range", () => {
+    fs.writeFileSync(path.join(tmpDir, "portless.json"), JSON.stringify({ appPort: 99999 }));
+    const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    expect(() => loadConfig(tmpDir)).toThrow("process.exit");
+    mockExit.mockRestore();
+  });
+
+  it("exits when appPort is a string", () => {
+    fs.writeFileSync(path.join(tmpDir, "portless.json"), JSON.stringify({ appPort: "3000" }));
+    const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    expect(() => loadConfig(tmpDir)).toThrow("process.exit");
+    mockExit.mockRestore();
+  });
+
+  it("exits when apps entry is not an object", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "portless.json"),
+      JSON.stringify({ apps: { "apps/web": "bad" } })
+    );
+    const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    expect(() => loadConfig(tmpDir)).toThrow("process.exit");
+    mockExit.mockRestore();
+  });
+});
+
+describe("resolveAppConfig", () => {
+  it("returns top-level fields when no apps key", () => {
+    const config = { name: "myapp", script: "dev" };
+    const result = resolveAppConfig(config, "/repo", "/repo");
+    expect(result).toEqual({ name: "myapp", script: "dev" });
+  });
+
+  it("matches exact path in apps map", () => {
+    const config = {
+      apps: {
+        "apps/web": { name: "web" },
+        "apps/api": { name: "api" },
+      },
+    };
+    const result = resolveAppConfig(config, "/repo", "/repo/apps/web");
+    expect(result).toEqual({ name: "web" });
+  });
+
+  it("matches subdirectory to parent app entry", () => {
+    const config = {
+      apps: {
+        "apps/web": { name: "web" },
+      },
+    };
+    const result = resolveAppConfig(config, "/repo", "/repo/apps/web/src/components");
+    expect(result).toEqual({ name: "web" });
+  });
+
+  it("returns empty object when no apps key matches", () => {
+    const config = {
+      apps: {
+        "apps/web": { name: "web" },
+      },
+    };
+    const result = resolveAppConfig(config, "/repo", "/repo/packages/shared");
+    expect(result).toEqual({});
+  });
+
+  it("ignores top-level fields when apps is present", () => {
+    const config = {
+      name: "top-level",
+      apps: {
+        "apps/web": { name: "web" },
+      },
+    };
+    const result = resolveAppConfig(config, "/repo", "/repo/packages/other");
+    expect(result).toEqual({});
+  });
+
+  it("handles Windows-style backslash paths", () => {
+    const config = {
+      apps: {
+        "apps/web": { name: "web" },
+      },
+    };
+    // path.relative on Windows returns backslashes
+    const result = resolveAppConfig(config, "/repo", "/repo/apps/web");
+    expect(result).toEqual({ name: "web" });
+  });
+});
+
+describe("resolveScript", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    cleanupDir(tmpDir);
+  });
+
+  it("reads script from package.json", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ scripts: { dev: "next dev" } })
+    );
+    const result = resolveScript("dev", tmpDir);
+    expect(result).toEqual(["next", "dev"]);
+  });
+
+  it("returns null for missing script", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ scripts: { build: "next build" } })
+    );
+    expect(resolveScript("dev", tmpDir)).toBeNull();
+  });
+
+  it("returns null for missing package.json", () => {
+    expect(resolveScript("dev", tmpDir)).toBeNull();
+  });
+
+  it("returns null for empty script value", () => {
+    fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ scripts: { dev: "" } }));
+    expect(resolveScript("dev", tmpDir)).toBeNull();
+  });
+
+  it("splits multi-word script into args", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ scripts: { dev: "NODE_ENV=development next dev --turbo" } })
+    );
+    const result = resolveScript("dev", tmpDir);
+    expect(result).toEqual(["NODE_ENV=development", "next", "dev", "--turbo"]);
+  });
+});
+
+describe("hasScript", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    cleanupDir(tmpDir);
+  });
+
+  it("returns true when script exists", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ scripts: { dev: "next dev" } })
+    );
+    expect(hasScript("dev", tmpDir)).toBe(true);
+  });
+
+  it("returns false when script is missing", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ scripts: { build: "next build" } })
+    );
+    expect(hasScript("dev", tmpDir)).toBe(false);
+  });
+
+  it("returns false when package.json is missing", () => {
+    expect(hasScript("dev", tmpDir)).toBe(false);
+  });
+
+  it("returns false when scripts object is missing", () => {
+    fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ name: "test" }));
+    expect(hasScript("dev", tmpDir)).toBe(false);
+  });
+});
+
+// Vitest provides vi globally
+import { vi } from "vitest";

--- a/packages/portless/src/config.ts
+++ b/packages/portless/src/config.ts
@@ -6,6 +6,7 @@ export interface AppConfig {
   name?: string;
   script?: string;
   appPort?: number;
+  proxy?: boolean;
 }
 
 export interface PortlessConfig extends AppConfig {
@@ -20,12 +21,14 @@ export interface LoadedConfig {
 const CONFIG_FILENAME = "portless.json";
 
 /**
- * Walk up from `cwd` looking for portless.json. Returns the parsed config
- * and the directory it was found in, or null if no config exists.
+ * Walk up from `cwd` looking for portless config. Checks `portless.json`
+ * first, then falls back to a `"portless"` key in `package.json`.
+ * Returns the parsed config and the directory it was found in, or null.
  */
 export function loadConfig(cwd: string = process.cwd()): LoadedConfig | null {
   let dir = cwd;
   for (;;) {
+    // Prefer standalone portless.json
     const configPath = path.join(dir, CONFIG_FILENAME);
     try {
       const raw = fs.readFileSync(configPath, "utf-8");
@@ -34,6 +37,10 @@ export function loadConfig(cwd: string = process.cwd()): LoadedConfig | null {
       return { config: parsed, configDir: dir };
     } catch (err) {
       if (isErrnoException(err) && err.code === "ENOENT") {
+        // No portless.json — try package.json "portless" key
+        const fromPkg = loadConfigFromPackageJson(dir);
+        if (fromPkg) return fromPkg;
+
         const parent = path.dirname(dir);
         if (parent === dir) return null;
         dir = parent;
@@ -46,6 +53,56 @@ export function loadConfig(cwd: string = process.cwd()): LoadedConfig | null {
       throw err;
     }
   }
+}
+
+/** Normalize the raw `"portless"` value: a string is shorthand for `{ name }`. */
+function normalizePortlessValue(value: unknown): unknown {
+  if (typeof value === "string") {
+    return value.trim() ? { name: value.trim() } : null;
+  }
+  return value;
+}
+
+function loadConfigFromPackageJson(dir: string): LoadedConfig | null {
+  const pkgPath = path.join(dir, "package.json");
+  try {
+    const raw = fs.readFileSync(pkgPath, "utf-8");
+    const pkg = JSON.parse(raw);
+    if (pkg && typeof pkg === "object" && "portless" in pkg) {
+      const config = normalizePortlessValue(pkg.portless);
+      if (config === null) return null;
+      validateConfig(config, `${pkgPath} "portless"`);
+      return { config: config as PortlessConfig, configDir: dir };
+    }
+  } catch (err) {
+    if (isErrnoException(err) && err.code === "ENOENT") return null;
+    if (err instanceof SyntaxError) return null;
+    throw err;
+  }
+  return null;
+}
+
+/**
+ * Load the `"portless"` config from a specific directory's package.json
+ * (does not walk up). Returns the AppConfig fields or null.
+ */
+export function loadPackagePortlessConfig(dir: string): AppConfig | null {
+  const pkgPath = path.join(dir, "package.json");
+  try {
+    const raw = fs.readFileSync(pkgPath, "utf-8");
+    const pkg = JSON.parse(raw);
+    if (pkg && typeof pkg === "object" && "portless" in pkg) {
+      const config = normalizePortlessValue(pkg.portless);
+      if (config === null) return null;
+      if (typeof config === "object" && !Array.isArray(config)) {
+        validateAppConfig(config as Record<string, unknown>, "portless", pkgPath);
+        return config as AppConfig;
+      }
+    }
+  } catch {
+    // Ignore — missing or unparseable
+  }
+  return null;
 }
 
 /**
@@ -115,6 +172,33 @@ export function splitCommand(command: string): string[] {
   return command.trim().split(/\s+/).filter(Boolean);
 }
 
+/**
+ * Commands that are build tools / watchers and never start an HTTP server.
+ * Used to auto-detect packages that should run without a proxy route.
+ */
+const BUILD_ONLY_COMMANDS = new Set([
+  "tsup",
+  "tsc",
+  "esbuild",
+  "rollup",
+  "babel",
+  "swc",
+  "unbuild",
+  "pkgroll",
+  "ncc",
+  "microbundle",
+]);
+
+/**
+ * Returns true if the command looks like it starts an HTTP server
+ * (and should be proxied), false if it's a known build-only tool.
+ */
+export function isServerCommand(args: string[]): boolean {
+  if (args.length === 0) return false;
+  const bin = path.basename(args[0]);
+  return !BUILD_ONLY_COMMANDS.has(bin);
+}
+
 /** Normalize path separators to forward slashes for cross-platform matching. */
 function normalizePath(p: string): string {
   return p.replace(/\\/g, "/");
@@ -156,6 +240,13 @@ function validateConfig(config: unknown, configPath: string): asserts config is 
       console.error(
         colors.red(`Error: "appPort" in ${configPath} must be an integer between 1 and 65535.`)
       );
+      process.exit(1);
+    }
+  }
+
+  if (obj.proxy !== undefined) {
+    if (typeof obj.proxy !== "boolean") {
+      console.error(colors.red(`Error: "proxy" in ${configPath} must be a boolean.`));
       process.exit(1);
     }
   }
@@ -203,6 +294,14 @@ function validateAppConfig(obj: Record<string, unknown>, prefix: string, configP
         colors.red(
           `Error: "${prefix}.appPort" in ${configPath} must be an integer between 1 and 65535.`
         )
+      );
+      process.exit(1);
+    }
+  }
+  if (obj.proxy !== undefined) {
+    if (typeof obj.proxy !== "boolean") {
+      console.error(
+        colors.red(`Error: "${prefix}.proxy" in ${configPath} must be a boolean.`)
       );
       process.exit(1);
     }

--- a/packages/portless/src/config.ts
+++ b/packages/portless/src/config.ts
@@ -6,6 +6,7 @@ export interface AppConfig {
   name?: string;
   script?: string;
   appPort?: number;
+  proxy?: boolean;
 }
 
 export interface PortlessConfig extends AppConfig {
@@ -118,8 +119,7 @@ export function resolveAppConfig(
     }
     return {};
   }
-  const { apps: _, ...topLevel } = config;
-  return topLevel;
+  return { name: config.name, script: config.script, appPort: config.appPort, proxy: config.proxy };
 }
 
 /**
@@ -155,13 +155,23 @@ export function hasScript(scriptName: string, dir: string): boolean {
   }
 }
 
-/** Split a command string on whitespace, respecting single and double quotes. */
+/** Split a command string on whitespace, respecting quotes and backslash escapes. */
 export function splitCommand(command: string): string[] {
   const args: string[] = [];
   let current = "";
   let inSingle = false;
   let inDouble = false;
+  let escaped = false;
   for (const ch of command) {
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escaped = true;
+      continue;
+    }
     if (ch === "'" && !inDouble) {
       inSingle = !inSingle;
     } else if (ch === '"' && !inSingle) {
@@ -199,6 +209,10 @@ const BUILD_ONLY_COMMANDS = new Set([
 /**
  * Returns true if the command looks like it starts an HTTP server
  * (and should be proxied), false if it's a known build-only tool.
+ *
+ * Uses a denylist: unknown commands are assumed to be servers. This is
+ * intentionally permissive so we proxy by default rather than silently
+ * skipping a real server. Use `proxy: false` in config to override.
  */
 export function isServerCommand(args: string[]): boolean {
   if (args.length === 0) return false;
@@ -251,6 +265,13 @@ function validateConfig(config: unknown, configPath: string): asserts config is 
     }
   }
 
+  if (obj.proxy !== undefined) {
+    if (typeof obj.proxy !== "boolean") {
+      console.error(colors.red(`Error: "proxy" in ${configPath} must be a boolean.`));
+      process.exit(1);
+    }
+  }
+
   if (obj.apps !== undefined) {
     if (typeof obj.apps !== "object" || obj.apps === null || Array.isArray(obj.apps)) {
       console.error(colors.red(`Error: "apps" in ${configPath} must be an object.`));
@@ -295,6 +316,12 @@ function validateAppConfig(obj: Record<string, unknown>, prefix: string, configP
           `Error: "${prefix}.appPort" in ${configPath} must be an integer between 1 and 65535.`
         )
       );
+      process.exit(1);
+    }
+  }
+  if (obj.proxy !== undefined) {
+    if (typeof obj.proxy !== "boolean") {
+      console.error(colors.red(`Error: "${prefix}.proxy" in ${configPath} must be a boolean.`));
       process.exit(1);
     }
   }

--- a/packages/portless/src/config.ts
+++ b/packages/portless/src/config.ts
@@ -1,6 +1,12 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import colors from "./colors.js";
+
+export class ConfigValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConfigValidationError";
+  }
+}
 
 export interface AppConfig {
   name?: string;
@@ -37,8 +43,7 @@ export function loadConfig(cwd: string = process.cwd()): LoadedConfig | null {
       return loadConfigFromPackageJson(cwd);
     }
     if (err instanceof SyntaxError) {
-      console.error(colors.red(`Error: Invalid JSON in ${configPath}`));
-      process.exit(1);
+      throw new ConfigValidationError(`Invalid JSON in ${configPath}`);
     }
     throw err;
   }
@@ -290,23 +295,20 @@ function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
 
 function validateConfig(config: unknown, configPath: string): asserts config is PortlessConfig {
   if (typeof config !== "object" || config === null || Array.isArray(config)) {
-    console.error(colors.red(`Error: ${configPath} must be a JSON object.`));
-    process.exit(1);
+    throw new ConfigValidationError(`${configPath} must be a JSON object.`);
   }
 
   const obj = config as Record<string, unknown>;
 
   if (obj.name !== undefined) {
     if (typeof obj.name !== "string" || !obj.name.trim()) {
-      console.error(colors.red(`Error: "name" in ${configPath} must be a non-empty string.`));
-      process.exit(1);
+      throw new ConfigValidationError(`"name" in ${configPath} must be a non-empty string.`);
     }
   }
 
   if (obj.script !== undefined) {
     if (typeof obj.script !== "string" || !obj.script.trim()) {
-      console.error(colors.red(`Error: "script" in ${configPath} must be a non-empty string.`));
-      process.exit(1);
+      throw new ConfigValidationError(`"script" in ${configPath} must be a non-empty string.`);
     }
   }
 
@@ -317,29 +319,25 @@ function validateConfig(config: unknown, configPath: string): asserts config is 
       obj.appPort < 1 ||
       obj.appPort > 65535
     ) {
-      console.error(
-        colors.red(`Error: "appPort" in ${configPath} must be an integer between 1 and 65535.`)
+      throw new ConfigValidationError(
+        `"appPort" in ${configPath} must be an integer between 1 and 65535.`
       );
-      process.exit(1);
     }
   }
 
   if (obj.proxy !== undefined) {
     if (typeof obj.proxy !== "boolean") {
-      console.error(colors.red(`Error: "proxy" in ${configPath} must be a boolean.`));
-      process.exit(1);
+      throw new ConfigValidationError(`"proxy" in ${configPath} must be a boolean.`);
     }
   }
 
   if (obj.apps !== undefined) {
     if (typeof obj.apps !== "object" || obj.apps === null || Array.isArray(obj.apps)) {
-      console.error(colors.red(`Error: "apps" in ${configPath} must be an object.`));
-      process.exit(1);
+      throw new ConfigValidationError(`"apps" in ${configPath} must be an object.`);
     }
     for (const [key, value] of Object.entries(obj.apps as Record<string, unknown>)) {
       if (typeof value !== "object" || value === null || Array.isArray(value)) {
-        console.error(colors.red(`Error: "apps.${key}" in ${configPath} must be an object.`));
-        process.exit(1);
+        throw new ConfigValidationError(`"apps.${key}" in ${configPath} must be an object.`);
       }
       validateAppConfig(value as Record<string, unknown>, `apps.${key}`, configPath);
     }
@@ -349,18 +347,16 @@ function validateConfig(config: unknown, configPath: string): asserts config is 
 function validateAppConfig(obj: Record<string, unknown>, prefix: string, configPath: string): void {
   if (obj.name !== undefined) {
     if (typeof obj.name !== "string" || !obj.name.trim()) {
-      console.error(
-        colors.red(`Error: "${prefix}.name" in ${configPath} must be a non-empty string.`)
+      throw new ConfigValidationError(
+        `"${prefix}.name" in ${configPath} must be a non-empty string.`
       );
-      process.exit(1);
     }
   }
   if (obj.script !== undefined) {
     if (typeof obj.script !== "string" || !obj.script.trim()) {
-      console.error(
-        colors.red(`Error: "${prefix}.script" in ${configPath} must be a non-empty string.`)
+      throw new ConfigValidationError(
+        `"${prefix}.script" in ${configPath} must be a non-empty string.`
       );
-      process.exit(1);
     }
   }
   if (obj.appPort !== undefined) {
@@ -370,18 +366,14 @@ function validateAppConfig(obj: Record<string, unknown>, prefix: string, configP
       obj.appPort < 1 ||
       obj.appPort > 65535
     ) {
-      console.error(
-        colors.red(
-          `Error: "${prefix}.appPort" in ${configPath} must be an integer between 1 and 65535.`
-        )
+      throw new ConfigValidationError(
+        `"${prefix}.appPort" in ${configPath} must be an integer between 1 and 65535.`
       );
-      process.exit(1);
     }
   }
   if (obj.proxy !== undefined) {
     if (typeof obj.proxy !== "boolean") {
-      console.error(colors.red(`Error: "${prefix}.proxy" in ${configPath} must be a boolean.`));
-      process.exit(1);
+      throw new ConfigValidationError(`"${prefix}.proxy" in ${configPath} must be a boolean.`);
     }
   }
 }

--- a/packages/portless/src/config.ts
+++ b/packages/portless/src/config.ts
@@ -93,8 +93,8 @@ export function loadPackagePortlessConfig(dir: string): AppConfig | null {
         return config as AppConfig;
       }
     }
-  } catch {
-    // Ignore — missing or unparseable
+  } catch (err) {
+    if (err instanceof ConfigValidationError) throw err;
   }
   return null;
 }
@@ -232,7 +232,7 @@ export function splitCommand(command: string): string[] {
       escaped = false;
       continue;
     }
-    if (ch === "\\") {
+    if (ch === "\\" && !inSingle) {
       escaped = true;
       continue;
     }
@@ -293,6 +293,9 @@ function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
   return err instanceof Error && "code" in err;
 }
 
+const KNOWN_TOP_KEYS = new Set(["name", "script", "appPort", "proxy", "apps"]);
+const KNOWN_APP_KEYS = new Set(["name", "script", "appPort", "proxy"]);
+
 function validateConfig(config: unknown, configPath: string): asserts config is PortlessConfig {
   if (typeof config !== "object" || config === null || Array.isArray(config)) {
     throw new ConfigValidationError(`${configPath} must be a JSON object.`);
@@ -342,6 +345,8 @@ function validateConfig(config: unknown, configPath: string): asserts config is 
       validateAppConfig(value as Record<string, unknown>, `apps.${key}`, configPath);
     }
   }
+
+  warnUnknownKeys(obj, KNOWN_TOP_KEYS, configPath);
 }
 
 function validateAppConfig(obj: Record<string, unknown>, prefix: string, configPath: string): void {
@@ -374,6 +379,24 @@ function validateAppConfig(obj: Record<string, unknown>, prefix: string, configP
   if (obj.proxy !== undefined) {
     if (typeof obj.proxy !== "boolean") {
       throw new ConfigValidationError(`"${prefix}.proxy" in ${configPath} must be a boolean.`);
+    }
+  }
+
+  warnUnknownKeys(obj, KNOWN_APP_KEYS, configPath, prefix);
+}
+
+function warnUnknownKeys(
+  obj: Record<string, unknown>,
+  known: Set<string>,
+  configPath: string,
+  prefix?: string
+): void {
+  for (const key of Object.keys(obj)) {
+    if (!known.has(key)) {
+      const label = prefix ? `"${prefix}.${key}"` : `"${key}"`;
+      console.warn(
+        `Warning: Unknown key ${label} in ${configPath}. Known keys: ${[...known].join(", ")}`
+      );
     }
   }
 }

--- a/packages/portless/src/config.ts
+++ b/packages/portless/src/config.ts
@@ -17,6 +17,7 @@ export interface AppConfig {
 
 export interface PortlessConfig extends AppConfig {
   apps?: Record<string, AppConfig>;
+  turbo?: boolean;
 }
 
 export interface LoadedConfig {
@@ -293,7 +294,7 @@ function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
   return err instanceof Error && "code" in err;
 }
 
-const KNOWN_TOP_KEYS = new Set(["name", "script", "appPort", "proxy", "apps"]);
+const KNOWN_TOP_KEYS = new Set(["name", "script", "appPort", "proxy", "apps", "turbo"]);
 const KNOWN_APP_KEYS = new Set(["name", "script", "appPort", "proxy"]);
 
 function validateConfig(config: unknown, configPath: string): asserts config is PortlessConfig {
@@ -331,6 +332,12 @@ function validateConfig(config: unknown, configPath: string): asserts config is 
   if (obj.proxy !== undefined) {
     if (typeof obj.proxy !== "boolean") {
       throw new ConfigValidationError(`"proxy" in ${configPath} must be a boolean.`);
+    }
+  }
+
+  if (obj.turbo !== undefined) {
+    if (typeof obj.turbo !== "boolean") {
+      throw new ConfigValidationError(`"turbo" in ${configPath} must be a boolean.`);
     }
   }
 

--- a/packages/portless/src/config.ts
+++ b/packages/portless/src/config.ts
@@ -6,7 +6,6 @@ export interface AppConfig {
   name?: string;
   script?: string;
   appPort?: number;
-  proxy?: boolean;
 }
 
 export interface PortlessConfig extends AppConfig {
@@ -21,37 +20,26 @@ export interface LoadedConfig {
 const CONFIG_FILENAME = "portless.json";
 
 /**
- * Walk up from `cwd` looking for portless config. Checks `portless.json`
- * first, then falls back to a `"portless"` key in `package.json`.
- * Returns the parsed config and the directory it was found in, or null.
+ * Load portless config from `cwd`. Checks `portless.json` first, then
+ * falls back to a `"portless"` key in `package.json`. Does not walk up
+ * to parent directories.
  */
 export function loadConfig(cwd: string = process.cwd()): LoadedConfig | null {
-  let dir = cwd;
-  for (;;) {
-    // Prefer standalone portless.json
-    const configPath = path.join(dir, CONFIG_FILENAME);
-    try {
-      const raw = fs.readFileSync(configPath, "utf-8");
-      const parsed = JSON.parse(raw);
-      validateConfig(parsed, configPath);
-      return { config: parsed, configDir: dir };
-    } catch (err) {
-      if (isErrnoException(err) && err.code === "ENOENT") {
-        // No portless.json — try package.json "portless" key
-        const fromPkg = loadConfigFromPackageJson(dir);
-        if (fromPkg) return fromPkg;
-
-        const parent = path.dirname(dir);
-        if (parent === dir) return null;
-        dir = parent;
-        continue;
-      }
-      if (err instanceof SyntaxError) {
-        console.error(colors.red(`Error: Invalid JSON in ${configPath}`));
-        process.exit(1);
-      }
-      throw err;
+  const configPath = path.join(cwd, CONFIG_FILENAME);
+  try {
+    const raw = fs.readFileSync(configPath, "utf-8");
+    const parsed = JSON.parse(raw);
+    validateConfig(parsed, configPath);
+    return { config: parsed, configDir: cwd };
+  } catch (err) {
+    if (isErrnoException(err) && err.code === "ENOENT") {
+      return loadConfigFromPackageJson(cwd);
     }
+    if (err instanceof SyntaxError) {
+      console.error(colors.red(`Error: Invalid JSON in ${configPath}`));
+      process.exit(1);
+    }
+    throw err;
   }
 }
 
@@ -167,9 +155,28 @@ export function hasScript(scriptName: string, dir: string): boolean {
   }
 }
 
-/** Split a command string on whitespace into an args array. */
+/** Split a command string on whitespace, respecting single and double quotes. */
 export function splitCommand(command: string): string[] {
-  return command.trim().split(/\s+/).filter(Boolean);
+  const args: string[] = [];
+  let current = "";
+  let inSingle = false;
+  let inDouble = false;
+  for (const ch of command) {
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+    } else if (ch === '"' && !inSingle) {
+      inDouble = !inDouble;
+    } else if (/\s/.test(ch) && !inSingle && !inDouble) {
+      if (current) {
+        args.push(current);
+        current = "";
+      }
+    } else {
+      current += ch;
+    }
+  }
+  if (current) args.push(current);
+  return args;
 }
 
 /**
@@ -244,13 +251,6 @@ function validateConfig(config: unknown, configPath: string): asserts config is 
     }
   }
 
-  if (obj.proxy !== undefined) {
-    if (typeof obj.proxy !== "boolean") {
-      console.error(colors.red(`Error: "proxy" in ${configPath} must be a boolean.`));
-      process.exit(1);
-    }
-  }
-
   if (obj.apps !== undefined) {
     if (typeof obj.apps !== "object" || obj.apps === null || Array.isArray(obj.apps)) {
       console.error(colors.red(`Error: "apps" in ${configPath} must be an object.`));
@@ -294,14 +294,6 @@ function validateAppConfig(obj: Record<string, unknown>, prefix: string, configP
         colors.red(
           `Error: "${prefix}.appPort" in ${configPath} must be an integer between 1 and 65535.`
         )
-      );
-      process.exit(1);
-    }
-  }
-  if (obj.proxy !== undefined) {
-    if (typeof obj.proxy !== "boolean") {
-      console.error(
-        colors.red(`Error: "${prefix}.proxy" in ${configPath} must be a boolean.`)
       );
       process.exit(1);
     }

--- a/packages/portless/src/config.ts
+++ b/packages/portless/src/config.ts
@@ -155,6 +155,65 @@ export function hasScript(scriptName: string, dir: string): boolean {
   }
 }
 
+export type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
+
+const LOCK_FILES: [string, PackageManager][] = [
+  ["pnpm-lock.yaml", "pnpm"],
+  ["yarn.lock", "yarn"],
+  ["bun.lockb", "bun"],
+  ["bun.lock", "bun"],
+  ["package-lock.json", "npm"],
+];
+
+/**
+ * Detect the package manager for a project by walking up from `cwd`.
+ * Checks `packageManager` field in package.json first, then lock files.
+ * Defaults to `npm` if nothing is found.
+ */
+export function detectPackageManager(cwd: string): PackageManager {
+  let dir = cwd;
+  for (;;) {
+    const pkgPath = path.join(dir, "package.json");
+    try {
+      const raw = fs.readFileSync(pkgPath, "utf-8");
+      const pkg = JSON.parse(raw);
+      if (typeof pkg.packageManager === "string") {
+        const name = pkg.packageManager.split("@")[0] as string;
+        if (name === "pnpm" || name === "yarn" || name === "bun" || name === "npm") {
+          return name;
+        }
+      }
+    } catch {
+      // no package.json here
+    }
+
+    for (const [file, pm] of LOCK_FILES) {
+      try {
+        fs.accessSync(path.join(dir, file), fs.constants.F_OK);
+        return pm;
+      } catch {
+        // not found
+      }
+    }
+
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return "npm";
+}
+
+/**
+ * Resolve a named script to a package-manager-delegated command.
+ * Returns e.g. `["pnpm", "run", "dev"]` instead of parsing the script contents.
+ * Returns null if the script doesn't exist.
+ */
+export function resolveScriptCommand(scriptName: string, packageDir: string): string[] | null {
+  if (!hasScript(scriptName, packageDir)) return null;
+  const pm = detectPackageManager(packageDir);
+  return [pm, "run", scriptName];
+}
+
 /** Split a command string on whitespace, respecting quotes and backslash escapes. */
 export function splitCommand(command: string): string[] {
   const args: string[] = [];

--- a/packages/portless/src/config.ts
+++ b/packages/portless/src/config.ts
@@ -1,0 +1,210 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import colors from "./colors.js";
+
+export interface AppConfig {
+  name?: string;
+  script?: string;
+  appPort?: number;
+}
+
+export interface PortlessConfig extends AppConfig {
+  apps?: Record<string, AppConfig>;
+}
+
+export interface LoadedConfig {
+  config: PortlessConfig;
+  configDir: string;
+}
+
+const CONFIG_FILENAME = "portless.json";
+
+/**
+ * Walk up from `cwd` looking for portless.json. Returns the parsed config
+ * and the directory it was found in, or null if no config exists.
+ */
+export function loadConfig(cwd: string = process.cwd()): LoadedConfig | null {
+  let dir = cwd;
+  for (;;) {
+    const configPath = path.join(dir, CONFIG_FILENAME);
+    try {
+      const raw = fs.readFileSync(configPath, "utf-8");
+      const parsed = JSON.parse(raw);
+      validateConfig(parsed, configPath);
+      return { config: parsed, configDir: dir };
+    } catch (err) {
+      if (isErrnoException(err) && err.code === "ENOENT") {
+        const parent = path.dirname(dir);
+        if (parent === dir) return null;
+        dir = parent;
+        continue;
+      }
+      if (err instanceof SyntaxError) {
+        console.error(colors.red(`Error: Invalid JSON in ${configPath}`));
+        process.exit(1);
+      }
+      throw err;
+    }
+  }
+}
+
+/**
+ * Resolve the effective AppConfig for a specific package directory.
+ * If the config has an `apps` map, match the package dir by walking
+ * the relative path upward. Otherwise return the top-level fields.
+ */
+export function resolveAppConfig(
+  config: PortlessConfig,
+  configDir: string,
+  packageDir: string
+): AppConfig {
+  if (config.apps) {
+    const rel = normalizePath(path.relative(configDir, packageDir));
+    if (rel && !rel.startsWith("..")) {
+      let candidate = rel;
+      while (candidate) {
+        if (config.apps[candidate]) {
+          return config.apps[candidate];
+        }
+        const parent = path.dirname(candidate);
+        if (parent === "." || parent === candidate) break;
+        candidate = normalizePath(parent);
+      }
+    }
+    return {};
+  }
+  const { apps: _, ...topLevel } = config;
+  return topLevel;
+}
+
+/**
+ * Read a named script from the package.json in `packageDir` and split
+ * it into an args array. Returns null if the script doesn't exist.
+ */
+export function resolveScript(scriptName: string, packageDir: string): string[] | null {
+  const pkgPath = path.join(packageDir, "package.json");
+  try {
+    const raw = fs.readFileSync(pkgPath, "utf-8");
+    const pkg = JSON.parse(raw);
+    const scriptValue = pkg?.scripts?.[scriptName];
+    if (typeof scriptValue !== "string" || !scriptValue.trim()) {
+      return null;
+    }
+    return splitCommand(scriptValue);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if a package.json in `dir` has a specific script defined.
+ */
+export function hasScript(scriptName: string, dir: string): boolean {
+  const pkgPath = path.join(dir, "package.json");
+  try {
+    const raw = fs.readFileSync(pkgPath, "utf-8");
+    const pkg = JSON.parse(raw);
+    return typeof pkg?.scripts?.[scriptName] === "string";
+  } catch {
+    return false;
+  }
+}
+
+/** Split a command string on whitespace into an args array. */
+export function splitCommand(command: string): string[] {
+  return command.trim().split(/\s+/).filter(Boolean);
+}
+
+/** Normalize path separators to forward slashes for cross-platform matching. */
+function normalizePath(p: string): string {
+  return p.replace(/\\/g, "/");
+}
+
+function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error && "code" in err;
+}
+
+function validateConfig(config: unknown, configPath: string): asserts config is PortlessConfig {
+  if (typeof config !== "object" || config === null || Array.isArray(config)) {
+    console.error(colors.red(`Error: ${configPath} must be a JSON object.`));
+    process.exit(1);
+  }
+
+  const obj = config as Record<string, unknown>;
+
+  if (obj.name !== undefined) {
+    if (typeof obj.name !== "string" || !obj.name.trim()) {
+      console.error(colors.red(`Error: "name" in ${configPath} must be a non-empty string.`));
+      process.exit(1);
+    }
+  }
+
+  if (obj.script !== undefined) {
+    if (typeof obj.script !== "string" || !obj.script.trim()) {
+      console.error(colors.red(`Error: "script" in ${configPath} must be a non-empty string.`));
+      process.exit(1);
+    }
+  }
+
+  if (obj.appPort !== undefined) {
+    if (
+      typeof obj.appPort !== "number" ||
+      !Number.isInteger(obj.appPort) ||
+      obj.appPort < 1 ||
+      obj.appPort > 65535
+    ) {
+      console.error(
+        colors.red(`Error: "appPort" in ${configPath} must be an integer between 1 and 65535.`)
+      );
+      process.exit(1);
+    }
+  }
+
+  if (obj.apps !== undefined) {
+    if (typeof obj.apps !== "object" || obj.apps === null || Array.isArray(obj.apps)) {
+      console.error(colors.red(`Error: "apps" in ${configPath} must be an object.`));
+      process.exit(1);
+    }
+    for (const [key, value] of Object.entries(obj.apps as Record<string, unknown>)) {
+      if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        console.error(colors.red(`Error: "apps.${key}" in ${configPath} must be an object.`));
+        process.exit(1);
+      }
+      validateAppConfig(value as Record<string, unknown>, `apps.${key}`, configPath);
+    }
+  }
+}
+
+function validateAppConfig(obj: Record<string, unknown>, prefix: string, configPath: string): void {
+  if (obj.name !== undefined) {
+    if (typeof obj.name !== "string" || !obj.name.trim()) {
+      console.error(
+        colors.red(`Error: "${prefix}.name" in ${configPath} must be a non-empty string.`)
+      );
+      process.exit(1);
+    }
+  }
+  if (obj.script !== undefined) {
+    if (typeof obj.script !== "string" || !obj.script.trim()) {
+      console.error(
+        colors.red(`Error: "${prefix}.script" in ${configPath} must be a non-empty string.`)
+      );
+      process.exit(1);
+    }
+  }
+  if (obj.appPort !== undefined) {
+    if (
+      typeof obj.appPort !== "number" ||
+      !Number.isInteger(obj.appPort) ||
+      obj.appPort < 1 ||
+      obj.appPort > 65535
+    ) {
+      console.error(
+        colors.red(
+          `Error: "${prefix}.appPort" in ${configPath} must be an integer between 1 and 65535.`
+        )
+      );
+      process.exit(1);
+    }
+  }
+}

--- a/packages/portless/src/routes.ts
+++ b/packages/portless/src/routes.ts
@@ -2,7 +2,6 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { RouteInfo } from "./types.js";
 import { fixOwnership, isErrnoException } from "./utils.js";
-import { SYSTEM_STATE_DIR } from "./cli-utils.js";
 
 /** How long (ms) before a lock directory is considered stale and forcibly removed. */
 const STALE_LOCK_THRESHOLD_MS = 10_000;
@@ -19,14 +18,8 @@ const LOCK_RETRY_CAP_MS = 500;
 /** File permission mode for route and state files. */
 export const FILE_MODE = 0o644;
 
-/** Directory permission mode for the user state directory. */
+/** Directory permission mode for the state directory. */
 export const DIR_MODE = 0o755;
-
-/** Directory permission mode for the system state directory (world-writable with sticky bit). */
-export const SYSTEM_DIR_MODE = 0o1777;
-
-/** File permission mode for shared state files in the system state directory. */
-export const SYSTEM_FILE_MODE = 0o666;
 
 export interface RouteMapping extends RouteInfo {
   pid: number;
@@ -84,26 +77,14 @@ export class RouteStore {
     this.onWarning = options?.onWarning;
   }
 
-  private isSystemDir(): boolean {
-    return this.dir === SYSTEM_STATE_DIR;
-  }
-
-  private get dirMode(): number {
-    return this.isSystemDir() ? SYSTEM_DIR_MODE : DIR_MODE;
-  }
-
-  private get fileMode(): number {
-    return this.isSystemDir() ? SYSTEM_FILE_MODE : FILE_MODE;
-  }
-
   ensureDir(): void {
     if (!fs.existsSync(this.dir)) {
-      fs.mkdirSync(this.dir, { recursive: true, mode: this.dirMode });
+      fs.mkdirSync(this.dir, { recursive: true, mode: DIR_MODE });
     }
     try {
-      fs.chmodSync(this.dir, this.dirMode);
+      fs.chmodSync(this.dir, DIR_MODE);
     } catch {
-      // May fail if directory is owned by another user (e.g. root); non-fatal
+      // May fail if directory is owned by another user; non-fatal
     }
     fixOwnership(this.dir);
   }
@@ -202,7 +183,7 @@ export class RouteStore {
         // Only safe when caller holds the lock.
         try {
           fs.writeFileSync(this.routesPath, JSON.stringify(alive, null, 2), {
-            mode: this.fileMode,
+            mode: FILE_MODE,
           });
         } catch {
           // Write may fail (permissions); non-fatal
@@ -215,7 +196,7 @@ export class RouteStore {
   }
 
   private saveRoutes(routes: RouteMapping[]): void {
-    fs.writeFileSync(this.routesPath, JSON.stringify(routes, null, 2), { mode: this.fileMode });
+    fs.writeFileSync(this.routesPath, JSON.stringify(routes, null, 2), { mode: FILE_MODE });
     fixOwnership(this.routesPath);
   }
 

--- a/packages/portless/src/turbo.test.ts
+++ b/packages/portless/src/turbo.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import {
+  ensureEnvLoader,
+  writeManifest,
+  removeManifest,
+  buildNodeOptions,
+  hasTurboConfig,
+  loaderPath,
+  manifestPath,
+  loaderSource,
+} from "./turbo.js";
+
+function createTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "portless-turbo-test-"));
+}
+
+function cleanupDir(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+describe("hasTurboConfig", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    cleanupDir(tmpDir);
+  });
+
+  it("returns true when turbo.json exists", () => {
+    fs.writeFileSync(path.join(tmpDir, "turbo.json"), "{}");
+    expect(hasTurboConfig(tmpDir)).toBe(true);
+  });
+
+  it("returns false when turbo.json is missing", () => {
+    expect(hasTurboConfig(tmpDir)).toBe(false);
+  });
+});
+
+describe("ensureEnvLoader", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    cleanupDir(tmpDir);
+  });
+
+  it("creates the loader file", () => {
+    ensureEnvLoader(tmpDir);
+    const target = loaderPath(tmpDir);
+    expect(fs.existsSync(target)).toBe(true);
+    const content = fs.readFileSync(target, "utf-8");
+    expect(content).toContain("dev-manifest.json");
+    expect(content).toContain("process.env");
+  });
+
+  it("is idempotent", () => {
+    ensureEnvLoader(tmpDir);
+    const first = fs.readFileSync(loaderPath(tmpDir), "utf-8");
+    ensureEnvLoader(tmpDir);
+    const second = fs.readFileSync(loaderPath(tmpDir), "utf-8");
+    expect(first).toBe(second);
+  });
+
+  it("updates the loader if source changes", () => {
+    const target = loaderPath(tmpDir);
+    fs.writeFileSync(target, "old content");
+    ensureEnvLoader(tmpDir);
+    const content = fs.readFileSync(target, "utf-8");
+    expect(content).toBe(loaderSource(tmpDir));
+  });
+});
+
+describe("writeManifest / removeManifest", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    cleanupDir(tmpDir);
+  });
+
+  it("writes and reads manifest JSON", () => {
+    const entries = {
+      "/path/to/app": {
+        PORT: "3001",
+        HOST: "127.0.0.1",
+        PORTLESS_URL: "https://app.project.local",
+      },
+    };
+    writeManifest(entries, tmpDir);
+    const raw = fs.readFileSync(manifestPath(tmpDir), "utf-8");
+    expect(JSON.parse(raw)).toEqual(entries);
+  });
+
+  it("includes NODE_EXTRA_CA_CERTS when provided", () => {
+    const entries = {
+      "/path/to/app": {
+        PORT: "3001",
+        HOST: "127.0.0.1",
+        PORTLESS_URL: "https://app.project.local",
+        NODE_EXTRA_CA_CERTS: "/home/user/.portless/ca.pem",
+      },
+    };
+    writeManifest(entries, tmpDir);
+    const raw = fs.readFileSync(manifestPath(tmpDir), "utf-8");
+    expect(JSON.parse(raw)["/path/to/app"].NODE_EXTRA_CA_CERTS).toBe("/home/user/.portless/ca.pem");
+  });
+
+  it("removeManifest deletes the file", () => {
+    writeManifest({}, tmpDir);
+    expect(fs.existsSync(manifestPath(tmpDir))).toBe(true);
+    removeManifest(tmpDir);
+    expect(fs.existsSync(manifestPath(tmpDir))).toBe(false);
+  });
+
+  it("removeManifest is safe when file does not exist", () => {
+    expect(() => removeManifest(tmpDir)).not.toThrow();
+  });
+});
+
+describe("buildNodeOptions", () => {
+  let tmpDir: string;
+  const originalNodeOptions = process.env.NODE_OPTIONS;
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    cleanupDir(tmpDir);
+    if (originalNodeOptions !== undefined) {
+      process.env.NODE_OPTIONS = originalNodeOptions;
+    } else {
+      delete process.env.NODE_OPTIONS;
+    }
+  });
+
+  it("sets --require when NODE_OPTIONS is empty", () => {
+    delete process.env.NODE_OPTIONS;
+    const result = buildNodeOptions(tmpDir);
+    expect(result).toBe(`--require ${loaderPath(tmpDir)}`);
+  });
+
+  it("prepends --require to existing NODE_OPTIONS", () => {
+    process.env.NODE_OPTIONS = "--max-old-space-size=4096";
+    const result = buildNodeOptions(tmpDir);
+    expect(result).toBe(`--require ${loaderPath(tmpDir)} --max-old-space-size=4096`);
+  });
+});
+
+describe("loaderSource", () => {
+  it("references the correct manifest path", () => {
+    const source = loaderSource("/custom/base");
+    expect(source).toContain("/custom/base");
+    expect(source).toContain("dev-manifest.json");
+  });
+
+  it("escapes backslashes for Windows paths", () => {
+    const source = loaderSource("C:\\Users\\test\\.portless");
+    expect(source).not.toContain("C:\\Users\\test\\.portless");
+    expect(source).toContain("dev-manifest.json");
+  });
+});

--- a/packages/portless/src/turbo.test.ts
+++ b/packages/portless/src/turbo.test.ts
@@ -157,6 +157,14 @@ describe("buildNodeOptions", () => {
     const result = buildNodeOptions(tmpDir);
     expect(result).toBe(`--require ${loaderPath(tmpDir)} --max-old-space-size=4096`);
   });
+
+  it("quotes the loader path when it contains spaces", () => {
+    delete process.env.NODE_OPTIONS;
+    const spacedDir = path.join(tmpDir, "path with spaces");
+    fs.mkdirSync(spacedDir, { recursive: true });
+    const result = buildNodeOptions(spacedDir);
+    expect(result).toBe(`--require "${loaderPath(spacedDir)}"`);
+  });
 });
 
 describe("loaderSource", () => {
@@ -168,7 +176,10 @@ describe("loaderSource", () => {
 
   it("escapes backslashes for Windows paths", () => {
     const source = loaderSource("C:\\Users\\test\\.portless");
-    expect(source).not.toContain("C:\\Users\\test\\.portless");
     expect(source).toContain("dev-manifest.json");
+    // JSON.stringify produces doubled backslashes in the JS source text.
+    // Verify exactly doubled (not quadrupled from a redundant manual escape).
+    expect(source).toContain("C:\\\\Users\\\\test\\\\.portless");
+    expect(source).not.toContain("C:\\\\\\\\Users");
   });
 });

--- a/packages/portless/src/turbo.ts
+++ b/packages/portless/src/turbo.ts
@@ -1,0 +1,102 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { USER_STATE_DIR } from "./cli-utils.js";
+
+export const LOADER_FILENAME = "turbo-env-loader.cjs";
+export const MANIFEST_FILENAME = "dev-manifest.json";
+
+export function loaderPath(baseDir: string = USER_STATE_DIR): string {
+  return path.join(baseDir, LOADER_FILENAME);
+}
+
+export function manifestPath(baseDir: string = USER_STATE_DIR): string {
+  return path.join(baseDir, MANIFEST_FILENAME);
+}
+
+/**
+ * Generate the CJS loader script source. The manifest path is resolved
+ * relative to the given base directory at runtime.
+ */
+export function loaderSource(baseDir: string = USER_STATE_DIR): string {
+  const escaped = baseDir.replace(/\\/g, "\\\\");
+  return `"use strict";
+var fs = require("fs");
+var path = require("path");
+var manifestPath = path.join(${JSON.stringify(escaped)}, "dev-manifest.json");
+try {
+  var raw = fs.readFileSync(manifestPath, "utf-8");
+  var manifest = JSON.parse(raw);
+  var cwd = process.cwd();
+  var entry = manifest[cwd];
+  if (entry && typeof entry === "object") {
+    var keys = Object.keys(entry);
+    for (var i = 0; i < keys.length; i++) {
+      process.env[keys[i]] = entry[keys[i]];
+    }
+  }
+} catch (_) {}
+`;
+}
+
+/** Ensure the loader script exists. */
+export function ensureEnvLoader(baseDir: string = USER_STATE_DIR): void {
+  fs.mkdirSync(baseDir, { recursive: true, mode: 0o755 });
+  const target = loaderPath(baseDir);
+  const source = loaderSource(baseDir);
+
+  try {
+    const existing = fs.readFileSync(target, "utf-8");
+    if (existing === source) return;
+  } catch {
+    // doesn't exist yet
+  }
+  fs.writeFileSync(target, source, { mode: 0o644 });
+}
+
+export interface ManifestEntry {
+  PORT: string;
+  HOST: string;
+  PORTLESS_URL: string;
+  NODE_EXTRA_CA_CERTS?: string;
+}
+
+/**
+ * Write the dev-manifest.json mapping package directories to env vars.
+ * Keys are absolute paths to package directories.
+ */
+export function writeManifest(
+  entries: Record<string, ManifestEntry>,
+  baseDir: string = USER_STATE_DIR
+): void {
+  fs.mkdirSync(baseDir, { recursive: true, mode: 0o755 });
+  fs.writeFileSync(manifestPath(baseDir), JSON.stringify(entries, null, 2) + "\n", { mode: 0o644 });
+}
+
+/** Remove the dev-manifest.json file. */
+export function removeManifest(baseDir: string = USER_STATE_DIR): void {
+  try {
+    fs.unlinkSync(manifestPath(baseDir));
+  } catch {
+    // already gone
+  }
+}
+
+/**
+ * Build the NODE_OPTIONS value with the --require loader prepended.
+ * Preserves any existing NODE_OPTIONS value.
+ */
+export function buildNodeOptions(baseDir: string = USER_STATE_DIR): string {
+  const existing = process.env.NODE_OPTIONS || "";
+  const requireFlag = `--require ${loaderPath(baseDir)}`;
+  return existing ? `${requireFlag} ${existing}` : requireFlag;
+}
+
+/** Check whether turbo.json exists at the given workspace root. */
+export function hasTurboConfig(wsRoot: string): boolean {
+  try {
+    fs.accessSync(path.join(wsRoot, "turbo.json"), fs.constants.R_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/portless/src/turbo.ts
+++ b/packages/portless/src/turbo.ts
@@ -18,11 +18,10 @@ export function manifestPath(baseDir: string = USER_STATE_DIR): string {
  * relative to the given base directory at runtime.
  */
 export function loaderSource(baseDir: string = USER_STATE_DIR): string {
-  const escaped = baseDir.replace(/\\/g, "\\\\");
   return `"use strict";
 var fs = require("fs");
 var path = require("path");
-var manifestPath = path.join(${JSON.stringify(escaped)}, "dev-manifest.json");
+var manifestPath = path.join(${JSON.stringify(baseDir)}, "dev-manifest.json");
 try {
   var raw = fs.readFileSync(manifestPath, "utf-8");
   var manifest = JSON.parse(raw);
@@ -87,7 +86,8 @@ export function removeManifest(baseDir: string = USER_STATE_DIR): void {
  */
 export function buildNodeOptions(baseDir: string = USER_STATE_DIR): string {
   const existing = process.env.NODE_OPTIONS || "";
-  const requireFlag = `--require ${loaderPath(baseDir)}`;
+  const lp = loaderPath(baseDir);
+  const requireFlag = lp.includes(" ") ? `--require "${lp}"` : `--require ${lp}`;
   return existing ? `${requireFlag} ${existing}` : requireFlag;
 }
 

--- a/packages/portless/src/utils.ts
+++ b/packages/portless/src/utils.ts
@@ -12,6 +12,8 @@ export function fixOwnership(...paths: string[]): void {
   if (!uid || process.getuid?.() !== 0) return;
   for (const p of paths) {
     try {
+      const stat = fs.lstatSync(p);
+      if (stat.isSymbolicLink()) continue;
       fs.chownSync(p, parseInt(uid, 10), parseInt(gid || uid, 10));
     } catch {
       // Best-effort

--- a/packages/portless/src/workspace.test.ts
+++ b/packages/portless/src/workspace.test.ts
@@ -78,6 +78,20 @@ catalog:
 `;
     expect(parsePnpmWorkspaceYaml(content)).toEqual(["apps/*", "packages/*"]);
   });
+
+  it("parses flow sequence on same line", () => {
+    expect(parsePnpmWorkspaceYaml("packages: [apps/*, packages/*]")).toEqual([
+      "apps/*",
+      "packages/*",
+    ]);
+  });
+
+  it("parses flow sequence with quotes", () => {
+    expect(parsePnpmWorkspaceYaml(`packages: ['apps/*', "packages/*"]`)).toEqual([
+      "apps/*",
+      "packages/*",
+    ]);
+  });
 });
 
 describe("expandPackageGlobs", () => {
@@ -127,6 +141,40 @@ describe("expandPackageGlobs", () => {
     const result = expandPackageGlobs(tmpDir, ["packages/**"]);
     expect(result).toHaveLength(1);
     expect(result).toContain(path.join(tmpDir, "packages", "shared"));
+  });
+
+  it("handles mid-path wildcard (packages/*/src)", () => {
+    const sharedSrc = path.join(tmpDir, "packages", "shared", "src");
+    const utilsSrc = path.join(tmpDir, "packages", "utils", "src");
+    fs.mkdirSync(sharedSrc, { recursive: true });
+    fs.mkdirSync(utilsSrc, { recursive: true });
+    // A package without src should not match
+    fs.mkdirSync(path.join(tmpDir, "packages", "no-src"), { recursive: true });
+
+    const result = expandPackageGlobs(tmpDir, ["packages/*/src"]);
+    expect(result).toHaveLength(2);
+    expect(result).toContain(sharedSrc);
+    expect(result).toContain(utilsSrc);
+  });
+
+  it("handles prefix wildcard (apps/team-*)", () => {
+    fs.mkdirSync(path.join(tmpDir, "apps", "team-alpha"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, "apps", "team-beta"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, "apps", "other"), { recursive: true });
+
+    const result = expandPackageGlobs(tmpDir, ["apps/team-*"]);
+    expect(result).toHaveLength(2);
+    expect(result).toContain(path.join(tmpDir, "apps", "team-alpha"));
+    expect(result).toContain(path.join(tmpDir, "apps", "team-beta"));
+  });
+
+  it("does not crash on prefix wildcard with trailing segments", () => {
+    fs.mkdirSync(path.join(tmpDir, "apps", "team-alpha", "sub"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, "apps", "team-beta"), { recursive: true });
+
+    const result = expandPackageGlobs(tmpDir, ["apps/team-*/sub"]);
+    expect(result).toHaveLength(1);
+    expect(result).toContain(path.join(tmpDir, "apps", "team-alpha", "sub"));
   });
 });
 

--- a/packages/portless/src/workspace.test.ts
+++ b/packages/portless/src/workspace.test.ts
@@ -7,6 +7,7 @@ import {
   discoverWorkspacePackages,
   parsePnpmWorkspaceYaml,
   expandPackageGlobs,
+  readWorkspacesFromPackageJson,
 } from "./workspace.js";
 
 function createTmpDir(): string {
@@ -129,6 +130,51 @@ describe("expandPackageGlobs", () => {
   });
 });
 
+describe("readWorkspacesFromPackageJson", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    cleanupDir(tmpDir);
+  });
+
+  it("reads array-form workspaces", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ workspaces: ["apps/*", "packages/*"] })
+    );
+    expect(readWorkspacesFromPackageJson(tmpDir)).toEqual(["apps/*", "packages/*"]);
+  });
+
+  it("reads yarn-classic object form", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ workspaces: { packages: ["apps/*", "packages/*"] } })
+    );
+    expect(readWorkspacesFromPackageJson(tmpDir)).toEqual(["apps/*", "packages/*"]);
+  });
+
+  it("returns null when no workspaces field", () => {
+    fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ name: "test" }));
+    expect(readWorkspacesFromPackageJson(tmpDir)).toBeNull();
+  });
+
+  it("returns null when no package.json", () => {
+    expect(readWorkspacesFromPackageJson(tmpDir)).toBeNull();
+  });
+
+  it("filters non-string entries", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ workspaces: ["apps/*", 42, null, "packages/*"] })
+    );
+    expect(readWorkspacesFromPackageJson(tmpDir)).toEqual(["apps/*", "packages/*"]);
+  });
+});
+
 describe("findWorkspaceRoot", () => {
   let tmpDir: string;
 
@@ -152,7 +198,33 @@ describe("findWorkspaceRoot", () => {
     expect(findWorkspaceRoot(subDir)).toBe(tmpDir);
   });
 
-  it("returns null when no pnpm-workspace.yaml exists", () => {
+  it("returns null when no workspace root exists", () => {
+    expect(findWorkspaceRoot(tmpDir)).toBeNull();
+  });
+
+  it("finds package.json workspaces in cwd", () => {
+    fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ workspaces: ["apps/*"] }));
+    expect(findWorkspaceRoot(tmpDir)).toBe(tmpDir);
+  });
+
+  it("walks up to find package.json workspaces", () => {
+    fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ workspaces: ["apps/*"] }));
+    const subDir = path.join(tmpDir, "apps", "web");
+    fs.mkdirSync(subDir, { recursive: true });
+    expect(findWorkspaceRoot(subDir)).toBe(tmpDir);
+  });
+
+  it("prefers pnpm-workspace.yaml over package.json workspaces", () => {
+    fs.writeFileSync(path.join(tmpDir, "pnpm-workspace.yaml"), "packages:\n  - pnpm-apps/*\n");
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ workspaces: ["npm-apps/*"] })
+    );
+    expect(findWorkspaceRoot(tmpDir)).toBe(tmpDir);
+  });
+
+  it("ignores package.json without workspaces field", () => {
+    fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ name: "test" }));
     expect(findWorkspaceRoot(tmpDir)).toBeNull();
   });
 });
@@ -253,7 +325,67 @@ describe("discoverWorkspacePackages", () => {
     expect(names).toEqual(["api", "shared", "web"]);
   });
 
-  it("returns empty when pnpm-workspace.yaml is missing", () => {
+  it("returns empty when no workspace config exists", () => {
     expect(discoverWorkspacePackages(tmpDir)).toEqual([]);
+  });
+
+  it("discovers packages from package.json workspaces (npm/yarn/bun)", () => {
+    fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ workspaces: ["apps/*"] }));
+    const webDir = path.join(tmpDir, "apps", "web");
+    fs.mkdirSync(webDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(webDir, "package.json"),
+      JSON.stringify({ name: "@myorg/web", scripts: { dev: "next dev" } })
+    );
+
+    const packages = discoverWorkspacePackages(tmpDir);
+    expect(packages).toHaveLength(1);
+    expect(packages[0].name).toBe("web");
+    expect(packages[0].scope).toBe("myorg");
+    expect(packages[0].dir).toBe(webDir);
+  });
+
+  it("discovers packages from yarn-classic object workspaces", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ workspaces: { packages: ["apps/*", "packages/*"] } })
+    );
+    for (const dir of ["apps/web", "packages/shared"]) {
+      const full = path.join(tmpDir, dir);
+      fs.mkdirSync(full, { recursive: true });
+      fs.writeFileSync(
+        path.join(full, "package.json"),
+        JSON.stringify({ name: path.basename(dir), scripts: { dev: "echo dev" } })
+      );
+    }
+
+    const packages = discoverWorkspacePackages(tmpDir);
+    expect(packages).toHaveLength(2);
+    const names = packages.map((p) => p.name).sort();
+    expect(names).toEqual(["shared", "web"]);
+  });
+
+  it("prefers pnpm-workspace.yaml over package.json workspaces", () => {
+    fs.writeFileSync(path.join(tmpDir, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n");
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ workspaces: ["packages/*"] })
+    );
+    const webDir = path.join(tmpDir, "apps", "web");
+    fs.mkdirSync(webDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(webDir, "package.json"),
+      JSON.stringify({ name: "web", scripts: { dev: "echo dev" } })
+    );
+    const sharedDir = path.join(tmpDir, "packages", "shared");
+    fs.mkdirSync(sharedDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(sharedDir, "package.json"),
+      JSON.stringify({ name: "shared", scripts: { dev: "echo dev" } })
+    );
+
+    const packages = discoverWorkspacePackages(tmpDir);
+    expect(packages).toHaveLength(1);
+    expect(packages[0].name).toBe("web");
   });
 });

--- a/packages/portless/src/workspace.test.ts
+++ b/packages/portless/src/workspace.test.ts
@@ -180,11 +180,12 @@ describe("discoverWorkspacePackages", () => {
     const packages = discoverWorkspacePackages(tmpDir);
     expect(packages).toHaveLength(1);
     expect(packages[0].name).toBe("web");
+    expect(packages[0].scope).toBe("myorg");
     expect(packages[0].scripts.dev).toBe("next dev");
     expect(packages[0].dir).toBe(webDir);
   });
 
-  it("strips @scope/ from package names", () => {
+  it("strips @scope/ from package names and preserves scope", () => {
     fs.writeFileSync(path.join(tmpDir, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n");
     const webDir = path.join(tmpDir, "apps", "web");
     fs.mkdirSync(webDir, { recursive: true });
@@ -195,6 +196,7 @@ describe("discoverWorkspacePackages", () => {
 
     const packages = discoverWorkspacePackages(tmpDir);
     expect(packages[0].name).toBe("web-app");
+    expect(packages[0].scope).toBe("company");
   });
 
   it("handles packages without a name field", () => {
@@ -208,6 +210,18 @@ describe("discoverWorkspacePackages", () => {
 
     const packages = discoverWorkspacePackages(tmpDir);
     expect(packages[0].name).toBeNull();
+    expect(packages[0].scope).toBeNull();
+  });
+
+  it("handles unscoped package names", () => {
+    fs.writeFileSync(path.join(tmpDir, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n");
+    const webDir = path.join(tmpDir, "apps", "web");
+    fs.mkdirSync(webDir, { recursive: true });
+    fs.writeFileSync(path.join(webDir, "package.json"), JSON.stringify({ name: "my-app" }));
+
+    const packages = discoverWorkspacePackages(tmpDir);
+    expect(packages[0].name).toBe("my-app");
+    expect(packages[0].scope).toBeNull();
   });
 
   it("skips directories without package.json", () => {

--- a/packages/portless/src/workspace.test.ts
+++ b/packages/portless/src/workspace.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import {
+  findWorkspaceRoot,
+  discoverWorkspacePackages,
+  parsePnpmWorkspaceYaml,
+  expandPackageGlobs,
+} from "./workspace.js";
+
+function createTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "portless-ws-test-"));
+}
+
+function cleanupDir(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+describe("parsePnpmWorkspaceYaml", () => {
+  it("parses basic packages list", () => {
+    const content = `packages:
+  - apps/*
+  - packages/*
+`;
+    expect(parsePnpmWorkspaceYaml(content)).toEqual(["apps/*", "packages/*"]);
+  });
+
+  it("handles comments and blank lines", () => {
+    const content = `packages:
+  # Apps directory
+  - apps/*
+
+  # Packages directory
+  - packages/*
+`;
+    expect(parsePnpmWorkspaceYaml(content)).toEqual(["apps/*", "packages/*"]);
+  });
+
+  it("handles quoted values", () => {
+    const content = `packages:
+  - 'apps/*'
+  - "packages/*"
+`;
+    expect(parsePnpmWorkspaceYaml(content)).toEqual(["apps/*", "packages/*"]);
+  });
+
+  it("returns empty array when no packages key", () => {
+    expect(parsePnpmWorkspaceYaml("version: 1")).toEqual([]);
+  });
+
+  it("returns empty array for empty content", () => {
+    expect(parsePnpmWorkspaceYaml("")).toEqual([]);
+  });
+
+  it("stops at next top-level key", () => {
+    const content = `packages:
+  - apps/*
+catalog:
+  react: 19
+`;
+    expect(parsePnpmWorkspaceYaml(content)).toEqual(["apps/*"]);
+  });
+
+  it("handles negation patterns", () => {
+    const content = `packages:
+  - apps/*
+  - '!apps/legacy'
+`;
+    expect(parsePnpmWorkspaceYaml(content)).toEqual(["apps/*", "!apps/legacy"]);
+  });
+
+  it("handles inline comments", () => {
+    const content = `packages:
+  - apps/* # the apps
+  - packages/*
+`;
+    expect(parsePnpmWorkspaceYaml(content)).toEqual(["apps/*", "packages/*"]);
+  });
+});
+
+describe("expandPackageGlobs", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    cleanupDir(tmpDir);
+  });
+
+  it("expands wildcard globs to directories", () => {
+    fs.mkdirSync(path.join(tmpDir, "apps", "web"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, "apps", "api"), { recursive: true });
+    // Create a file to ensure it's filtered out
+    fs.writeFileSync(path.join(tmpDir, "apps", "README.md"), "");
+
+    const result = expandPackageGlobs(tmpDir, ["apps/*"]);
+    expect(result).toHaveLength(2);
+    expect(result).toContain(path.join(tmpDir, "apps", "api"));
+    expect(result).toContain(path.join(tmpDir, "apps", "web"));
+  });
+
+  it("handles literal directory paths", () => {
+    fs.mkdirSync(path.join(tmpDir, "tools"), { recursive: true });
+    const result = expandPackageGlobs(tmpDir, ["tools"]);
+    expect(result).toEqual([path.join(tmpDir, "tools")]);
+  });
+
+  it("handles negation patterns", () => {
+    fs.mkdirSync(path.join(tmpDir, "apps", "web"), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, "apps", "legacy"), { recursive: true });
+
+    const result = expandPackageGlobs(tmpDir, ["apps/*", "!apps/legacy"]);
+    expect(result).toHaveLength(1);
+    expect(result).toContain(path.join(tmpDir, "apps", "web"));
+  });
+
+  it("returns empty for non-existent base directory", () => {
+    expect(expandPackageGlobs(tmpDir, ["nonexistent/*"])).toEqual([]);
+  });
+
+  it("handles double-star globs same as single star", () => {
+    fs.mkdirSync(path.join(tmpDir, "packages", "shared"), { recursive: true });
+    const result = expandPackageGlobs(tmpDir, ["packages/**"]);
+    expect(result).toHaveLength(1);
+    expect(result).toContain(path.join(tmpDir, "packages", "shared"));
+  });
+});
+
+describe("findWorkspaceRoot", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    cleanupDir(tmpDir);
+  });
+
+  it("finds pnpm-workspace.yaml in cwd", () => {
+    fs.writeFileSync(path.join(tmpDir, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n");
+    expect(findWorkspaceRoot(tmpDir)).toBe(tmpDir);
+  });
+
+  it("walks up to find pnpm-workspace.yaml", () => {
+    fs.writeFileSync(path.join(tmpDir, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n");
+    const subDir = path.join(tmpDir, "apps", "web", "src");
+    fs.mkdirSync(subDir, { recursive: true });
+    expect(findWorkspaceRoot(subDir)).toBe(tmpDir);
+  });
+
+  it("returns null when no pnpm-workspace.yaml exists", () => {
+    expect(findWorkspaceRoot(tmpDir)).toBeNull();
+  });
+});
+
+describe("discoverWorkspacePackages", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = createTmpDir();
+  });
+
+  afterEach(() => {
+    cleanupDir(tmpDir);
+  });
+
+  it("discovers packages with package.json", () => {
+    fs.writeFileSync(path.join(tmpDir, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n");
+    const webDir = path.join(tmpDir, "apps", "web");
+    fs.mkdirSync(webDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(webDir, "package.json"),
+      JSON.stringify({ name: "@myorg/web", scripts: { dev: "next dev" } })
+    );
+
+    const packages = discoverWorkspacePackages(tmpDir);
+    expect(packages).toHaveLength(1);
+    expect(packages[0].name).toBe("web");
+    expect(packages[0].scripts.dev).toBe("next dev");
+    expect(packages[0].dir).toBe(webDir);
+  });
+
+  it("strips @scope/ from package names", () => {
+    fs.writeFileSync(path.join(tmpDir, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n");
+    const webDir = path.join(tmpDir, "apps", "web");
+    fs.mkdirSync(webDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(webDir, "package.json"),
+      JSON.stringify({ name: "@company/web-app" })
+    );
+
+    const packages = discoverWorkspacePackages(tmpDir);
+    expect(packages[0].name).toBe("web-app");
+  });
+
+  it("handles packages without a name field", () => {
+    fs.writeFileSync(path.join(tmpDir, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n");
+    const webDir = path.join(tmpDir, "apps", "web");
+    fs.mkdirSync(webDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(webDir, "package.json"),
+      JSON.stringify({ scripts: { dev: "next dev" } })
+    );
+
+    const packages = discoverWorkspacePackages(tmpDir);
+    expect(packages[0].name).toBeNull();
+  });
+
+  it("skips directories without package.json", () => {
+    fs.writeFileSync(path.join(tmpDir, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n");
+    fs.mkdirSync(path.join(tmpDir, "apps", "empty"), { recursive: true });
+
+    const packages = discoverWorkspacePackages(tmpDir);
+    expect(packages).toHaveLength(0);
+  });
+
+  it("discovers multiple packages from multiple globs", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "pnpm-workspace.yaml"),
+      "packages:\n  - apps/*\n  - packages/*\n"
+    );
+
+    for (const dir of ["apps/web", "apps/api", "packages/shared"]) {
+      const full = path.join(tmpDir, dir);
+      fs.mkdirSync(full, { recursive: true });
+      fs.writeFileSync(
+        path.join(full, "package.json"),
+        JSON.stringify({ name: path.basename(dir), scripts: { dev: "echo dev" } })
+      );
+    }
+
+    const packages = discoverWorkspacePackages(tmpDir);
+    expect(packages).toHaveLength(3);
+    const names = packages.map((p) => p.name).sort();
+    expect(names).toEqual(["api", "shared", "web"]);
+  });
+
+  it("returns empty when pnpm-workspace.yaml is missing", () => {
+    expect(discoverWorkspacePackages(tmpDir)).toEqual([]);
+  });
+});

--- a/packages/portless/src/workspace.ts
+++ b/packages/portless/src/workspace.ts
@@ -10,20 +10,28 @@ export interface WorkspacePackage {
   scripts: Record<string, string>;
 }
 
+export type WorkspaceSource = "pnpm" | "package-json";
+
 /**
- * Walk up from `cwd` looking for pnpm-workspace.yaml.
- * Returns the directory containing it, or null.
+ * Walk up from `cwd` looking for a workspace root.
+ * Checks `pnpm-workspace.yaml` first, then `package.json` with a
+ * `"workspaces"` field (npm, yarn, bun). Returns the directory and
+ * the source type, or null if no workspace root is found.
  */
 export function findWorkspaceRoot(cwd: string = process.cwd()): string | null {
   let dir = cwd;
   for (;;) {
-    const wsPath = path.join(dir, "pnpm-workspace.yaml");
     try {
-      fs.accessSync(wsPath, fs.constants.R_OK);
+      fs.accessSync(path.join(dir, "pnpm-workspace.yaml"), fs.constants.R_OK);
       return dir;
     } catch {
       // not here
     }
+
+    if (readWorkspacesFromPackageJson(dir) !== null) {
+      return dir;
+    }
+
     const parent = path.dirname(dir);
     if (parent === dir) return null;
     dir = parent;
@@ -31,19 +39,70 @@ export function findWorkspaceRoot(cwd: string = process.cwd()): string | null {
 }
 
 /**
- * Discover all workspace packages from pnpm-workspace.yaml at `workspaceRoot`.
+ * Determine the workspace source at a given root directory.
+ * Prefers pnpm-workspace.yaml over package.json workspaces.
+ */
+function detectWorkspaceSource(workspaceRoot: string): WorkspaceSource | null {
+  try {
+    fs.accessSync(path.join(workspaceRoot, "pnpm-workspace.yaml"), fs.constants.R_OK);
+    return "pnpm";
+  } catch {
+    // not pnpm
+  }
+  if (readWorkspacesFromPackageJson(workspaceRoot) !== null) {
+    return "package-json";
+  }
+  return null;
+}
+
+/**
+ * Read the `"workspaces"` field from package.json in `dir`.
+ * Supports both array form (`["apps/*"]`) and yarn-classic object
+ * form (`{ "packages": ["apps/*"] }`). Returns null if not found.
+ */
+export function readWorkspacesFromPackageJson(dir: string): string[] | null {
+  const pkgPath = path.join(dir, "package.json");
+  try {
+    const raw = fs.readFileSync(pkgPath, "utf-8");
+    const pkg = JSON.parse(raw);
+    if (!pkg || typeof pkg !== "object") return null;
+    const ws = pkg.workspaces;
+    if (Array.isArray(ws)) {
+      return ws.filter((g: unknown) => typeof g === "string");
+    }
+    if (ws && typeof ws === "object" && !Array.isArray(ws) && Array.isArray(ws.packages)) {
+      return ws.packages.filter((g: unknown) => typeof g === "string");
+    }
+  } catch {
+    // missing or unparseable
+  }
+  return null;
+}
+
+/**
+ * Discover all workspace packages at `workspaceRoot`.
+ * Supports pnpm (pnpm-workspace.yaml) and npm/yarn/bun (package.json workspaces).
  * Returns packages that have a package.json (ignoring dirs without one).
  */
 export function discoverWorkspacePackages(workspaceRoot: string): WorkspacePackage[] {
-  const wsPath = path.join(workspaceRoot, "pnpm-workspace.yaml");
-  let content: string;
-  try {
-    content = fs.readFileSync(wsPath, "utf-8");
-  } catch {
+  const source = detectWorkspaceSource(workspaceRoot);
+  let globs: string[];
+
+  if (source === "pnpm") {
+    const wsPath = path.join(workspaceRoot, "pnpm-workspace.yaml");
+    let content: string;
+    try {
+      content = fs.readFileSync(wsPath, "utf-8");
+    } catch {
+      return [];
+    }
+    globs = parsePnpmWorkspaceYaml(content);
+  } else if (source === "package-json") {
+    globs = readWorkspacesFromPackageJson(workspaceRoot) ?? [];
+  } else {
     return [];
   }
 
-  const globs = parsePnpmWorkspaceYaml(content);
   const dirs = expandPackageGlobs(workspaceRoot, globs);
   const packages: WorkspacePackage[] = [];
 

--- a/packages/portless/src/workspace.ts
+++ b/packages/portless/src/workspace.ts
@@ -127,8 +127,14 @@ export function discoverWorkspacePackages(workspaceRoot: string): WorkspacePacka
 
 /**
  * Parse the `packages:` list from pnpm-workspace.yaml content.
- * Handles the simple format (flat list of `- <glob>` lines under `packages:`).
- * No YAML library needed.
+ *
+ * Supports the two common forms:
+ *   - Block list: `packages:\n  - glob\n  - glob`
+ *   - Flow sequence: `packages: [glob, glob]`
+ *
+ * This is an intentionally minimal parser covering the subset of YAML
+ * used by pnpm workspaces. It does not handle anchors, aliases, multi-line
+ * flow sequences, or nested structures.
  */
 export function parsePnpmWorkspaceYaml(content: string): string[] {
   const lines = content.split("\n");
@@ -138,7 +144,12 @@ export function parsePnpmWorkspaceYaml(content: string): string[] {
   for (const rawLine of lines) {
     const line = rawLine.trimEnd();
 
-    if (/^packages\s*:/.test(line)) {
+    const headerMatch = line.match(/^packages\s*:(.*)/);
+    if (headerMatch) {
+      const rest = headerMatch[1].trim();
+      if (rest.startsWith("[")) {
+        return parseFlowSequence(rest);
+      }
       inPackages = true;
       continue;
     }
@@ -168,11 +179,27 @@ export function parsePnpmWorkspaceYaml(content: string): string[] {
   return globs;
 }
 
+/** Parse a YAML flow sequence like `[apps/*, packages/*]`. */
+function parseFlowSequence(input: string): string[] {
+  const inner = input.replace(/^\[/, "").replace(/]\s*$/, "");
+  return inner
+    .split(",")
+    .map((s) => s.trim().replace(/^['"]/, "").replace(/['"]$/, "").trim())
+    .filter(Boolean);
+}
+
 /**
- * Expand workspace globs to actual directories. Supports:
- * - `dir/*` (single-level wildcard, most common)
- * - `dir` (literal directory)
- * - Negation patterns (`!dir`) are used to filter out matches.
+ * Expand workspace globs to actual directories.
+ *
+ * Supported patterns:
+ *   dir/\*  or  dir/\*\*   single-level wildcard
+ *   dir/\*\/sub             mid-path wildcard
+ *   dir/prefix-\*           prefix wildcard within a segment
+ *   dir                     literal directory
+ *   !dir                    negation (filters out matches)
+ *
+ * Only star wildcards within a single path segment are supported.
+ * Regex, question marks, and character classes are not handled.
  */
 export function expandPackageGlobs(root: string, globs: string[]): string[] {
   const included = new Set<string>();
@@ -198,24 +225,50 @@ export function expandPackageGlobs(root: string, globs: string[]): string[] {
   return [...included].sort();
 }
 
+/** Match a single path segment against a pattern containing `*`. */
+function segmentMatches(pattern: string, name: string): boolean {
+  if (pattern === "*" || pattern === "**") return true;
+  const starIdx = pattern.indexOf("*");
+  if (starIdx === -1) return pattern === name;
+  const prefix = pattern.slice(0, starIdx);
+  const suffix = pattern.slice(starIdx + 1).replace(/\*+$/, "");
+  return name.startsWith(prefix) && name.endsWith(suffix);
+}
+
 function expandSingleGlob(root: string, glob: string): string[] {
-  if (glob.endsWith("/*") || glob.endsWith("/**")) {
-    const baseDir = glob.replace(/\/\*+$/, "");
-    const fullBase = path.join(root, baseDir);
+  const segments = glob.split("/");
+  return expandSegments(root, segments);
+}
+
+function expandSegments(base: string, segments: string[]): string[] {
+  if (segments.length === 0) {
     try {
-      const entries = fs.readdirSync(fullBase, { withFileTypes: true });
-      return entries.filter((e) => e.isDirectory()).map((e) => path.join(fullBase, e.name));
+      const stat = fs.statSync(base);
+      if (stat.isDirectory()) return [base];
+    } catch {
+      // doesn't exist
+    }
+    return [];
+  }
+
+  const [current, ...rest] = segments;
+
+  if (current.includes("*")) {
+    try {
+      const entries = fs.readdirSync(base, { withFileTypes: true });
+      const matched = entries.filter((e) => e.isDirectory() && segmentMatches(current, e.name));
+      if (rest.length === 0) {
+        return matched.map((e) => path.join(base, e.name));
+      }
+      const results: string[] = [];
+      for (const entry of matched) {
+        results.push(...expandSegments(path.join(base, entry.name), rest));
+      }
+      return results;
     } catch {
       return [];
     }
   }
 
-  const full = path.join(root, glob);
-  try {
-    const stat = fs.statSync(full);
-    if (stat.isDirectory()) return [full];
-  } catch {
-    // doesn't exist
-  }
-  return [];
+  return expandSegments(path.join(base, current), rest);
 }

--- a/packages/portless/src/workspace.ts
+++ b/packages/portless/src/workspace.ts
@@ -3,7 +3,10 @@ import * as path from "node:path";
 
 export interface WorkspacePackage {
   dir: string;
+  /** Package name with scope stripped (e.g., `@org/web` → `web`). */
   name: string | null;
+  /** Npm scope without the `@` prefix (e.g., `@og-sdk/web` → `og-sdk`). Null if unscoped. */
+  scope: string | null;
   scripts: Record<string, string>;
 }
 
@@ -49,9 +52,12 @@ export function discoverWorkspacePackages(workspaceRoot: string): WorkspacePacka
     try {
       const raw = fs.readFileSync(pkgPath, "utf-8");
       const pkg = JSON.parse(raw);
-      const name = typeof pkg.name === "string" ? pkg.name.replace(/^@[^/]+\//, "") : null;
+      const rawName = typeof pkg.name === "string" ? pkg.name : null;
+      const scopeMatch = rawName?.match(/^@([^/]+)\//);
+      const scope = scopeMatch ? scopeMatch[1] : null;
+      const name = rawName ? rawName.replace(/^@[^/]+\//, "") : null;
       const scripts = typeof pkg.scripts === "object" && pkg.scripts !== null ? pkg.scripts : {};
-      packages.push({ dir, name, scripts });
+      packages.push({ dir, name, scope, scripts });
     } catch {
       // no package.json or invalid; skip
     }

--- a/packages/portless/src/workspace.ts
+++ b/packages/portless/src/workspace.ts
@@ -10,7 +10,7 @@ export interface WorkspacePackage {
   scripts: Record<string, string>;
 }
 
-export type WorkspaceSource = "pnpm" | "package-json";
+type WorkspaceSource = "pnpm" | "package-json";
 
 /**
  * Walk up from `cwd` looking for a workspace root.

--- a/packages/portless/src/workspace.ts
+++ b/packages/portless/src/workspace.ts
@@ -1,0 +1,156 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export interface WorkspacePackage {
+  dir: string;
+  name: string | null;
+  scripts: Record<string, string>;
+}
+
+/**
+ * Walk up from `cwd` looking for pnpm-workspace.yaml.
+ * Returns the directory containing it, or null.
+ */
+export function findWorkspaceRoot(cwd: string = process.cwd()): string | null {
+  let dir = cwd;
+  for (;;) {
+    const wsPath = path.join(dir, "pnpm-workspace.yaml");
+    try {
+      fs.accessSync(wsPath, fs.constants.R_OK);
+      return dir;
+    } catch {
+      // not here
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+/**
+ * Discover all workspace packages from pnpm-workspace.yaml at `workspaceRoot`.
+ * Returns packages that have a package.json (ignoring dirs without one).
+ */
+export function discoverWorkspacePackages(workspaceRoot: string): WorkspacePackage[] {
+  const wsPath = path.join(workspaceRoot, "pnpm-workspace.yaml");
+  let content: string;
+  try {
+    content = fs.readFileSync(wsPath, "utf-8");
+  } catch {
+    return [];
+  }
+
+  const globs = parsePnpmWorkspaceYaml(content);
+  const dirs = expandPackageGlobs(workspaceRoot, globs);
+  const packages: WorkspacePackage[] = [];
+
+  for (const dir of dirs) {
+    const pkgPath = path.join(dir, "package.json");
+    try {
+      const raw = fs.readFileSync(pkgPath, "utf-8");
+      const pkg = JSON.parse(raw);
+      const name = typeof pkg.name === "string" ? pkg.name.replace(/^@[^/]+\//, "") : null;
+      const scripts = typeof pkg.scripts === "object" && pkg.scripts !== null ? pkg.scripts : {};
+      packages.push({ dir, name, scripts });
+    } catch {
+      // no package.json or invalid; skip
+    }
+  }
+
+  return packages;
+}
+
+/**
+ * Parse the `packages:` list from pnpm-workspace.yaml content.
+ * Handles the simple format (flat list of `- <glob>` lines under `packages:`).
+ * No YAML library needed.
+ */
+export function parsePnpmWorkspaceYaml(content: string): string[] {
+  const lines = content.split("\n");
+  const globs: string[] = [];
+  let inPackages = false;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd();
+
+    if (/^packages\s*:/.test(line)) {
+      inPackages = true;
+      continue;
+    }
+
+    if (inPackages) {
+      // End of list: non-empty line that isn't indented or a list item
+      if (
+        line.length > 0 &&
+        !line.startsWith(" ") &&
+        !line.startsWith("\t") &&
+        !line.startsWith("-")
+      ) {
+        break;
+      }
+
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+
+      const match = trimmed.match(/^-\s+['"]?([^'"#]+?)['"]?\s*(?:#.*)?$/);
+      if (match) {
+        const glob = match[1].trim();
+        if (glob) globs.push(glob);
+      }
+    }
+  }
+
+  return globs;
+}
+
+/**
+ * Expand workspace globs to actual directories. Supports:
+ * - `dir/*` (single-level wildcard, most common)
+ * - `dir` (literal directory)
+ * - Negation patterns (`!dir`) are used to filter out matches.
+ */
+export function expandPackageGlobs(root: string, globs: string[]): string[] {
+  const included = new Set<string>();
+  const excluded = new Set<string>();
+
+  for (const glob of globs) {
+    if (glob.startsWith("!")) {
+      const negated = glob.slice(1);
+      for (const dir of expandSingleGlob(root, negated)) {
+        excluded.add(dir);
+      }
+    } else {
+      for (const dir of expandSingleGlob(root, glob)) {
+        included.add(dir);
+      }
+    }
+  }
+
+  for (const dir of excluded) {
+    included.delete(dir);
+  }
+
+  return [...included].sort();
+}
+
+function expandSingleGlob(root: string, glob: string): string[] {
+  if (glob.endsWith("/*") || glob.endsWith("/**")) {
+    const baseDir = glob.replace(/\/\*+$/, "");
+    const fullBase = path.join(root, baseDir);
+    try {
+      const entries = fs.readdirSync(fullBase, { withFileTypes: true });
+      return entries.filter((e) => e.isDirectory()).map((e) => path.join(fullBase, e.name));
+    } catch {
+      return [];
+    }
+  }
+
+  const full = path.join(root, glob);
+  try {
+    const stat = fs.statSync(full);
+    if (stat.isDirectory()) return [full];
+  } catch {
+    // doesn't exist
+  }
+  return [];
+}

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -56,26 +56,22 @@ In non-interactive environments (no TTY, or `CI=1`), portless exits with a descr
 
 ### Zero-config (recommended)
 
-Create a `portless.json` with the app name. Your `package.json` scripts stay portless-free:
+Bare `portless` works out of the box. It runs the `"dev"` script from `package.json` through the proxy, inferring the app name from the package name, git root, or directory:
 
-**portless.json:**
+```bash
+portless        # -> runs "dev" script, https://<project>.localhost
+pnpm dev        # -> works without portless, plain "next dev"
+```
+
+Use an optional `portless.json` to override defaults (name, script, port):
 
 ```json
 { "name": "myapp" }
 ```
 
-**package.json:**
-
-```json
-{ "scripts": { "dev": "next dev" } }
-```
-
 ```bash
-portless        # -> runs "dev" script through proxy as https://myapp.localhost
-pnpm dev        # -> works without portless, plain "next dev"
+portless        # -> runs "dev" script, https://myapp.localhost
 ```
-
-Without a `portless.json`, the name is inferred from `package.json`. The script defaults to `"dev"`.
 
 ### Monorepo
 
@@ -228,7 +224,7 @@ LAN mode depends on the system mDNS helpers that portless launches: macOS includ
 
 | Command                                | Description                                                    |
 | -------------------------------------- | -------------------------------------------------------------- |
-| `portless`                             | With portless.json: run dev script through proxy               |
+| `portless`                             | Run dev script through proxy                                   |
 | `portless`                             | From monorepo root: run all workspace packages                 |
 | `portless --script <name>`             | Run a specific package.json script (default: dev)              |
 | `portless run [cmd] [args...]`         | Infer name from project, run through proxy (auto-starts)       |

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -77,9 +77,9 @@ pnpm dev        # -> works without portless, plain "next dev"
 
 Without a `portless.json`, the name is inferred from `package.json`. The script defaults to `"dev"`.
 
-### Monorepo (pnpm workspace)
+### Monorepo
 
-One `portless.json` at the repo root. Portless reads `pnpm-workspace.yaml` to discover packages:
+One `portless.json` at the repo root. Portless discovers packages from `pnpm-workspace.yaml`, or the `"workspaces"` field in `package.json` (npm, yarn, bun):
 
 ```json
 {

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -255,18 +255,19 @@ LAN mode depends on the system mDNS helpers that portless launches: macOS includ
 
 ## portless.json
 
-Optional config file. Portless walks up from cwd to find it.
+Optional config file. Portless looks for it in the current directory.
 
-| Field     | Type   | Default                    | Description                                              |
-| --------- | ------ | -------------------------- | -------------------------------------------------------- |
-| `name`    | string | inferred from package.json | Base app name (worktree prefix still applies)            |
-| `script`  | string | `"dev"`                    | Name of a package.json script to run                     |
-| `appPort` | number | auto-assigned              | Fixed port for the child process                         |
-| `apps`    | object |                            | Overrides for workspace packages, keyed by relative path |
+| Field     | Type    | Default                    | Description                                              |
+| --------- | ------- | -------------------------- | -------------------------------------------------------- |
+| `name`    | string  | inferred from package.json | Base app name (worktree prefix still applies)            |
+| `script`  | string  | `"dev"`                    | Name of a package.json script to run                     |
+| `appPort` | number  | auto-assigned              | Fixed port for the child process                         |
+| `proxy`   | boolean | auto-detected              | Whether to route through the proxy (`false` for tasks)   |
+| `apps`    | object  |                            | Overrides for workspace packages, keyed by relative path |
 
-Each `apps` entry has the same shape (`name`, `script`, `appPort`). When `apps` is present, top-level fields apply only in single-app mode.
+Each `apps` entry has the same shape (`name`, `script`, `appPort`, `proxy`). When `apps` is present, top-level fields apply only in single-app mode.
 
-Precedence: CLI flags > portless.json > package.json inference > defaults.
+Precedence (closest wins): CLI flags > package.json `"portless"` key > portless.json app entry > defaults.
 
 ## Troubleshooting
 

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -54,7 +54,51 @@ In non-interactive environments (no TTY, or `CI=1`), portless exits with a descr
 
 ## Integration Patterns
 
+### Zero-config (recommended)
+
+Create a `portless.json` with the app name. Your `package.json` scripts stay portless-free:
+
+```json
+// portless.json
+{ "name": "myapp" }
+```
+
+```json
+// package.json
+{ "scripts": { "dev": "next dev" } }
+```
+
+```bash
+portless        # -> runs "dev" script through proxy as https://myapp.localhost
+pnpm dev        # -> works without portless, plain "next dev"
+```
+
+Without a `portless.json`, the name is inferred from `package.json`. The script defaults to `"dev"`.
+
+### Monorepo (pnpm workspace)
+
+One `portless.json` at the repo root. Portless reads `pnpm-workspace.yaml` to discover packages:
+
+```json
+{
+  "apps": {
+    "apps/web": { "name": "myapp" },
+    "apps/api": { "name": "api.myapp" }
+  }
+}
+```
+
+```bash
+portless                  # from repo root: start all packages with a "dev" script
+cd apps/web && portless   # start just one package
+portless --script start   # run "start" instead of "dev"
+```
+
+The `apps` map is optional and only provides name overrides. Unlisted packages auto-discover with inferred names.
+
 ### package.json scripts
+
+You can still use portless directly in scripts:
 
 ```json
 {
@@ -173,7 +217,10 @@ LAN mode depends on the system mDNS helpers that portless launches: macOS includ
 
 | Command                                | Description                                                    |
 | -------------------------------------- | -------------------------------------------------------------- |
-| `portless run <cmd> [args...]`         | Infer name from project, run through proxy (auto-starts)       |
+| `portless`                             | With portless.json: run dev script through proxy               |
+| `portless`                             | From monorepo root: run all workspace packages                 |
+| `portless --script <name>`             | Run a specific package.json script (default: dev)              |
+| `portless run [cmd] [args...]`         | Infer name from project, run through proxy (auto-starts)       |
 | `portless run --name <name> <cmd>`     | Override inferred base name (worktree prefix still applies)    |
 | `portless <name> <cmd> [args...]`      | Run app at `https://<name>.localhost` (auto-starts proxy)      |
 | `portless get <name>`                  | Print URL for a service (for cross-service wiring)             |
@@ -203,6 +250,21 @@ LAN mode depends on the system mDNS helpers that portless launches: macOS includ
 | `portless --version` / `-v`            | Show version                                                   |
 
 **Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `trust`, `clean`, and `proxy` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name, or `portless --name <name> <cmd>` to force any name including reserved ones.
+
+## portless.json
+
+Optional config file. Portless walks up from cwd to find it.
+
+| Field     | Type   | Default                    | Description                                              |
+| --------- | ------ | -------------------------- | -------------------------------------------------------- |
+| `name`    | string | inferred from package.json | Base app name (worktree prefix still applies)            |
+| `script`  | string | `"dev"`                    | Name of a package.json script to run                     |
+| `appPort` | number | auto-assigned              | Fixed port for the child process                         |
+| `apps`    | object |                            | Overrides for workspace packages, keyed by relative path |
+
+Each `apps` entry has the same shape (`name`, `script`, `appPort`). When `apps` is present, top-level fields apply only in single-app mode.
+
+Precedence: CLI flags > portless.json > package.json inference > defaults.
 
 ## Troubleshooting
 

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -98,6 +98,19 @@ portless --script start   # run "start" instead of "dev"
 
 The `apps` map is optional and only provides name overrides. Unlisted packages auto-discover with inferred names.
 
+### Turborepo
+
+For turborepo projects, use portless as the `dev` script with the real command in a separate script:
+
+```json
+{
+  "scripts": { "dev": "portless", "dev:app": "next dev" },
+  "portless": { "name": "myapp", "script": "dev:app" }
+}
+```
+
+`pnpm dev` runs turbo, which runs `portless` in each package. Portless detects the package manager and runs `pnpm run dev:app` through the proxy.
+
 ### package.json scripts
 
 You can still use portless directly in scripts:

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -98,6 +98,8 @@ portless --script start   # run "start" instead of "dev"
 
 The `apps` map is optional and only provides name overrides. Unlisted packages auto-discover with inferred names.
 
+Without an `apps` map, hostnames follow `<package>.<project>.localhost`. The project name comes from the most common npm scope (e.g. `@myorg/web` and `@myorg/api` produce `myorg`), falling back to the workspace root directory name. If a package's short name matches the project name, it uses the bare `<project>.localhost`.
+
 ### Turborepo
 
 For turborepo projects, use portless as the `dev` script with the real command in a separate script:
@@ -169,13 +171,7 @@ Most frameworks (Next.js, Express, Nuxt, etc.) respect the `PORT` env var automa
 
 ### State directory
 
-Portless stores its state (routes, PID file, port file) in a directory that depends on the proxy port:
-
-- **Port < 1024** (sudo required): `/tmp/portless` (macOS/Linux only)
-- **Port >= 1024** (no sudo): `~/.portless`
-- **Windows**: Always `~/.portless` (no privileged port concept)
-
-Override with the `PORTLESS_STATE_DIR` environment variable.
+Portless stores its state (routes, PID file, port file) in `~/.portless`. Override with the `PORTLESS_STATE_DIR` environment variable.
 
 ### Environment variables
 
@@ -277,8 +273,23 @@ Optional config file. Portless looks for it in the current directory.
 | `appPort` | number  | auto-assigned              | Fixed port for the child process                         |
 | `proxy`   | boolean | auto-detected              | Whether to route through the proxy (`false` for tasks)   |
 | `apps`    | object  |                            | Overrides for workspace packages, keyed by relative path |
+| `turbo`   | boolean | `true`                     | Set `false` to use direct spawning instead of turborepo  |
 
 Each `apps` entry has the same shape (`name`, `script`, `appPort`, `proxy`). When `apps` is present, top-level fields apply only in single-app mode.
+
+### package.json "portless" key
+
+Instead of a separate `portless.json`, you can add a `"portless"` key to your `package.json`. A string value is shorthand for setting the name:
+
+```json
+{ "portless": "myapp" }
+```
+
+An object supports all per-app fields (`name`, `script`, `appPort`, `proxy`):
+
+```json
+{ "portless": { "name": "myapp", "script": "dev:app" } }
+```
 
 Precedence (closest wins): CLI flags > package.json `"portless"` key > portless.json app entry > defaults.
 
@@ -367,7 +378,7 @@ proxy: {
 }
 ```
 
-Portless automatically sets `NODE_EXTRA_CA_CERTS` in child processes so Node.js trusts the portless CA. If you run a separate Node.js process outside portless, point it at the CA manually: `NODE_EXTRA_CA_CERTS=/tmp/portless/ca.pem` (or `~/.portless/ca.pem` when the proxy runs on a non-privileged port like 1355). Alternatively, use `--no-tls` for plain HTTP.
+Portless automatically sets `NODE_EXTRA_CA_CERTS` in child processes so Node.js trusts the portless CA. If you run a separate Node.js process outside portless, point it at the CA manually: `NODE_EXTRA_CA_CERTS=~/.portless/ca.pem`. Alternatively, use `--no-tls` for plain HTTP.
 
 ### Requirements
 

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -58,13 +58,15 @@ In non-interactive environments (no TTY, or `CI=1`), portless exits with a descr
 
 Create a `portless.json` with the app name. Your `package.json` scripts stay portless-free:
 
+**portless.json:**
+
 ```json
-// portless.json
 { "name": "myapp" }
 ```
 
+**package.json:**
+
 ```json
-// package.json
 { "scripts": { "dev": "next dev" } }
 ```
 


### PR DESCRIPTION
## Summary

- **Config file support** — optional `portless.json` or a `"portless"` key in `package.json` (string shorthand or object) for setting app name, script, port, and proxy behavior without embedding portless in scripts
- **Zero-arg mode** — running bare `portless` from a workspace root auto-discovers packages via `pnpm-workspace.yaml` or `package.json` `"workspaces"` (npm, yarn, bun) and starts all dev scripts concurrently through the proxy
- **Multi-app orchestration** — hostnames use `<package>.<project>.localhost` convention, deriving the project name from the common npm scope; scripts already invoking `portless` are passed through without re-wrapping
- **Turbo integration** — when `turbo.json` is present, multi-app mode delegates to turbo and injects per-package env vars (PORT, HOST, PORTLESS_URL) via a `--require` loader; disable with `"turbo": false` in config
- **Build tool detection** — known non-server commands (tsup, tsc, esbuild, etc.) run as tasks without a proxy route; explicit `"proxy": false` config available for edge cases
- **Trust marker** — caches CA fingerprint after successful trust to avoid re-triggering the macOS authentication dialog on every `proxy start`
- **State dir simplification** — all state now lives in `~/.portless` regardless of port; `/tmp/portless` retained as a read-only fallback for proxies started with older versions
- **`--script` flag** — global flag to override the default `"dev"` script for a single invocation
- New modules: `config.ts` (config loading, validation, script resolution), `workspace.ts` (workspace discovery for pnpm, npm, yarn, bun), and `turbo.ts` (env loader and manifest for turbo integration)
- Updates docs app, README, SKILL.md, and CLI help text