### PR TITLE
Prepare v0.11.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,23 @@
 # Changelog
 
-## 0.11.0
+## 0.11.1
 
 <!-- release:start -->
+
+### New Features
+
+- **`portless prune` command**: Safety net to find and kill orphaned dev servers left behind by dead CLI sessions. Reads stale route entries, checks if something is still listening on each port, and terminates the orphan.
+
+### Bug Fixes
+
+- **Zombie process orphaning on CLI crash**: Spawn child processes with `detached:true` on Unix so they get their own process group. Signal handlers now kill the entire group instead of just the immediate child, preventing orphaned dev servers from surviving CLI crashes or `kill -9`.
+
+### Contributors
+
+- @ctate
+<!-- release:end -->
+
+## 0.11.0
 
 ### New Features
 
@@ -29,7 +44,6 @@
 ### Contributors
 
 - @ctate
-<!-- release:end -->
 
 ## 0.10.3
 

--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ portless alias --remove <name>   # Remove a static route
 portless list                    # Show active routes
 portless trust                   # Add local CA to system trust store
 portless clean                   # Remove state, CA trust entry, and hosts block
+portless prune                   # Kill orphaned dev servers from crashed sessions
 portless hosts sync              # Add routes to /etc/hosts (fixes Safari)
 portless hosts clean             # Remove portless entries from /etc/hosts
 
