### PR TITLE
fix(cli-utils): detect npm exec as a package runner

### DIFF
--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -591,6 +591,12 @@ describe("injectFrameworkFlags", () => {
     expect(args).toEqual(["pnpm", "exec", "astro", "dev", "--port", "4567", "--host", "127.0.0.1"]);
   });
 
+  it("injects flags for npm exec astro dev", () => {
+    const args = ["npm", "exec", "astro", "dev"];
+    injectFrameworkFlags(args, 4567);
+    expect(args).toEqual(["npm", "exec", "astro", "dev", "--port", "4567", "--host", "127.0.0.1"]);
+  });
+
   it("injects flags for npx rsbuild dev", () => {
     const args = ["npx", "rsbuild", "dev"];
     injectFrameworkFlags(args, 4567);

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -881,6 +881,7 @@ const PACKAGE_RUNNERS: Record<string, string[]> = {
   npx: [],
   bunx: [],
   pnpx: [],
+  npm: ["exec"],
   yarn: ["dlx", "exec"],
   pnpm: ["dlx", "exec"],
 };


### PR DESCRIPTION
## Summary

Adds `npm: ["exec"]` to `PACKAGE_RUNNERS` so `npm exec <framework> dev` is detected the same way `npx`, `bunx`, `yarn exec`, and `pnpm exec` already are. Functionally identical to npx; the entry was missing from the runners table while its peers were present.

## Why

Discovered while debugging an Astro 5 + portless setup where bare `portless` (which expands to `npm run dev`) silently fell back to Astro's default port instead of portless's assigned random port, producing 502s on the named subdomain. While `npm run dev` is correctly handled via portless's separate `detectPackageManager` / `resolveScriptCommand` path (PR #251), users who explicitly choose `npm exec astro dev` hit the same 502 silently because the runner table didn't include `npm: ["exec"]`.

## Change

One entry added to the constant in `packages/portless/src/cli-utils.ts`. No behavior change for any existing input; new behavior only fires for inputs starting with `npm exec`.

## Test

Added one test case in `packages/portless/src/cli-utils.test.ts` mirroring the existing `pnpm exec astro dev` test: asserts `injectFrameworkFlags(["npm", "exec", "astro", "dev"], 4567)` produces `["npm", "exec", "astro", "dev", "--port", "4567", "--host", "127.0.0.1"]`. Full portless test suite passes locally (545 passed, 2 skipped).

## Notes

This PR is co-authored by Corvus, an AI agent operated by Varde Labs (Kai deSilva). Source dive into the runner-detection logic was conducted by the agent; design call (npm vs not, test coverage approach) was joint. Happy to iterate on any of it.