@@ -344,7 +345,7 @@ PORTLESS_URL                     Public URL (e.g. https://myapp.localhost)
 NODE_EXTRA_CA_CERTS              Path to the portless CA (when HTTPS is active)
 ```
 
-> **Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `trust`, `clean`, and `proxy` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name from your project, or `portless --name <name> <cmd>` to force any name including reserved ones.
+> **Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `trust`, `clean`, `prune`, and `proxy` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name from your project, or `portless --name <name> <cmd>` to force any name including reserved ones.
 
 ## Uninstall / reset
 

--- a/apps/docs/src/app/changelog/page.mdx
+++ b/apps/docs/src/app/changelog/page.mdx
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.11.1
+
+### New Features
+
+- **`portless prune` command**: Safety net to find and kill orphaned dev servers left behind by dead CLI sessions. Reads stale route entries, checks if something is still listening on each port, and terminates the orphan.
+
+### Bug Fixes
+
+- **Zombie process orphaning on CLI crash**: Spawn child processes with `detached:true` on Unix so they get their own process group. Signal handlers now kill the entire group instead of just the immediate child, preventing orphaned dev servers from surviving CLI crashes or `kill -9`.
+
 ## 0.11.0
 
 ### New Features

--- a/apps/docs/src/app/commands/page.mdx
+++ b/apps/docs/src/app/commands/page.mdx
@@ -117,6 +117,15 @@ portless clean
 
 Stops the proxy if it is running, removes the portless CA from the OS trust store when portless installed it, deletes allowlisted files under `~/.portless`, the system state directory, and `PORTLESS_STATE_DIR` when set, and removes the portless block from `/etc/hosts`. May prompt for elevated privileges. Custom `--cert` / `--key` paths are not removed.
 
+## Prune orphans
+
+```bash
+portless prune
+portless prune --force
+```
+
+Finds and kills orphaned dev server processes left behind by crashed portless sessions. When the CLI is killed with `kill -9` or crashes, child dev servers may survive and continue holding their ports. This command checks routes whose owning process is dead but whose port is still in use, terminates the orphans, and removes the stale route entries. Use `--force` to send SIGKILL instead of SIGTERM.
+
 ## Proxy control
 
 ### Start

--- a/packages/portless/package.json
+++ b/packages/portless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portless",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Replace port numbers with stable, named .localhost URLs. For humans and agents.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -91,6 +91,35 @@ export const SIGNAL_CODES: Record<string, number> = {
   SIGTERM: 15,
 };
 
+/**
+ * Kill a child process and its entire process tree. On Unix, when the child
+ * was spawned with `detached: true`, it leads its own process group and
+ * process.kill(-pid) reaches every descendant. Falls back to killing just
+ * the child on Windows or when the group kill fails.
+ */
+export function killTree(
+  child: ReturnType<typeof spawn>,
+  signal: NodeJS.Signals = "SIGTERM"
+): void {
+  if (!child.pid) {
+    child.kill(signal);
+    return;
+  }
+  if (!isWindows) {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch {
+      // Process group may already be gone; fall through
+    }
+  }
+  try {
+    child.kill(signal);
+  } catch {
+    // Already dead
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Port configuration
 // ---------------------------------------------------------------------------
@@ -620,6 +649,35 @@ export function parsePidFromNetstat(output: string, port: number): number | null
 }
 
 /**
+ * Find all PIDs listening on the given TCP port.
+ * Uses lsof on macOS/Linux and netstat on Windows.
+ */
+export function findPidsOnPort(port: number): number[] {
+  try {
+    if (isWindows) {
+      const output = execSync("netstat -ano -p tcp", {
+        encoding: "utf-8",
+        timeout: PID_LOOKUP_TIMEOUT_MS,
+      });
+      const pid = parsePidFromNetstat(output, port);
+      return pid === null ? [] : [pid];
+    }
+
+    const output = execSync(`lsof -ti tcp:${port} -sTCP:LISTEN`, {
+      encoding: "utf-8",
+      timeout: PID_LOOKUP_TIMEOUT_MS,
+    });
+    return output
+      .trim()
+      .split("\n")
+      .map((s) => parseInt(s, 10))
+      .filter((n) => !isNaN(n) && n > 0);
+  } catch {
+    return [];
+  }
+}
+
+/**
  * Try to find the PID of a process listening on the given TCP port.
  * Uses lsof on macOS/Linux and netstat on Windows.
  * Returns null if the PID cannot be determined.
@@ -737,6 +795,9 @@ export function spawnCommand(
     }
   }
 
+  // On Unix, spawn detached so the child gets its own process group. This
+  // lets us kill the entire tree (shell + grandchild dev server) with a
+  // single process.kill(-pid, signal) instead of only the immediate child.
   const child = isWindows
     ? spawn("cmd.exe", ["/d", "/s", "/c", commandArgs.join(" ")], {
         stdio: "inherit",
@@ -745,6 +806,7 @@ export function spawnCommand(
     : spawn("/bin/sh", ["-c", commandArgs.map(shellEscape).join(" ")], {
         stdio: "inherit",
         env,
+        detached: true,
       });
 
   let exiting = false;
@@ -758,7 +820,7 @@ export function spawnCommand(
   const handleSignal = (signal: NodeJS.Signals) => {
     if (exiting) return;
     exiting = true;
-    child.kill(signal);
+    killTree(child, signal);
     cleanup();
     process.exit(128 + (SIGNAL_CODES[signal] || 15));
   };

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -31,6 +31,7 @@ import {
   discoverState,
   findFreePort,
   findPidOnPort,
+  findPidsOnPort,
   getDefaultPort,
   getDefaultTld,
   injectFrameworkFlags,
@@ -40,6 +41,7 @@ import {
   isLanEnvEnabled,
   isProxyRunning,
   isWindows,
+  killTree,
   readLanMarker,
   readPersistedProxyState,
   readTldFromDir,
@@ -1302,6 +1304,7 @@ ${colors.bold("Usage:")}
   ${colors.cyan("portless list")}                    Show active routes
   ${colors.cyan("portless trust")}                   Add local CA to system trust store
   ${colors.cyan("portless clean")}                   Remove portless state, trust entry, and hosts block
+  ${colors.cyan("portless prune")}                   Kill orphaned dev servers from crashed sessions
   ${colors.cyan("portless hosts sync")}              Add routes to ${HOSTS_DISPLAY} (fixes Safari)
   ${colors.cyan("portless hosts clean")}             Remove portless entries from ${HOSTS_DISPLAY}
 
@@ -1414,8 +1417,8 @@ ${colors.bold("Skip portless:")}
   PORTLESS=0 pnpm dev           # Runs command directly without proxy
 
 ${colors.bold("Reserved names:")}
-  run, get, alias, hosts, list, trust, clean, proxy are subcommands and cannot
-  be used as app names directly. Use "portless run" to infer the name,
+  run, get, alias, hosts, list, trust, clean, prune, proxy are subcommands and
+  cannot be used as app names directly. Use "portless run" to infer the name,
   or "portless --name <name>" to force any name including reserved ones.
 `);
   process.exit(0);
@@ -1560,6 +1563,68 @@ ${colors.bold("Options:")}
   }
 
   console.log(colors.green("Clean finished."));
+}
+
+async function handlePrune(args: string[]): Promise<void> {
+  if (args[1] === "--help" || args[1] === "-h") {
+    console.log(`
+${colors.bold("portless prune")} - Kill orphaned dev servers left behind by crashed portless sessions.
+
+When portless is killed with SIGKILL (kill -9) or crashes, child dev servers
+may survive and continue holding their ports. This command finds those orphans
+by checking routes whose owning CLI process is dead but whose port is still in
+use, then terminates them and cleans up the stale route entries.
+
+${colors.bold("Usage:")}
+  ${colors.cyan("portless prune")}
+  ${colors.cyan("portless prune --force")}     Send SIGKILL instead of SIGTERM
+
+${colors.bold("Options:")}
+  --force                Send SIGKILL instead of SIGTERM
+  --help, -h             Show this help
+`);
+    process.exit(0);
+  }
+
+  const forceKill = args.includes("--force");
+
+  const { dir } = await discoverState();
+  const store = new RouteStore(dir, {
+    onWarning: (msg) => console.warn(colors.yellow(msg)),
+  });
+
+  const stale = store.pruneStaleRoutes();
+  if (stale.length === 0) {
+    console.log("No orphaned routes found.");
+    return;
+  }
+
+  let killed = 0;
+  for (const route of stale) {
+    const pids = findPidsOnPort(route.port);
+    if (pids.length === 0) {
+      console.log(`  ${route.hostname} :${route.port} - route removed (port already free)`);
+      continue;
+    }
+    const signal = forceKill ? "SIGKILL" : "SIGTERM";
+    for (const pid of pids) {
+      try {
+        process.kill(pid, signal);
+        killed++;
+        console.log(`  ${route.hostname} :${route.port} - killed PID ${pid} (${signal})`);
+      } catch {
+        console.log(`  ${route.hostname} :${route.port} - PID ${pid} already exited`);
+      }
+    }
+  }
+
+  const routeWord = stale.length === 1 ? "route" : "routes";
+  const procWord = killed === 1 ? "process" : "processes";
+  console.log(
+    colors.green(
+      `\nPruned ${stale.length} stale ${routeWord}, killed ${killed} orphaned ${procWord}.`
+    )
+  );
 }
 
 async function handleList(): Promise<void> {
@@ -2463,6 +2528,7 @@ function spawnChildProcess(
     stdio: ["ignore", "pipe", "pipe"],
     env,
     cwd,
+    ...(isWindows ? {} : { detached: true }),
   });
 }
 
@@ -2831,6 +2897,7 @@ async function runWithTurbo(
       ...process.env,
       NODE_OPTIONS: buildNodeOptions(),
     },
+    ...(isWindows ? {} : { detached: true }),
   });
 
   const SIGKILL_TIMEOUT_MS = 5_000;
@@ -2840,18 +2907,10 @@ async function runWithTurbo(
     if (cleanedUp) return;
     cleanedUp = true;
 
-    try {
-      turboChild.kill("SIGTERM");
-    } catch {
-      // already dead
-    }
+    killTree(turboChild, "SIGTERM");
     setTimeout(() => {
       if (turboChild.exitCode === null && !turboChild.killed) {
-        try {
-          turboChild.kill("SIGKILL");
-        } catch {
-          // already dead
-        }
+        killTree(turboChild, "SIGKILL");
       }
     }, SIGKILL_TIMEOUT_MS).unref();
 
@@ -2932,20 +2991,12 @@ async function runWithDirectSpawn(
     cleanedUp = true;
 
     for (const child of children) {
-      try {
-        child.kill("SIGTERM");
-      } catch {
-        // already dead
-      }
+      killTree(child, "SIGTERM");
     }
     setTimeout(() => {
       for (const child of children) {
         if (child.exitCode === null && !child.killed) {
-          try {
-            child.kill("SIGKILL");
-          } catch {
-            // already dead
-          }
+          killTree(child, "SIGKILL");
         }
       }
     }, SIGKILL_TIMEOUT_MS).unref();
@@ -3188,7 +3239,7 @@ async function main() {
 
   // --name flag: treat the next arg as an explicit app name, bypassing
   // subcommand dispatch. Useful when the app name collides with a reserved
-  // subcommand (run, alias, hosts, list, trust, clean, proxy).
+  // subcommand (run, alias, hosts, list, trust, clean, prune, proxy).
   if (args[0] === "--name") {
     args.shift();
     if (!args[0]) {
@@ -3245,7 +3296,7 @@ async function main() {
     return;
   }
 
-  // Global dispatch: help, version, trust, clean, list, alias, hosts, proxy
+  // Global dispatch: help, version, trust, clean, prune, list, alias, hosts, proxy
   // When `run` is used, skip these so args like "list" or "--help" are treated
   // as child-command tokens, not portless subcommands.
   if (!isRunCommand) {
@@ -3270,6 +3321,10 @@ async function main() {
     }
     if (args[0] === "clean") {
       await handleClean(args);
+      return;
+    }
+    if (args[0] === "prune") {
+      await handlePrune(args);
       return;
     }
     if (args[0] === "list") {

--- a/packages/portless/src/routes.ts
+++ b/packages/portless/src/routes.ts
@@ -236,6 +236,61 @@ export class RouteStore {
     return killedPid;
   }
 
+  /**
+   * Load all routes from disk without filtering out dead PIDs. Used by
+   * `portless prune` to discover stale entries whose owning CLI is gone
+   * but whose dev server may still be holding a port.
+   */
+  loadRoutesRaw(): RouteMapping[] {
+    if (!fs.existsSync(this.routesPath)) {
+      return [];
+    }
+    try {
+      const raw = fs.readFileSync(this.routesPath, "utf-8");
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        return [];
+      }
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+      return parsed.filter(isValidRoute);
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Remove all route entries whose owning process is dead and persist the
+   * result. Returns the removed stale entries so the caller can act on them.
+   */
+  pruneStaleRoutes(): RouteMapping[] {
+    this.ensureDir();
+    if (!this.acquireLock()) {
+      throw new Error("Failed to acquire route lock");
+    }
+    try {
+      const all = this.loadRoutesRaw();
+      const alive: RouteMapping[] = [];
+      const stale: RouteMapping[] = [];
+      for (const r of all) {
+        if (r.pid === 0 || this.isProcessAlive(r.pid)) {
+          alive.push(r);
+        } else {
+          stale.push(r);
+        }
+      }
+      if (stale.length > 0) {
+        this.saveRoutes(alive);
+      }
+      return stale;
+    } finally {
+      this.releaseLock();
+    }
+  }
+
   removeRoute(hostname: string): void {
     this.ensureDir();
     if (!this.acquireLock()) {

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -235,6 +235,8 @@ LAN mode depends on the system mDNS helpers that portless launches: macOS includ
 | `portless list`                        | Show active routes                                             |
 | `portless trust`                       | Add local CA to system trust store (for HTTPS)                 |
 | `portless clean`                       | Remove state, CA trust entry, and /etc/hosts block             |
+| `portless prune`                       | Kill orphaned dev servers from crashed sessions                |
+| `portless prune --force`               | Kill orphans with SIGKILL instead of SIGTERM                   |
 | `portless proxy start`                 | Start HTTPS proxy as a daemon (port 443, auto-elevates)        |
 | `portless proxy start --no-tls`        | Start without HTTPS (plain HTTP on port 80)                    |
 | `portless proxy start --lan`           | Start in LAN mode (mDNS `.local`, auto-follows LAN IP changes) |
@@ -256,7 +258,7 @@ LAN mode depends on the system mDNS helpers that portless launches: macOS includ
 | `portless run --help`                  | Show help for a subcommand (also: alias, hosts, clean)         |
 | `portless --version` / `-v`            | Show version                                                   |
 
-**Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `trust`, `clean`, and `proxy` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name, or `portless --name <name> <cmd>` to force any name including reserved ones.
+**Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `trust`, `clean`, `prune`, and `proxy` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name, or `portless --name <name> <cmd>` to force any name including reserved ones.
 
 ## portless.json
 

--- a/tests/e2e/fixtures/minimal-server/wrapper.js
+++ b/tests/e2e/fixtures/minimal-server/wrapper.js
@@ -1,0 +1,17 @@
+/* global process */
+// Wrapper that spawns server.js as a child process, mimicking how
+// `npm run dev` creates a grandchild. Prevents /bin/sh from exec-ing
+// directly, which is required to reproduce the orphaned-grandchild bug.
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import * as path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const child = spawn(process.execPath, [path.join(__dirname, "server.js")], {
+  stdio: "inherit",
+  env: process.env,
+});
+
+child.on("exit", (code) => {
+  process.exit(code ?? 0);
+});

--- a/tests/e2e/src/zombie.test.ts
+++ b/tests/e2e/src/zombie.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { spawn, spawnSync, execSync, type ChildProcess } from "node:child_process";
+import * as fs from "node:fs";
+import * as http from "node:http";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI_PATH = path.resolve(__dirname, "../../../packages/portless/dist/cli.js");
+const FIXTURE_DIR = path.resolve(__dirname, "../fixtures/minimal-server");
+const PROXY_PORT = 19013;
+
+const isWindows = process.platform === "win32";
+
+function killPort(port: number): void {
+  try {
+    if (isWindows) {
+      const output = execSync("netstat -ano -p tcp", {
+        encoding: "utf-8",
+        timeout: 5000,
+      });
+      const myPid = process.pid;
+      for (const line of output.split(/\r?\n/)) {
+        if (!line.includes("LISTENING")) continue;
+        const parts = line.trim().split(/\s+/);
+        if (parts.length < 5) continue;
+        const localAddr = parts[1];
+        const lastColon = localAddr.lastIndexOf(":");
+        if (lastColon === -1) continue;
+        const addrPort = parseInt(localAddr.substring(lastColon + 1), 10);
+        if (addrPort !== port) continue;
+        const pid = parseInt(parts[parts.length - 1], 10);
+        if (isNaN(pid) || pid <= 0 || pid === myPid) continue;
+        try {
+          process.kill(pid, "SIGTERM");
+        } catch {
+          // already dead
+        }
+      }
+    } else {
+      const pids = execSync(`lsof -ti tcp:${port}`, {
+        encoding: "utf-8",
+        timeout: 5000,
+      }).trim();
+      if (pids) {
+        const myPid = process.pid;
+        for (const raw of pids.split("\n")) {
+          const pid = parseInt(raw, 10);
+          if (isNaN(pid) || pid === myPid) continue;
+          try {
+            process.kill(pid, "SIGTERM");
+          } catch {
+            // already dead
+          }
+        }
+      }
+    }
+  } catch {
+    // no process on port
+  }
+}
+
+function findPidsOnPort(port: number): number[] {
+  try {
+    if (isWindows) {
+      const output = execSync("netstat -ano -p tcp", {
+        encoding: "utf-8",
+        timeout: 5000,
+      });
+      const pids: number[] = [];
+      for (const line of output.split(/\r?\n/)) {
+        if (!line.includes("LISTENING")) continue;
+        const parts = line.trim().split(/\s+/);
+        if (parts.length < 5) continue;
+        const localAddr = parts[1];
+        const lastColon = localAddr.lastIndexOf(":");
+        if (lastColon === -1) continue;
+        const addrPort = parseInt(localAddr.substring(lastColon + 1), 10);
+        if (addrPort !== port) continue;
+        const pid = parseInt(parts[parts.length - 1], 10);
+        if (!isNaN(pid) && pid > 0) pids.push(pid);
+      }
+      return pids;
+    }
+    const output = execSync(`lsof -ti tcp:${port} -sTCP:LISTEN`, {
+      encoding: "utf-8",
+      timeout: 5000,
+    }).trim();
+    if (!output) return [];
+    return output
+      .split("\n")
+      .map((s) => parseInt(s, 10))
+      .filter((n) => !isNaN(n) && n > 0);
+  } catch {
+    return [];
+  }
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+interface TestState {
+  stateDir?: string;
+  cliChild?: ChildProcess;
+  appPort?: number;
+}
+
+async function cleanupTestState(state: TestState): Promise<void> {
+  if (state.cliChild && !state.cliChild.killed) {
+    state.cliChild.kill("SIGTERM");
+    await sleep(1000);
+    if (!state.cliChild.killed) state.cliChild.kill("SIGKILL");
+  }
+  if (state.appPort) killPort(state.appPort);
+
+  if (state.stateDir) {
+    spawnSync(process.execPath, [CLI_PATH, "proxy", "stop"], {
+      env: {
+        ...process.env,
+        PORTLESS_PORT: PROXY_PORT.toString(),
+        PORTLESS_STATE_DIR: state.stateDir,
+        NO_COLOR: "1",
+      },
+      timeout: 10_000,
+    });
+  }
+
+  killPort(PROXY_PORT);
+
+  if (state.stateDir) {
+    try {
+      fs.rmSync(state.stateDir, { recursive: true, force: true });
+    } catch {
+      // best effort
+    }
+  }
+}
+
+async function startCliApp(
+  appName: string,
+  state: TestState,
+  script = "server.js"
+): Promise<{ hostname: string; appPort: number }> {
+  state.stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-e2e-zombie-"));
+
+  const baseEnv = {
+    ...process.env,
+    PORTLESS_PORT: PROXY_PORT.toString(),
+    PORTLESS_HTTPS: "0",
+    PORTLESS_STATE_DIR: state.stateDir,
+    NO_COLOR: "1",
+  };
+
+  spawnSync(
+    process.execPath,
+    [CLI_PATH, "proxy", "start", "--no-tls", "-p", PROXY_PORT.toString()],
+    { env: baseEnv, timeout: 15_000 }
+  );
+
+  state.cliChild = spawn(process.execPath, [CLI_PATH, appName, "node", script], {
+    cwd: FIXTURE_DIR,
+    env: { ...baseEnv, APP_NAME: appName },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  state.cliChild.stdout!.on("data", () => {});
+  state.cliChild.stderr!.on("data", () => {});
+
+  const hostname = `${appName}.localhost`;
+  const deadline = Date.now() + 30_000;
+  let ready = false;
+  while (Date.now() < deadline) {
+    try {
+      const status = await new Promise<number>((resolve, reject) => {
+        const req = http.request(
+          `http://127.0.0.1:${PROXY_PORT}/`,
+          { headers: { Host: hostname } },
+          (res) => {
+            res.resume();
+            resolve(res.statusCode ?? 0);
+          }
+        );
+        req.on("error", reject);
+        req.setTimeout(2000, () => {
+          req.destroy();
+          reject(new Error("timeout"));
+        });
+        req.end();
+      });
+      if (status >= 200 && status < 400) {
+        ready = true;
+        break;
+      }
+    } catch {
+      // not ready
+    }
+    await sleep(500);
+  }
+  expect(ready).toBe(true);
+
+  const routesPath = path.join(state.stateDir, "routes.json");
+  const routes: Array<{ hostname: string; port: number; pid: number }> = JSON.parse(
+    fs.readFileSync(routesPath, "utf-8")
+  );
+  const route = routes.find((r) => r.hostname === hostname);
+  expect(route).toBeDefined();
+  state.appPort = route!.port;
+
+  const devPids = findPidsOnPort(state.appPort);
+  expect(devPids.length).toBeGreaterThan(0);
+
+  return { hostname, appPort: state.appPort };
+}
+
+describe("zombie process prevention", () => {
+  const state: TestState = {};
+
+  afterEach(async () => {
+    await cleanupTestState(state);
+    state.stateDir = undefined;
+    state.cliChild = undefined;
+    state.appPort = undefined;
+  });
+
+  it("SIGTERM kills the dev server via process group", async () => {
+    if (isWindows) return;
+
+    // Use wrapper.js so the tree is: CLI -> /bin/sh -> node wrapper.js -> node server.js
+    // Without wrapper.js, /bin/sh execs node directly and there's no grandchild to orphan.
+    const { appPort } = await startCliApp("zombie-sigterm", state, "wrapper.js");
+
+    // SIGTERM the portless CLI. The fix (detached + killTree) should kill the
+    // entire process group, including the grandchild dev server.
+    state.cliChild!.kill("SIGTERM");
+    await sleep(2000);
+
+    // The dev server must be dead. Without the process group fix, the
+    // grandchild survives because child.kill() only kills /bin/sh.
+    const survivors = findPidsOnPort(appPort);
+    expect(survivors).toEqual([]);
+  });
+
+  it("SIGKILL leaves orphan, portless prune cleans it up", async () => {
+    if (isWindows) return;
+
+    const { appPort } = await startCliApp("zombie-sigkill", state);
+
+    // SIGKILL is uncatchable so the signal handler never runs.
+    // The dev server will survive.
+    state.cliChild!.kill("SIGKILL");
+    await sleep(2000);
+
+    // Dev server should still be alive (SIGKILL cannot be intercepted)
+    const survivors = findPidsOnPort(appPort);
+    expect(survivors.length).toBeGreaterThan(0);
+
+    // portless prune is the safety net for this scenario
+    const pruneResult = spawnSync(process.execPath, [CLI_PATH, "prune"], {
+      env: {
+        ...process.env,
+        PORTLESS_PORT: PROXY_PORT.toString(),
+        PORTLESS_HTTPS: "0",
+        PORTLESS_STATE_DIR: state.stateDir,
+        NO_COLOR: "1",
+      },
+      encoding: "utf-8",
+      timeout: 10_000,
+    });
+    expect(pruneResult.status).toBe(0);
+    expect(pruneResult.stdout).toContain("killed");
+
+    await sleep(1000);
+    const pidsAfterPrune = findPidsOnPort(appPort);
+    expect(pidsAfterPrune).toEqual([]);
+  });
+});
+
+describe("portless prune", () => {
+  let stateDir: string | undefined;
+  let orphanServer: ChildProcess | undefined;
+  const ORPHAN_PORT = 17200;
+
+  afterEach(async () => {
+    if (orphanServer && !orphanServer.killed) {
+      orphanServer.kill("SIGKILL");
+    }
+    killPort(ORPHAN_PORT);
+    killPort(PROXY_PORT);
+    if (stateDir) {
+      try {
+        fs.rmSync(stateDir, { recursive: true, force: true });
+      } catch {
+        // best effort
+      }
+      stateDir = undefined;
+    }
+  });
+
+  it("kills orphaned processes and removes stale routes", async () => {
+    if (isWindows) return;
+
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-e2e-prune-"));
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    orphanServer = spawn(
+      "node",
+      [
+        "-e",
+        `
+      const http = require("http");
+      const s = http.createServer((_, res) => res.end("orphan"));
+      s.listen(${ORPHAN_PORT}, "127.0.0.1", () => {
+        console.log("listening");
+      });
+    `,
+      ],
+      { stdio: ["ignore", "pipe", "pipe"] }
+    );
+
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("orphan server did not start")), 5000);
+      orphanServer!.stdout!.on("data", (chunk: Buffer) => {
+        if (chunk.toString().includes("listening")) {
+          clearTimeout(timer);
+          resolve();
+        }
+      });
+    });
+
+    // Fake stale route: dead PID owns the orphan's port
+    const deadPid = 2147483647;
+    const routesPath = path.join(stateDir, "routes.json");
+    fs.writeFileSync(
+      routesPath,
+      JSON.stringify([{ hostname: "orphan-test.localhost", port: ORPHAN_PORT, pid: deadPid }])
+    );
+
+    expect(findPidsOnPort(ORPHAN_PORT).length).toBeGreaterThan(0);
+
+    const result = spawnSync(process.execPath, [CLI_PATH, "prune"], {
+      env: {
+        ...process.env,
+        PORTLESS_STATE_DIR: stateDir,
+        NO_COLOR: "1",
+      },
+      encoding: "utf-8",
+      timeout: 10_000,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("orphan-test.localhost");
+    expect(result.stdout).toContain("killed");
+    expect(result.stdout).toContain("Pruned 1 stale route");
+
+    await sleep(1000);
+    expect(findPidsOnPort(ORPHAN_PORT)).toEqual([]);
+
+    const routesAfter = JSON.parse(fs.readFileSync(routesPath, "utf-8"));
+    expect(routesAfter).toEqual([]);
+  });
+
+  it("reports nothing when no orphans exist", async () => {
+    if (isWindows) return;
+
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-e2e-prune-clean-"));
+
+    const result = spawnSync(process.execPath, [CLI_PATH, "prune"], {
+      env: {
+        ...process.env,
+        PORTLESS_STATE_DIR: stateDir,
+        NO_COLOR: "1",
+      },
+      encoding: "utf-8",
+      timeout: 10_000,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("No orphaned routes found");
+  });
+});


### PR DESCRIPTION
## Summary

- Bump version to 0.11.1
- Add changelog entry for zombie process orphaning fix and `portless prune` command
- Update docs changelog

## Release notes

### New Features

- **`portless prune` command**: Safety net to find and kill orphaned dev servers left behind by dead CLI sessions

### Bug Fixes

- **Zombie process orphaning on CLI crash**: Spawn child processes with their own process group on Unix, preventing orphaned dev servers from surviving CLI crashes or `kill -9`