### PR TITLE
Add Tailscale sharing and Funnel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,34 @@ LAN mode depends on the system mDNS tools that portless already spawns: macOS sh
 
 - **Expo / React Native**: portless always injects `--port`. React Native also gets `--host 127.0.0.1`. Expo gets `--host localhost` outside LAN mode, but in LAN mode portless leaves Metro on its default LAN host behavior instead of forcing `--host` or `HOST`.
 
+## Tailscale sharing
+
+Share your dev server with teammates on your [Tailscale](https://tailscale.com) network:
+
+```bash
+portless myapp --tailscale next dev
+# -> https://myapp.localhost           (local)
+# -> https://devbox.yourteam.ts.net    (tailnet)
+```
+
+Each `--tailscale` app is root-mounted on its own Tailscale HTTPS port, so no framework `basePath` configuration is needed. The first app gets port 443, subsequent apps get 8443, 8444, etc.
+
+```bash
+portless myapp --tailscale next dev     # -> https://devbox.ts.net
+portless api --tailscale pnpm start     # -> https://devbox.ts.net:8443
+```
+
+Use `--funnel` to expose your dev server to the public internet via [Tailscale Funnel](https://tailscale.com/kb/1223/funnel/):
+
+```bash
+portless myapp --funnel next dev
+# -> https://devbox.yourteam.ts.net    (public)
+```
+
+Set `PORTLESS_TAILSCALE=1` in your shell profile or `.env` to share every app by default. `portless list` shows both local and tailnet URLs. Tailscale serve registrations are cleaned up automatically when the app exits.
+
+Requires the Tailscale CLI to be installed and connected (`tailscale up`).
+
 ## Commands
 
 ```bash
@@ -321,6 +349,8 @@ portless proxy stop              # Stop the proxy
 --wildcard                       Allow unregistered subdomains to fall back to parent route
 --script <name>                  Run a specific package.json script (default: dev)
 --app-port <number>              Use a fixed port for the app (skip auto-assignment)
+--tailscale                      Share the app on your Tailscale network (tailnet)
+--funnel                         Share the app publicly via Tailscale Funnel
 --force                          Kill the existing process and take over its route
 --name <name>                    Use <name> as the app name
 ```
@@ -336,12 +366,15 @@ PORTLESS_LAN=1                   Enable LAN mode when set to 1 (auto-detects LAN
 PORTLESS_TLD=<tld>               Use a custom TLD (e.g. test; default: localhost)
 PORTLESS_WILDCARD=1              Allow unregistered subdomains to fall back to parent route
 PORTLESS_SYNC_HOSTS=0            Disable auto-sync of /etc/hosts (on by default)
+PORTLESS_TAILSCALE=1             Share apps on your Tailscale network (same as --tailscale)
+PORTLESS_FUNNEL=1                Share apps publicly via Tailscale Funnel (same as --funnel)
 PORTLESS_STATE_DIR=<path>        Override the state directory
 
 # Injected into child processes
 PORT                             Ephemeral port the child should listen on
 HOST                             Usually 127.0.0.1 (omitted for Expo in LAN mode)
 PORTLESS_URL                     Public URL (e.g. https://myapp.localhost)
+PORTLESS_TAILSCALE_URL           Tailscale URL of the app (when --tailscale is active)
 NODE_EXTRA_CA_CERTS              Path to the portless CA (when HTTPS is active)
 ```
 
@@ -422,3 +455,4 @@ pnpm format           # Format all files with Prettier
 
 - Node.js 20+
 - macOS, Linux, or Windows
+- Tailscale CLI (optional, for `--tailscale` and `--funnel`)

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -1323,4 +1323,61 @@ describe("CLI", () => {
       expect(stderr).toContain("appPort");
     });
   });
+
+  describe("--tailscale flag", () => {
+    it("shows --tailscale in help output", () => {
+      const { status, stdout } = run(["--help"]);
+      expect(status).toBe(0);
+      expect(stdout).toContain("--tailscale");
+      expect(stdout).toContain("--funnel");
+      expect(stdout).toContain("PORTLESS_TAILSCALE");
+    });
+
+    it("fails with actionable message when tailscale is not installed", () => {
+      const { status, stderr } = run(["--tailscale", "myapp", "echo", "hello"], {
+        env: { PATH: "/tmp/portless-no-ts-path" },
+      });
+      expect(status).toBe(1);
+      expect(stderr).toContain("Tailscale");
+    });
+
+    it("fails with --funnel when tailscale is not installed", () => {
+      const { status, stderr } = run(["--funnel", "myapp", "echo", "hello"], {
+        env: { PATH: "/tmp/portless-no-ts-path" },
+      });
+      expect(status).toBe(1);
+      expect(stderr).toContain("Tailscale");
+    });
+
+    it("accepts PORTLESS_TAILSCALE=1 env var", () => {
+      const { status, stderr } = run(["myapp", "echo", "hello"], {
+        env: { PORTLESS_TAILSCALE: "1", PATH: "/tmp/portless-no-ts-path" },
+      });
+      expect(status).toBe(1);
+      expect(stderr).toContain("Tailscale");
+    });
+
+    it("accepts --tailscale after app name", () => {
+      const { status, stderr } = run(["myapp", "--tailscale", "echo", "hello"], {
+        env: { PATH: "/tmp/portless-no-ts-path" },
+      });
+      expect(status).toBe(1);
+      expect(stderr).toContain("Tailscale");
+    });
+
+    it("accepts --tailscale in run subcommand", () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-cli-ts-run-"));
+      try {
+        fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ name: "test-app" }));
+        const { status, stderr } = run(["run", "--tailscale", "echo", "hello"], {
+          cwd: tmpDir,
+          env: { PATH: "/tmp/portless-no-ts-path" },
+        });
+        expect(status).toBe(1);
+        expect(stderr).toContain("Tailscale");
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+  });
 });

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -19,8 +19,7 @@ import {
   getUsedServePorts,
   registerFunnel,
   registerServe,
-  unregisterFunnel,
-  unregisterServe,
+  unregisterTailscale,
 } from "./tailscale.js";
 import {
   inferProjectName,
@@ -951,9 +950,11 @@ async function runApp(
 
   // Check tailscale readiness early, before auto-starting the proxy.
   // No point starting the proxy if tailscale will fail afterward.
-  const wantsTailscale =
-    process.env.PORTLESS_TAILSCALE === "1" || process.env.PORTLESS_TAILSCALE === "true";
   const wantsFunnel = process.env.PORTLESS_FUNNEL === "1" || process.env.PORTLESS_FUNNEL === "true";
+  const wantsTailscale =
+    wantsFunnel ||
+    process.env.PORTLESS_TAILSCALE === "1" ||
+    process.env.PORTLESS_TAILSCALE === "true";
   let tsBaseUrl: string | undefined;
 
   if (wantsTailscale) {
@@ -1075,22 +1076,29 @@ async function runApp(
   let tailscaleUrl: string | undefined;
 
   if (wantsTailscale && tsBaseUrl) {
-    const usedPorts = getUsedServePorts();
-    tailscaleHttpsPort = findAvailableServePort(usedPorts);
-
-    try {
-      if (wantsFunnel) {
-        registerFunnel(port, tailscaleHttpsPort);
-      } else {
-        registerServe(port, tailscaleHttpsPort);
+    const maxAttempts = 3;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const usedPorts = getUsedServePorts();
+      tailscaleHttpsPort = findAvailableServePort(usedPorts);
+      try {
+        if (wantsFunnel) {
+          registerFunnel(port, tailscaleHttpsPort);
+        } else {
+          registerServe(port, tailscaleHttpsPort);
+        }
+        break;
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        const isConflict = message.includes("already in use");
+        if (isConflict && attempt < maxAttempts) continue;
+        console.error(colors.red(`Error: ${message}`));
+        process.exit(1);
       }
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err);
-      console.error(colors.red(`Error: ${message}`));
-      process.exit(1);
     }
 
-    tailscaleUrl = formatTailscaleUrl(tsBaseUrl, tailscaleHttpsPort);
+    // tailscaleHttpsPort is always assigned: the loop either breaks after
+    // a successful register or exits the process on final failure.
+    tailscaleUrl = formatTailscaleUrl(tsBaseUrl, tailscaleHttpsPort!);
     const label = wantsFunnel ? "Funnel (public)" : "Tailscale";
     console.log(chalk.green(`  ${label} -> ${tailscaleUrl}`));
     if (wantsFunnel) {
@@ -1169,16 +1177,13 @@ async function runApp(
       ...caEnv,
     },
     onCleanup: () => {
-      if (tailscaleHttpsPort !== undefined) {
-        try {
-          if (wantsFunnel) {
-            unregisterFunnel(tailscaleHttpsPort, { ignoreMissing: true });
-          } else {
-            unregisterServe(tailscaleHttpsPort, { ignoreMissing: true });
-          }
-        } catch {
-          // Best-effort cleanup; non-fatal
-        }
+      try {
+        unregisterTailscale({
+          tailscaleHttpsPort,
+          tailscaleFunnel: wantsFunnel || undefined,
+        });
+      } catch {
+        // Best-effort cleanup; non-fatal
       }
       try {
         store.removeRoute(hostname);
@@ -1230,6 +1235,19 @@ function appPortFromEnv(): number | undefined {
     process.exit(1);
   }
   return port;
+}
+
+function applyTailscaleFlag(flag: string): boolean {
+  if (flag === "--tailscale") {
+    process.env.PORTLESS_TAILSCALE = "1";
+    return true;
+  }
+  if (flag === "--funnel") {
+    process.env.PORTLESS_FUNNEL = "1";
+    process.env.PORTLESS_TAILSCALE = "1";
+    return true;
+  }
+  return false;
 }
 
 /**
@@ -1296,11 +1314,8 @@ ${colors.bold("Examples:")}
         process.exit(1);
       }
       name = args[i];
-    } else if (args[i] === "--tailscale") {
-      process.env.PORTLESS_TAILSCALE = "1";
-    } else if (args[i] === "--funnel") {
-      process.env.PORTLESS_FUNNEL = "1";
-      process.env.PORTLESS_TAILSCALE = "1";
+    } else if (applyTailscaleFlag(args[i])) {
+      // handled
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
       console.error(
@@ -1338,11 +1353,8 @@ function parseAppArgs(args: string[]): ParsedAppArgs {
     } else if (args[i] === "--app-port") {
       i++;
       appPort = parseAppPort(args[i]);
-    } else if (args[i] === "--tailscale") {
-      process.env.PORTLESS_TAILSCALE = "1";
-    } else if (args[i] === "--funnel") {
-      process.env.PORTLESS_FUNNEL = "1";
-      process.env.PORTLESS_TAILSCALE = "1";
+    } else if (applyTailscaleFlag(args[i])) {
+      // handled
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
       console.error(colors.blue("Known flags: --force, --app-port, --tailscale, --funnel"));
@@ -1365,11 +1377,8 @@ function parseAppArgs(args: string[]): ParsedAppArgs {
     } else if (args[i] === "--app-port") {
       i++;
       appPort = parseAppPort(args[i]);
-    } else if (args[i] === "--tailscale") {
-      process.env.PORTLESS_TAILSCALE = "1";
-    } else if (args[i] === "--funnel") {
-      process.env.PORTLESS_FUNNEL = "1";
-      process.env.PORTLESS_TAILSCALE = "1";
+    } else if (applyTailscaleFlag(args[i])) {
+      // handled
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
       console.error(colors.blue("Known flags: --force, --app-port, --tailscale, --funnel"));
@@ -1641,11 +1650,7 @@ ${colors.bold("Options:")}
   for (const route of routesForClean) {
     if (route.tailscaleHttpsPort) {
       try {
-        if (route.tailscaleFunnel) {
-          unregisterFunnel(route.tailscaleHttpsPort, { ignoreMissing: true });
-        } else {
-          unregisterServe(route.tailscaleHttpsPort, { ignoreMissing: true });
-        }
+        unregisterTailscale(route);
         console.log(colors.green(`Removed tailscale serve on port ${route.tailscaleHttpsPort}.`));
       } catch {
         // Tailscale may not be installed; non-fatal
@@ -1743,11 +1748,7 @@ ${colors.bold("Options:")}
   for (const route of stale) {
     if (route.tailscaleHttpsPort) {
       try {
-        if (route.tailscaleFunnel) {
-          unregisterFunnel(route.tailscaleHttpsPort, { ignoreMissing: true });
-        } else {
-          unregisterServe(route.tailscaleHttpsPort, { ignoreMissing: true });
-        }
+        unregisterTailscale(route);
         console.log(
           `  ${route.hostname} - removed tailscale serve on port ${route.tailscaleHttpsPort}`
         );

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1079,7 +1079,7 @@ async function runApp(
     const maxAttempts = 3;
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       const usedPorts = getUsedServePorts();
-      tailscaleHttpsPort = findAvailableServePort(usedPorts);
+      tailscaleHttpsPort = findAvailableServePort(usedPorts, wantsFunnel ? "funnel" : "serve");
       try {
         if (wantsFunnel) {
           registerFunnel(port, tailscaleHttpsPort);

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -13,6 +13,16 @@ import { fixOwnership, formatUrl, isErrnoException, parseHostname } from "./util
 import { syncHostsFile, cleanHostsFile, shouldAutoSyncHosts } from "./hosts.js";
 import { FILE_MODE, RouteConflictError, RouteStore } from "./routes.js";
 import {
+  ensureTailscaleReady,
+  findAvailableServePort,
+  formatTailscaleUrl,
+  getUsedServePorts,
+  registerFunnel,
+  registerServe,
+  unregisterFunnel,
+  unregisterServe,
+} from "./tailscale.js";
+import {
   inferProjectName,
   detectWorktreePrefix,
   truncateLabel,
@@ -771,6 +781,10 @@ function listRoutes(store: RouteStore, proxyPort: number, tls: boolean): void {
     console.log(
       `  ${colors.cyan(url)}  ${colors.gray("->")}  ${colors.white(`localhost:${route.port}`)}  ${colors.gray(label)}`
     );
+    if (route.tailscaleUrl) {
+      const tsLabel = route.tailscaleFunnel ? "funnel" : "tailscale";
+      console.log(`    ${colors.gray(tsLabel + ":")} ${colors.green(route.tailscaleUrl)}`);
+    }
   }
   console.log();
 }
@@ -935,6 +949,30 @@ async function runApp(
   let store = initialStore;
   console.log(chalk.blue.bold(`\nportless\n`));
 
+  // Check tailscale readiness early, before auto-starting the proxy.
+  // No point starting the proxy if tailscale will fail afterward.
+  const wantsTailscale =
+    process.env.PORTLESS_TAILSCALE === "1" || process.env.PORTLESS_TAILSCALE === "true";
+  const wantsFunnel = process.env.PORTLESS_FUNNEL === "1" || process.env.PORTLESS_FUNNEL === "true";
+  let tsBaseUrl: string | undefined;
+
+  if (wantsTailscale) {
+    try {
+      const tsReady = ensureTailscaleReady();
+      tsBaseUrl = tsReady.baseUrl;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(colors.red(`Error: ${message}`));
+      if (message.includes("not found")) {
+        console.error(colors.blue("Install Tailscale: https://tailscale.com/download"));
+      } else {
+        console.error(colors.blue("Make sure Tailscale is connected:"));
+        console.error(colors.cyan("  tailscale up"));
+      }
+      process.exit(1);
+    }
+  }
+
   let desired: ProxyDesiredState;
   try {
     desired = resolveProxyDesiredState(lanMode);
@@ -1031,6 +1069,47 @@ async function runApp(
     console.log(chalk.gray("  (accessible from other devices on the same WiFi network)\n"));
   }
 
+  // Tailscale sharing: register with tailscale serve (or funnel).
+  // Readiness was already checked at the top of runApp().
+  let tailscaleHttpsPort: number | undefined;
+  let tailscaleUrl: string | undefined;
+
+  if (wantsTailscale && tsBaseUrl) {
+    const usedPorts = getUsedServePorts();
+    tailscaleHttpsPort = findAvailableServePort(usedPorts);
+
+    try {
+      if (wantsFunnel) {
+        registerFunnel(port, tailscaleHttpsPort);
+      } else {
+        registerServe(port, tailscaleHttpsPort);
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(colors.red(`Error: ${message}`));
+      process.exit(1);
+    }
+
+    tailscaleUrl = formatTailscaleUrl(tsBaseUrl, tailscaleHttpsPort);
+    const label = wantsFunnel ? "Funnel (public)" : "Tailscale";
+    console.log(chalk.green(`  ${label} -> ${tailscaleUrl}`));
+    if (wantsFunnel) {
+      console.log(chalk.gray("  (accessible from the public internet via Tailscale Funnel)\n"));
+    } else {
+      console.log(chalk.gray("  (accessible from your tailnet)\n"));
+    }
+
+    try {
+      store.updateRoute(hostname, {
+        tailscaleUrl: tailscaleUrl,
+        tailscaleHttpsPort,
+        tailscaleFunnel: wantsFunnel || undefined,
+      });
+    } catch {
+      // Non-fatal: route display metadata only
+    }
+  }
+
   // Child servers always bind to localhost; the proxy handles cross-device LAN access.
   // Exception: Expo in LAN mode — Metro defaults to LAN and setting HOST=127.0.0.1
   // conflicts with its internal networking, causing HMR WebSocket degradation.
@@ -1086,9 +1165,21 @@ async function runApp(
       // baked-in pinging, making this env var ineffective. Expo handles its
       // own LAN discovery natively.
       ...(lanMode ? { PORTLESS_LAN: "1" } : {}),
+      ...(tailscaleUrl ? { PORTLESS_TAILSCALE_URL: tailscaleUrl } : {}),
       ...caEnv,
     },
     onCleanup: () => {
+      if (tailscaleHttpsPort !== undefined) {
+        try {
+          if (wantsFunnel) {
+            unregisterFunnel(tailscaleHttpsPort, { ignoreMissing: true });
+          } else {
+            unregisterServe(tailscaleHttpsPort, { ignoreMissing: true });
+          }
+        } catch {
+          // Best-effort cleanup; non-fatal
+        }
+      }
       try {
         store.removeRoute(hostname);
       } catch {
@@ -1205,9 +1296,16 @@ ${colors.bold("Examples:")}
         process.exit(1);
       }
       name = args[i];
+    } else if (args[i] === "--tailscale") {
+      process.env.PORTLESS_TAILSCALE = "1";
+    } else if (args[i] === "--funnel") {
+      process.env.PORTLESS_FUNNEL = "1";
+      process.env.PORTLESS_TAILSCALE = "1";
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
-      console.error(colors.blue("Known flags: --name, --force, --app-port, --help"));
+      console.error(
+        colors.blue("Known flags: --name, --force, --app-port, --tailscale, --funnel, --help")
+      );
       process.exit(1);
     }
     i++;
@@ -1240,9 +1338,14 @@ function parseAppArgs(args: string[]): ParsedAppArgs {
     } else if (args[i] === "--app-port") {
       i++;
       appPort = parseAppPort(args[i]);
+    } else if (args[i] === "--tailscale") {
+      process.env.PORTLESS_TAILSCALE = "1";
+    } else if (args[i] === "--funnel") {
+      process.env.PORTLESS_FUNNEL = "1";
+      process.env.PORTLESS_TAILSCALE = "1";
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
-      console.error(colors.blue("Known flags: --force, --app-port"));
+      console.error(colors.blue("Known flags: --force, --app-port, --tailscale, --funnel"));
       process.exit(1);
     }
     i++;
@@ -1262,9 +1365,14 @@ function parseAppArgs(args: string[]): ParsedAppArgs {
     } else if (args[i] === "--app-port") {
       i++;
       appPort = parseAppPort(args[i]);
+    } else if (args[i] === "--tailscale") {
+      process.env.PORTLESS_TAILSCALE = "1";
+    } else if (args[i] === "--funnel") {
+      process.env.PORTLESS_FUNNEL = "1";
+      process.env.PORTLESS_TAILSCALE = "1";
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
-      console.error(colors.blue("Known flags: --force, --app-port"));
+      console.error(colors.blue("Known flags: --force, --app-port, --tailscale, --funnel"));
       process.exit(1);
     }
     i++;
@@ -1316,6 +1424,8 @@ ${colors.bold("Examples:")}
   portless run next dev               # -> https://<project>.localhost
   portless run next dev               # in worktree -> https://<worktree>.<project>.localhost
   portless get backend                # -> https://backend.localhost
+  portless myapp --tailscale next dev # -> also https://<node>.ts.net (tailnet)
+  portless myapp --funnel next dev    # -> also https://<node>.ts.net (public)
 
 ${colors.bold("Configuration (portless.json):")}
   Optional. Portless works out of the box by running the "dev" script
@@ -1366,6 +1476,15 @@ ${colors.bold("LAN mode:")}
   ${colors.cyan("portless proxy start --lan --https")}
   ${colors.cyan("portless proxy start --lan --ip 192.168.1.42")}
 
+${colors.bold("Tailscale sharing:")}
+  Use --tailscale to share your dev server with teammates on your tailnet.
+  Each app is root-mounted on its own Tailscale HTTPS port (443, then 8443,
+  8444, etc.) so no basePath configuration is needed.
+  Use --funnel to expose your dev server to the public internet via
+  Tailscale Funnel. Requires Tailscale CLI to be installed and connected.
+  ${colors.cyan("portless myapp --tailscale next dev")}
+  ${colors.cyan("portless myapp --funnel next dev")}
+
 ${colors.bold("Options:")}
   run [--name <name>] <cmd>      Infer project name (or override with --name)
                                 Adds worktree prefix in git worktrees
@@ -1382,6 +1501,8 @@ ${colors.bold("Options:")}
   --tld <tld>                   Use a custom TLD instead of .localhost (e.g. test, dev)
   --wildcard                    Allow unregistered subdomains to fall back to parent route
   --app-port <number>           Use a fixed port for the app (skip auto-assignment)
+  --tailscale                   Share the app on your Tailscale network (tailnet)
+  --funnel                      Share the app publicly via Tailscale Funnel
   --force                       Kill the existing process and take over its route
   --name <name>                 Use <name> as the app name (bypasses subcommand dispatch)
   --                            Stop flag parsing; everything after is passed to the child
@@ -1394,6 +1515,8 @@ ${colors.bold("Environment variables:")}
   PORTLESS_TLD=<tld>            Use a custom TLD (e.g. test, dev; default: localhost)
   PORTLESS_WILDCARD=1           Allow unregistered subdomains to fall back to parent route
   PORTLESS_SYNC_HOSTS=0         Disable auto-sync of ${HOSTS_DISPLAY} (on by default)
+  PORTLESS_TAILSCALE=1          Share apps on your Tailscale network (same as --tailscale)
+  PORTLESS_FUNNEL=1             Share apps publicly via Tailscale Funnel (same as --funnel)
   PORTLESS_STATE_DIR=<path>     Override the state directory
   PORTLESS=0                    Run command directly without proxy
 
@@ -1402,6 +1525,7 @@ ${colors.bold("Child process environment:")}
   HOST                          Usually 127.0.0.1 (omitted for Expo in LAN mode)
   PORTLESS_URL                  Public URL of the app (e.g. https://myapp.localhost)
   PORTLESS_LAN                  Set to 1 when proxy is in LAN mode
+  PORTLESS_TAILSCALE_URL        Tailscale URL of the app (when --tailscale is active)
   NODE_EXTRA_CA_CERTS           Path to the portless CA (set when HTTPS is active)
 
 ${colors.bold("Safari / DNS:")}
@@ -1512,6 +1636,23 @@ ${colors.bold("Options:")}
   });
   await stopProxy(store, port, tls);
 
+  // Clean up any tailscale serve/funnel registrations tied to stale routes
+  const routesForClean = store.loadRoutesRaw();
+  for (const route of routesForClean) {
+    if (route.tailscaleHttpsPort) {
+      try {
+        if (route.tailscaleFunnel) {
+          unregisterFunnel(route.tailscaleHttpsPort, { ignoreMissing: true });
+        } else {
+          unregisterServe(route.tailscaleHttpsPort, { ignoreMissing: true });
+        }
+        console.log(colors.green(`Removed tailscale serve on port ${route.tailscaleHttpsPort}.`));
+      } catch {
+        // Tailscale may not be installed; non-fatal
+      }
+    }
+  }
+
   const stateDirs = collectStateDirsForCleanup();
   for (const stateDir of stateDirs) {
     const caPath = path.join(stateDir, "ca.pem");
@@ -1597,6 +1738,23 @@ ${colors.bold("Options:")}
   if (stale.length === 0) {
     console.log("No orphaned routes found.");
     return;
+  }
+
+  for (const route of stale) {
+    if (route.tailscaleHttpsPort) {
+      try {
+        if (route.tailscaleFunnel) {
+          unregisterFunnel(route.tailscaleHttpsPort, { ignoreMissing: true });
+        } else {
+          unregisterServe(route.tailscaleHttpsPort, { ignoreMissing: true });
+        }
+        console.log(
+          `  ${route.hostname} - removed tailscale serve on port ${route.tailscaleHttpsPort}`
+        );
+      } catch {
+        // Tailscale CLI may not be installed; non-fatal during prune
+      }
+    }
   }
 
   let killed = 0;
@@ -3226,6 +3384,14 @@ async function main() {
   } else if (typeof autoIpResult === "string") {
     process.env[INTERNAL_LAN_IP_ENV] = autoIpResult;
     process.env.PORTLESS_LAN = "1";
+  }
+
+  if (stripGlobalFlag("--tailscale", false)) {
+    process.env.PORTLESS_TAILSCALE = "1";
+  }
+  if (stripGlobalFlag("--funnel", false)) {
+    process.env.PORTLESS_FUNNEL = "1";
+    process.env.PORTLESS_TAILSCALE = "1";
   }
 
   // --script flag: override the default "dev" script for zero-arg mode.

--- a/packages/portless/src/routes.test.ts
+++ b/packages/portless/src/routes.test.ts
@@ -399,4 +399,49 @@ describe("RouteStore", () => {
       expect(routes[0].hostname).toBe("contended.localhost");
     }, 10_000);
   });
+
+  describe("tailscale metadata", () => {
+    it("persists and loads tailscale fields via updateRoute", () => {
+      store.addRoute("myapp.localhost", 4123, process.pid);
+      store.updateRoute("myapp.localhost", {
+        tailscaleUrl: "https://devbox.example.ts.net",
+        tailscaleHttpsPort: 443,
+      });
+      const routes = store.loadRoutes();
+      expect(routes).toHaveLength(1);
+      expect(routes[0].tailscaleUrl).toBe("https://devbox.example.ts.net");
+      expect(routes[0].tailscaleHttpsPort).toBe(443);
+      expect(routes[0].tailscaleFunnel).toBeUndefined();
+    });
+
+    it("persists funnel flag via updateRoute", () => {
+      store.addRoute("api.localhost", 4456, process.pid);
+      store.updateRoute("api.localhost", {
+        tailscaleUrl: "https://devbox.example.ts.net:8443",
+        tailscaleHttpsPort: 8443,
+        tailscaleFunnel: true,
+      });
+      const routes = store.loadRoutes();
+      expect(routes).toHaveLength(1);
+      expect(routes[0].tailscaleFunnel).toBe(true);
+    });
+
+    it("loads routes without tailscale fields (backward compat)", () => {
+      store.addRoute("legacy.localhost", 4000, process.pid);
+      const routes = store.loadRoutes();
+      expect(routes).toHaveLength(1);
+      expect(routes[0].tailscaleUrl).toBeUndefined();
+      expect(routes[0].tailscaleHttpsPort).toBeUndefined();
+    });
+
+    it("updateRoute is a no-op for nonexistent hostname", () => {
+      store.addRoute("myapp.localhost", 4123, process.pid);
+      store.updateRoute("noexist.localhost", {
+        tailscaleUrl: "https://devbox.example.ts.net",
+      });
+      const routes = store.loadRoutes();
+      expect(routes).toHaveLength(1);
+      expect(routes[0].tailscaleUrl).toBeUndefined();
+    });
+  });
 });

--- a/packages/portless/src/routes.ts
+++ b/packages/portless/src/routes.ts
@@ -23,6 +23,9 @@ export const DIR_MODE = 0o755;
 
 export interface RouteMapping extends RouteInfo {
   pid: number;
+  tailscaleUrl?: string;
+  tailscaleHttpsPort?: number;
+  tailscaleFunnel?: boolean;
 }
 
 /** Runtime check that a parsed JSON value is a valid RouteMapping. */
@@ -228,7 +231,8 @@ export class RouteStore {
         }
       }
       const filtered = routes.filter((r) => r.hostname !== hostname);
-      filtered.push({ hostname, port, pid });
+      const entry: RouteMapping = { hostname, port, pid };
+      filtered.push(entry);
       this.saveRoutes(filtered);
     } finally {
       this.releaseLock();
@@ -286,6 +290,32 @@ export class RouteStore {
         this.saveRoutes(alive);
       }
       return stale;
+    } finally {
+      this.releaseLock();
+    }
+  }
+
+  /**
+   * Update metadata on an existing route entry. Only provided fields are
+   * merged; the route must already exist (matched by hostname).
+   */
+  updateRoute(
+    hostname: string,
+    fields: Partial<Pick<RouteMapping, "tailscaleUrl" | "tailscaleHttpsPort" | "tailscaleFunnel">>
+  ): void {
+    this.ensureDir();
+    if (!this.acquireLock()) {
+      throw new Error("Failed to acquire route lock");
+    }
+    try {
+      const routes = this.loadRoutes(true);
+      const route = routes.find((r) => r.hostname === hostname);
+      if (!route) return;
+      if (fields.tailscaleUrl !== undefined) route.tailscaleUrl = fields.tailscaleUrl;
+      if (fields.tailscaleHttpsPort !== undefined)
+        route.tailscaleHttpsPort = fields.tailscaleHttpsPort;
+      if (fields.tailscaleFunnel !== undefined) route.tailscaleFunnel = fields.tailscaleFunnel;
+      this.saveRoutes(routes);
     } finally {
       this.releaseLock();
     }

--- a/packages/portless/src/tailscale.test.ts
+++ b/packages/portless/src/tailscale.test.ts
@@ -195,6 +195,24 @@ describe("tailscale", () => {
       const all = new Set([443, 8443, 8444, 8445, 8446, 8447, 8448, 8449, 8450]);
       expect(findAvailableServePort(all)).toBe(8451);
     });
+
+    it("returns 443 for funnel when nothing is in use", () => {
+      expect(findAvailableServePort(new Set(), "funnel")).toBe(443);
+    });
+
+    it("returns 8443 for funnel when 443 is taken", () => {
+      expect(findAvailableServePort(new Set([443]), "funnel")).toBe(8443);
+    });
+
+    it("returns 10000 for funnel when 443 and 8443 are taken", () => {
+      expect(findAvailableServePort(new Set([443, 8443]), "funnel")).toBe(10000);
+    });
+
+    it("throws when all funnel ports are taken", () => {
+      expect(() => findAvailableServePort(new Set([443, 8443, 10000]), "funnel")).toThrow(
+        "All Tailscale Funnel ports are in use"
+      );
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/packages/portless/src/tailscale.test.ts
+++ b/packages/portless/src/tailscale.test.ts
@@ -8,6 +8,7 @@ import {
   registerServe,
   unregisterFunnel,
   unregisterServe,
+  unregisterTailscale,
   type TailscaleCommandRunner,
 } from "./tailscale.js";
 
@@ -345,6 +346,34 @@ describe("tailscale", () => {
         },
       });
       expect(() => unregisterFunnel(8443, { ignoreMissing: true, runner })).not.toThrow();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // unregisterTailscale
+  // -----------------------------------------------------------------------
+
+  describe("unregisterTailscale", () => {
+    it("calls serve off for non-funnel route", () => {
+      const calls: string[][] = [];
+      const runner = createRunner({ "serve --yes --https=443 off": { status: 0 } }, calls);
+      unregisterServe(443, { runner });
+      expect(calls[0]).toEqual(["serve", "--yes", "--https=443", "off"]);
+    });
+
+    it("calls funnel off for funnel route", () => {
+      const calls: string[][] = [];
+      const runner = createRunner({ "funnel --yes --https=8443 off": { status: 0 } }, calls);
+      unregisterFunnel(8443, { runner });
+      expect(calls[0]).toEqual(["funnel", "--yes", "--https=8443", "off"]);
+    });
+
+    it("is a no-op when tailscaleHttpsPort is undefined", () => {
+      expect(() => unregisterTailscale({})).not.toThrow();
+    });
+
+    it("is a no-op when tailscaleHttpsPort is missing", () => {
+      expect(() => unregisterTailscale({ tailscaleFunnel: true })).not.toThrow();
     });
   });
 

--- a/packages/portless/src/tailscale.test.ts
+++ b/packages/portless/src/tailscale.test.ts
@@ -1,0 +1,374 @@
+import { describe, it, expect } from "vitest";
+import {
+  ensureTailscaleReady,
+  findAvailableServePort,
+  formatTailscaleUrl,
+  getUsedServePorts,
+  registerFunnel,
+  registerServe,
+  unregisterFunnel,
+  unregisterServe,
+  type TailscaleCommandRunner,
+} from "./tailscale.js";
+
+interface MockResult {
+  status?: number | null;
+  stdout?: string;
+  stderr?: string;
+  error?: Error;
+}
+
+function createRunner(
+  results: Record<string, MockResult>,
+  calls: string[][] = []
+): TailscaleCommandRunner {
+  return (args: string[]) => {
+    calls.push(args);
+    const key = args.join(" ");
+    const result = results[key];
+    if (!result) {
+      throw new Error(`Unexpected tailscale call: ${key}`);
+    }
+    return {
+      status: result.status ?? 0,
+      stdout: result.stdout ?? "",
+      stderr: result.stderr ?? "",
+      ...(result.error ? { error: result.error } : {}),
+    };
+  };
+}
+
+describe("tailscale", () => {
+  // -----------------------------------------------------------------------
+  // ensureTailscaleReady
+  // -----------------------------------------------------------------------
+
+  describe("ensureTailscaleReady", () => {
+    it("resolves base URL from Self.DNSName", () => {
+      const runner = createRunner({
+        version: { status: 0 },
+        "status --json": {
+          status: 0,
+          stdout: JSON.stringify({
+            Self: { DNSName: "devbox.example.ts.net." },
+          }),
+        },
+      });
+      const ready = ensureTailscaleReady(runner);
+      expect(ready.dnsName).toBe("devbox.example.ts.net");
+      expect(ready.baseUrl).toBe("https://devbox.example.ts.net");
+    });
+
+    it("falls back to HostName and MagicDNSSuffix", () => {
+      const runner = createRunner({
+        version: { status: 0 },
+        "status --json": {
+          status: 0,
+          stdout: JSON.stringify({
+            Self: { HostName: "devbox" },
+            CurrentTailnet: { MagicDNSSuffix: "example.ts.net." },
+          }),
+        },
+      });
+      const ready = ensureTailscaleReady(runner);
+      expect(ready.dnsName).toBe("devbox.example.ts.net");
+    });
+
+    it("throws when tailscale CLI is missing", () => {
+      const enoent = Object.assign(new Error("spawn tailscale ENOENT"), {
+        code: "ENOENT",
+      });
+      const runner = createRunner({
+        version: { status: null, error: enoent },
+      });
+      expect(() => ensureTailscaleReady(runner)).toThrow("Tailscale CLI not found");
+    });
+
+    it("throws when tailscale is not connected", () => {
+      const runner = createRunner({
+        version: { status: 0 },
+        "status --json": {
+          status: 0,
+          stdout: JSON.stringify({ Self: {} }),
+        },
+      });
+      expect(() => ensureTailscaleReady(runner)).toThrow("Could not determine");
+    });
+
+    it("throws on version check failure", () => {
+      const runner = createRunner({
+        version: { status: 1, stderr: "not found" },
+      });
+      expect(() => ensureTailscaleReady(runner)).toThrow("Failed to check tailscale version");
+    });
+
+    it("throws on invalid status JSON", () => {
+      const runner = createRunner({
+        version: { status: 0 },
+        "status --json": {
+          status: 0,
+          stdout: "not json",
+        },
+      });
+      expect(() => ensureTailscaleReady(runner)).toThrow("Failed to parse");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getUsedServePorts
+  // -----------------------------------------------------------------------
+
+  describe("getUsedServePorts", () => {
+    it("parses Web ports from serve status JSON", () => {
+      const runner = createRunner({
+        "serve status --json": {
+          status: 0,
+          stdout: JSON.stringify({
+            Web: {
+              "devbox.example.ts.net:443": { Handlers: {} },
+              "devbox.example.ts.net:8443": { Handlers: {} },
+            },
+          }),
+        },
+      });
+      const ports = getUsedServePorts(runner);
+      expect(ports).toEqual(new Set([443, 8443]));
+    });
+
+    it("parses TCP ports", () => {
+      const runner = createRunner({
+        "serve status --json": {
+          status: 0,
+          stdout: JSON.stringify({
+            TCP: { "22": { HTTPS: true }, "443": {} },
+          }),
+        },
+      });
+      const ports = getUsedServePorts(runner);
+      expect(ports).toEqual(new Set([22, 443]));
+    });
+
+    it("returns empty set on command failure", () => {
+      const runner = createRunner({
+        "serve status --json": { status: 1, stderr: "error" },
+      });
+      const ports = getUsedServePorts(runner);
+      expect(ports).toEqual(new Set());
+    });
+
+    it("returns empty set on invalid JSON", () => {
+      const runner = createRunner({
+        "serve status --json": { status: 0, stdout: "not json" },
+      });
+      const ports = getUsedServePorts(runner);
+      expect(ports).toEqual(new Set());
+    });
+
+    it("returns empty set on empty config", () => {
+      const runner = createRunner({
+        "serve status --json": { status: 0, stdout: "{}" },
+      });
+      const ports = getUsedServePorts(runner);
+      expect(ports).toEqual(new Set());
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // findAvailableServePort
+  // -----------------------------------------------------------------------
+
+  describe("findAvailableServePort", () => {
+    it("returns 443 when nothing is in use", () => {
+      expect(findAvailableServePort(new Set())).toBe(443);
+    });
+
+    it("returns 8443 when 443 is taken", () => {
+      expect(findAvailableServePort(new Set([443]))).toBe(8443);
+    });
+
+    it("skips to 8444 when 443 and 8443 are taken", () => {
+      expect(findAvailableServePort(new Set([443, 8443]))).toBe(8444);
+    });
+
+    it("goes beyond preferred list when all are taken", () => {
+      const all = new Set([443, 8443, 8444, 8445, 8446, 8447, 8448, 8449, 8450]);
+      expect(findAvailableServePort(all)).toBe(8451);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // registerServe / unregisterServe
+  // -----------------------------------------------------------------------
+
+  describe("registerServe", () => {
+    it("calls tailscale serve with correct args", () => {
+      const calls: string[][] = [];
+      const runner = createRunner(
+        {
+          "serve --bg --yes --https=443 http://127.0.0.1:4123": { status: 0 },
+        },
+        calls
+      );
+      registerServe(4123, 443, { runner });
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toEqual(["serve", "--bg", "--yes", "--https=443", "http://127.0.0.1:4123"]);
+    });
+
+    it("uses custom HTTPS port", () => {
+      const calls: string[][] = [];
+      const runner = createRunner(
+        {
+          "serve --bg --yes --https=8443 http://127.0.0.1:4456": { status: 0 },
+        },
+        calls
+      );
+      registerServe(4456, 8443, { runner });
+      expect(calls[0]).toContain("--https=8443");
+    });
+
+    it("throws on conflict", () => {
+      const runner = createRunner({
+        "serve --bg --yes --https=443 http://127.0.0.1:4123": {
+          status: 1,
+          stderr: "port already in use",
+        },
+      });
+      expect(() => registerServe(4123, 443, { runner })).toThrow("already in use");
+    });
+
+    it("throws on ENOENT", () => {
+      const enoent = Object.assign(new Error("spawn tailscale ENOENT"), {
+        code: "ENOENT",
+      });
+      const runner = createRunner({
+        "serve --bg --yes --https=443 http://127.0.0.1:4123": {
+          status: null,
+          error: enoent,
+        },
+      });
+      expect(() => registerServe(4123, 443, { runner })).toThrow("Tailscale CLI not found");
+    });
+
+    it("throws generic error on non-conflict failure", () => {
+      const runner = createRunner({
+        "serve --bg --yes --https=443 http://127.0.0.1:4123": {
+          status: 1,
+          stderr: "some unknown problem",
+        },
+      });
+      expect(() => registerServe(4123, 443, { runner })).toThrow("some unknown problem");
+    });
+  });
+
+  describe("unregisterServe", () => {
+    it("calls tailscale serve off with correct args", () => {
+      const calls: string[][] = [];
+      const runner = createRunner({ "serve --yes --https=443 off": { status: 0 } }, calls);
+      unregisterServe(443, { runner });
+      expect(calls[0]).toEqual(["serve", "--yes", "--https=443", "off"]);
+    });
+
+    it("ignores missing when requested", () => {
+      const runner = createRunner({
+        "serve --yes --https=443 off": {
+          status: 1,
+          stderr: "nothing to remove",
+        },
+      });
+      expect(() => unregisterServe(443, { ignoreMissing: true, runner })).not.toThrow();
+    });
+
+    it("throws on unexpected failure", () => {
+      const runner = createRunner({
+        "serve --yes --https=443 off": {
+          status: 1,
+          stderr: "permission denied",
+        },
+      });
+      expect(() => unregisterServe(443, { runner })).toThrow("permission denied");
+    });
+
+    it("silently returns on ENOENT", () => {
+      const enoent = Object.assign(new Error("spawn tailscale ENOENT"), {
+        code: "ENOENT",
+      });
+      const runner = createRunner({
+        "serve --yes --https=443 off": { status: null, error: enoent },
+      });
+      expect(() => unregisterServe(443, { runner })).not.toThrow();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // registerFunnel / unregisterFunnel
+  // -----------------------------------------------------------------------
+
+  describe("registerFunnel", () => {
+    it("calls tailscale funnel with correct args", () => {
+      const calls: string[][] = [];
+      const runner = createRunner(
+        {
+          "funnel --bg --yes --https=443 http://127.0.0.1:4123": { status: 0 },
+        },
+        calls
+      );
+      registerFunnel(4123, 443, { runner });
+      expect(calls[0]).toEqual(["funnel", "--bg", "--yes", "--https=443", "http://127.0.0.1:4123"]);
+    });
+
+    it("throws on conflict with funnel port info", () => {
+      const runner = createRunner({
+        "funnel --bg --yes --https=443 http://127.0.0.1:4123": {
+          status: 1,
+          stderr: "port already in use",
+        },
+      });
+      expect(() => registerFunnel(4123, 443, { runner })).toThrow(
+        "Tailscale Funnel supports ports 443, 8443, and 10000"
+      );
+    });
+  });
+
+  describe("unregisterFunnel", () => {
+    it("calls tailscale funnel off with correct args", () => {
+      const calls: string[][] = [];
+      const runner = createRunner({ "funnel --yes --https=443 off": { status: 0 } }, calls);
+      unregisterFunnel(443, { runner });
+      expect(calls[0]).toEqual(["funnel", "--yes", "--https=443", "off"]);
+    });
+
+    it("ignores missing when requested", () => {
+      const runner = createRunner({
+        "funnel --yes --https=8443 off": {
+          status: 1,
+          stderr: "does not exist",
+        },
+      });
+      expect(() => unregisterFunnel(8443, { ignoreMissing: true, runner })).not.toThrow();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // formatTailscaleUrl
+  // -----------------------------------------------------------------------
+
+  describe("formatTailscaleUrl", () => {
+    it("omits port for 443", () => {
+      expect(formatTailscaleUrl("https://devbox.example.ts.net", 443)).toBe(
+        "https://devbox.example.ts.net"
+      );
+    });
+
+    it("includes non-default port", () => {
+      expect(formatTailscaleUrl("https://devbox.example.ts.net", 8443)).toBe(
+        "https://devbox.example.ts.net:8443"
+      );
+    });
+
+    it("trims trailing slash from base URL", () => {
+      expect(formatTailscaleUrl("https://devbox.example.ts.net/", 443)).toBe(
+        "https://devbox.example.ts.net"
+      );
+    });
+  });
+});

--- a/packages/portless/src/tailscale.ts
+++ b/packages/portless/src/tailscale.ts
@@ -8,7 +8,10 @@ const TAILSCALE_BINARY = "tailscale";
  * Ports beyond this list are auto-assigned sequentially but may require
  * Tailscale ACL configuration to be reachable on the tailnet.
  */
-const PREFERRED_PORTS = [443, 8443, 8444, 8445, 8446, 8447, 8448, 8449, 8450];
+const PREFERRED_SERVE_PORTS = [443, 8443, 8444, 8445, 8446, 8447, 8448, 8449, 8450];
+
+/** Tailscale Funnel only supports these three ports. */
+const FUNNEL_PORTS = [443, 8443, 10000];
 
 interface TailscaleCommandResult {
   status: number | null;
@@ -170,14 +173,24 @@ export function getUsedServePorts(runner: TailscaleCommandRunner = defaultRunner
 
 /**
  * Pick the next available HTTPS port from the preferred sequence.
- * Returns the first port not in `usedPorts`.
+ * Returns the first port not in `usedPorts`. Funnel mode is restricted
+ * to 443, 8443, and 10000; serve mode extends beyond its preferred list.
  */
-export function findAvailableServePort(usedPorts: Set<number>): number {
-  for (const port of PREFERRED_PORTS) {
+export function findAvailableServePort(
+  usedPorts: Set<number>,
+  mode: TailscaleMode = "serve"
+): number {
+  const pool = mode === "funnel" ? FUNNEL_PORTS : PREFERRED_SERVE_PORTS;
+  for (const port of pool) {
     if (!usedPorts.has(port)) return port;
   }
-  // Extend beyond the preferred list
-  let port = PREFERRED_PORTS[PREFERRED_PORTS.length - 1] + 1;
+  if (mode === "funnel") {
+    throw new Error(
+      "All Tailscale Funnel ports are in use (443, 8443, 10000). " +
+        "Stop an existing funnel to free a port."
+    );
+  }
+  let port = PREFERRED_SERVE_PORTS[PREFERRED_SERVE_PORTS.length - 1] + 1;
   while (usedPorts.has(port)) port++;
   return port;
 }

--- a/packages/portless/src/tailscale.ts
+++ b/packages/portless/src/tailscale.ts
@@ -5,6 +5,8 @@ const TAILSCALE_BINARY = "tailscale";
 /**
  * Port allocation sequence for tailscale serve HTTPS ports.
  * First app gets 443 (default HTTPS), subsequent apps get 8443+.
+ * Ports beyond this list are auto-assigned sequentially but may require
+ * Tailscale ACL configuration to be reachable on the tailnet.
  */
 const PREFERRED_PORTS = [443, 8443, 8444, 8445, 8446, 8447, 8448, 8449, 8450];
 
@@ -187,143 +189,123 @@ export function findAvailableServePort(usedPorts: Set<number>): number {
 function isConflictError(stderr: string, stdout: string): boolean {
   const text = `${stderr}\n${stdout}`.toLowerCase();
   return (
-    text.includes("already") ||
-    text.includes("exists") ||
-    text.includes("conflict") ||
-    text.includes("in use")
+    text.includes("already in use") ||
+    text.includes("already exists") ||
+    text.includes("port conflict") ||
+    text.includes("address already")
   );
 }
+
+export type TailscaleMode = "serve" | "funnel";
 
 export interface RegisterServeOptions {
   runner?: TailscaleCommandRunner;
 }
 
-/**
- * Register a `tailscale serve` mapping: HTTPS on `httpsPort` proxying to
- * `http://127.0.0.1:<localPort>`. Uses `--bg` so it persists until removed.
- */
+const CONFLICT_MESSAGES: Record<TailscaleMode, string> = {
+  serve: "Stop the existing serve or let portless auto-assign a different port.",
+  funnel: "Tailscale Funnel supports ports 443, 8443, and 10000.",
+};
+
+function register(
+  mode: TailscaleMode,
+  localPort: number,
+  httpsPort: number,
+  runner: TailscaleCommandRunner
+): void {
+  const target = `http://127.0.0.1:${localPort}`;
+  const result = runner([mode, "--bg", "--yes", `--https=${httpsPort}`, target]);
+  if (result.error) {
+    const errno = result.error as NodeJS.ErrnoException;
+    if (errno.code === "ENOENT") {
+      throw new Error(
+        "Tailscale CLI not found. Install Tailscale (https://tailscale.com/download) and ensure `tailscale` is on PATH."
+      );
+    }
+    throw new Error(`Failed to register tailscale ${mode}: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    if (isConflictError(result.stderr, result.stdout)) {
+      throw new Error(
+        `Tailscale ${mode === "funnel" ? "Funnel " : ""}HTTPS port ${httpsPort} is already in use. ` +
+          CONFLICT_MESSAGES[mode]
+      );
+    }
+    const details = normalizeSpace(result.stderr || result.stdout);
+    throw new Error(
+      `Failed to register tailscale ${mode} on port ${httpsPort}: ${details || "unknown tailscale error"}`
+    );
+  }
+}
+
+function unregister(
+  mode: TailscaleMode,
+  httpsPort: number,
+  options?: { ignoreMissing?: boolean; runner?: TailscaleCommandRunner }
+): void {
+  const runner = options?.runner ?? defaultRunner;
+  const result = runner([mode, "--yes", `--https=${httpsPort}`, "off"]);
+  if (result.error) {
+    const errno = result.error as NodeJS.ErrnoException;
+    if (errno.code === "ENOENT") return;
+    throw new Error(`Failed to remove tailscale ${mode}: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const text = `${result.stderr}\n${result.stdout}`.toLowerCase();
+    const looksLikeMissing =
+      text.includes("not found") ||
+      text.includes("no serve config") ||
+      text.includes("nothing to remove") ||
+      text.includes("does not exist");
+    if (options?.ignoreMissing && looksLikeMissing) return;
+    const details = normalizeSpace(result.stderr || result.stdout);
+    throw new Error(
+      `Failed to remove tailscale ${mode} on port ${httpsPort}: ${details || "unknown tailscale error"}`
+    );
+  }
+}
+
 export function registerServe(
   localPort: number,
   httpsPort: number,
   options?: RegisterServeOptions
 ): void {
-  const runner = options?.runner ?? defaultRunner;
-  const target = `http://127.0.0.1:${localPort}`;
-  const result = runner(["serve", "--bg", "--yes", `--https=${httpsPort}`, target]);
-  if (result.error) {
-    const errno = result.error as NodeJS.ErrnoException;
-    if (errno.code === "ENOENT") {
-      throw new Error(
-        "Tailscale CLI not found. Install Tailscale (https://tailscale.com/download) and ensure `tailscale` is on PATH."
-      );
-    }
-    throw new Error(`Failed to register tailscale serve: ${result.error.message}`);
-  }
-  if (result.status !== 0) {
-    if (isConflictError(result.stderr, result.stdout)) {
-      throw new Error(
-        `Tailscale HTTPS port ${httpsPort} is already in use. ` +
-          "Stop the existing serve or let portless auto-assign a different port."
-      );
-    }
-    const details = normalizeSpace(result.stderr || result.stdout);
-    throw new Error(
-      `Failed to register tailscale serve on port ${httpsPort}: ${details || "unknown tailscale error"}`
-    );
-  }
+  register("serve", localPort, httpsPort, options?.runner ?? defaultRunner);
 }
 
-/**
- * Remove a `tailscale serve` mapping on the given HTTPS port.
- */
-export function unregisterServe(
-  httpsPort: number,
-  options?: { ignoreMissing?: boolean; runner?: TailscaleCommandRunner }
-): void {
-  const runner = options?.runner ?? defaultRunner;
-  const result = runner(["serve", "--yes", `--https=${httpsPort}`, "off"]);
-  if (result.error) {
-    const errno = result.error as NodeJS.ErrnoException;
-    if (errno.code === "ENOENT") return;
-    throw new Error(`Failed to remove tailscale serve: ${result.error.message}`);
-  }
-  if (result.status !== 0) {
-    const text = `${result.stderr}\n${result.stdout}`.toLowerCase();
-    const looksLikeMissing =
-      text.includes("not found") ||
-      text.includes("no serve config") ||
-      text.includes("nothing to remove") ||
-      text.includes("does not exist");
-    if (options?.ignoreMissing && looksLikeMissing) return;
-    const details = normalizeSpace(result.stderr || result.stdout);
-    throw new Error(
-      `Failed to remove tailscale serve on port ${httpsPort}: ${details || "unknown tailscale error"}`
-    );
-  }
-}
-
-/**
- * Register a `tailscale funnel` mapping: HTTPS on `httpsPort` proxying to
- * `http://127.0.0.1:<localPort>`. Exposes the service to the public internet.
- */
 export function registerFunnel(
   localPort: number,
   httpsPort: number,
   options?: RegisterServeOptions
 ): void {
-  const runner = options?.runner ?? defaultRunner;
-  const target = `http://127.0.0.1:${localPort}`;
-  const result = runner(["funnel", "--bg", "--yes", `--https=${httpsPort}`, target]);
-  if (result.error) {
-    const errno = result.error as NodeJS.ErrnoException;
-    if (errno.code === "ENOENT") {
-      throw new Error(
-        "Tailscale CLI not found. Install Tailscale (https://tailscale.com/download) and ensure `tailscale` is on PATH."
-      );
-    }
-    throw new Error(`Failed to register tailscale funnel: ${result.error.message}`);
-  }
-  if (result.status !== 0) {
-    if (isConflictError(result.stderr, result.stdout)) {
-      throw new Error(
-        `Tailscale Funnel HTTPS port ${httpsPort} is already in use. ` +
-          "Tailscale Funnel supports ports 443, 8443, and 10000."
-      );
-    }
-    const details = normalizeSpace(result.stderr || result.stdout);
-    throw new Error(
-      `Failed to register tailscale funnel on port ${httpsPort}: ${details || "unknown tailscale error"}`
-    );
-  }
+  register("funnel", localPort, httpsPort, options?.runner ?? defaultRunner);
 }
 
-/**
- * Remove a `tailscale funnel` mapping on the given HTTPS port.
- */
+export function unregisterServe(
+  httpsPort: number,
+  options?: { ignoreMissing?: boolean; runner?: TailscaleCommandRunner }
+): void {
+  unregister("serve", httpsPort, options);
+}
+
 export function unregisterFunnel(
   httpsPort: number,
   options?: { ignoreMissing?: boolean; runner?: TailscaleCommandRunner }
 ): void {
-  const runner = options?.runner ?? defaultRunner;
-  const result = runner(["funnel", "--yes", `--https=${httpsPort}`, "off"]);
-  if (result.error) {
-    const errno = result.error as NodeJS.ErrnoException;
-    if (errno.code === "ENOENT") return;
-    throw new Error(`Failed to remove tailscale funnel: ${result.error.message}`);
-  }
-  if (result.status !== 0) {
-    const text = `${result.stderr}\n${result.stdout}`.toLowerCase();
-    const looksLikeMissing =
-      text.includes("not found") ||
-      text.includes("no serve config") ||
-      text.includes("nothing to remove") ||
-      text.includes("does not exist");
-    if (options?.ignoreMissing && looksLikeMissing) return;
-    const details = normalizeSpace(result.stderr || result.stdout);
-    throw new Error(
-      `Failed to remove tailscale funnel on port ${httpsPort}: ${details || "unknown tailscale error"}`
-    );
-  }
+  unregister("funnel", httpsPort, options);
+}
+
+/**
+ * Best-effort cleanup of a tailscale serve or funnel registration from a
+ * route's metadata. Picks the right subcommand based on `tailscaleFunnel`.
+ */
+export function unregisterTailscale(route: {
+  tailscaleHttpsPort?: number;
+  tailscaleFunnel?: boolean;
+}): void {
+  if (!route.tailscaleHttpsPort) return;
+  const mode: TailscaleMode = route.tailscaleFunnel ? "funnel" : "serve";
+  unregister(mode, route.tailscaleHttpsPort, { ignoreMissing: true });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/portless/src/tailscale.ts
+++ b/packages/portless/src/tailscale.ts
@@ -1,0 +1,338 @@
+import { spawnSync } from "node:child_process";
+
+const TAILSCALE_BINARY = "tailscale";
+
+/**
+ * Port allocation sequence for tailscale serve HTTPS ports.
+ * First app gets 443 (default HTTPS), subsequent apps get 8443+.
+ */
+const PREFERRED_PORTS = [443, 8443, 8444, 8445, 8446, 8447, 8448, 8449, 8450];
+
+interface TailscaleCommandResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  error?: Error;
+}
+
+export type TailscaleCommandRunner = (args: string[]) => TailscaleCommandResult;
+
+interface TailscaleStatusJson {
+  Self?: {
+    DNSName?: string;
+    HostName?: string;
+  };
+  CurrentTailnet?: {
+    MagicDNSSuffix?: string;
+  };
+}
+
+export interface TailscaleReadyResult {
+  dnsName: string;
+  baseUrl: string;
+}
+
+function defaultRunner(args: string[]): TailscaleCommandResult {
+  const result = spawnSync(TAILSCALE_BINARY, args, { encoding: "utf-8" });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    ...(result.error ? { error: result.error } : {}),
+  };
+}
+
+function trimDot(value: string): string {
+  return value.endsWith(".") ? value.slice(0, -1) : value;
+}
+
+function normalizeSpace(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+function runOrThrow(
+  args: string[],
+  action: string,
+  runner: TailscaleCommandRunner
+): TailscaleCommandResult {
+  const result = runner(args);
+  if (result.error) {
+    const errno = result.error as NodeJS.ErrnoException;
+    if (errno.code === "ENOENT") {
+      throw new Error(
+        "Tailscale CLI not found. Install Tailscale (https://tailscale.com/download) and ensure `tailscale` is on PATH."
+      );
+    }
+    throw new Error(`Failed to ${action}: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const details = normalizeSpace(result.stderr || result.stdout);
+    throw new Error(`Failed to ${action}: ${details || "unknown tailscale error"}`);
+  }
+  return result;
+}
+
+function parseStatusJson(raw: string): TailscaleStatusJson {
+  try {
+    return JSON.parse(raw) as TailscaleStatusJson;
+  } catch {
+    throw new Error("Failed to parse `tailscale status --json` output.");
+  }
+}
+
+function statusToDnsName(status: TailscaleStatusJson): string {
+  const dnsName = status.Self?.DNSName;
+  if (typeof dnsName === "string" && dnsName.length > 0) {
+    return trimDot(dnsName);
+  }
+
+  const host = status.Self?.HostName;
+  const suffix = status.CurrentTailnet?.MagicDNSSuffix;
+  if (
+    typeof host === "string" &&
+    host.length > 0 &&
+    typeof suffix === "string" &&
+    suffix.length > 0
+  ) {
+    return `${host}.${trimDot(suffix)}`;
+  }
+
+  throw new Error(
+    "Could not determine Tailscale node DNS name from `tailscale status --json`. Is Tailscale connected?"
+  );
+}
+
+/**
+ * Verify that the Tailscale CLI is installed and the node is connected.
+ * Returns the node's DNS name and base URL.
+ */
+export function ensureTailscaleReady(
+  runner: TailscaleCommandRunner = defaultRunner
+): TailscaleReadyResult {
+  runOrThrow(["version"], "check tailscale version", runner);
+  const statusResult = runOrThrow(["status", "--json"], "read tailscale status", runner);
+  const status = parseStatusJson(statusResult.stdout);
+  const dnsName = statusToDnsName(status);
+  return {
+    dnsName,
+    baseUrl: `https://${dnsName}`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Port allocation
+// ---------------------------------------------------------------------------
+
+interface ServeStatusWeb {
+  [hostPort: string]: {
+    Handlers?: Record<string, unknown>;
+  };
+}
+
+interface ServeStatusJson {
+  Web?: ServeStatusWeb;
+  TCP?: Record<string, unknown>;
+}
+
+/**
+ * Query `tailscale serve status --json` and return the set of HTTPS ports
+ * currently in use.
+ */
+export function getUsedServePorts(runner: TailscaleCommandRunner = defaultRunner): Set<number> {
+  const result = runner(["serve", "status", "--json"]);
+  if (result.error || result.status !== 0) {
+    return new Set();
+  }
+  try {
+    const config = JSON.parse(result.stdout) as ServeStatusJson;
+    const ports = new Set<number>();
+    if (config.Web) {
+      for (const hostPort of Object.keys(config.Web)) {
+        const match = hostPort.match(/:(\d+)$/);
+        if (match) {
+          ports.add(parseInt(match[1], 10));
+        }
+      }
+    }
+    if (config.TCP) {
+      for (const portStr of Object.keys(config.TCP)) {
+        const p = parseInt(portStr, 10);
+        if (!isNaN(p)) ports.add(p);
+      }
+    }
+    return ports;
+  } catch {
+    return new Set();
+  }
+}
+
+/**
+ * Pick the next available HTTPS port from the preferred sequence.
+ * Returns the first port not in `usedPorts`.
+ */
+export function findAvailableServePort(usedPorts: Set<number>): number {
+  for (const port of PREFERRED_PORTS) {
+    if (!usedPorts.has(port)) return port;
+  }
+  // Extend beyond the preferred list
+  let port = PREFERRED_PORTS[PREFERRED_PORTS.length - 1] + 1;
+  while (usedPorts.has(port)) port++;
+  return port;
+}
+
+// ---------------------------------------------------------------------------
+// Register / unregister
+// ---------------------------------------------------------------------------
+
+function isConflictError(stderr: string, stdout: string): boolean {
+  const text = `${stderr}\n${stdout}`.toLowerCase();
+  return (
+    text.includes("already") ||
+    text.includes("exists") ||
+    text.includes("conflict") ||
+    text.includes("in use")
+  );
+}
+
+export interface RegisterServeOptions {
+  runner?: TailscaleCommandRunner;
+}
+
+/**
+ * Register a `tailscale serve` mapping: HTTPS on `httpsPort` proxying to
+ * `http://127.0.0.1:<localPort>`. Uses `--bg` so it persists until removed.
+ */
+export function registerServe(
+  localPort: number,
+  httpsPort: number,
+  options?: RegisterServeOptions
+): void {
+  const runner = options?.runner ?? defaultRunner;
+  const target = `http://127.0.0.1:${localPort}`;
+  const result = runner(["serve", "--bg", "--yes", `--https=${httpsPort}`, target]);
+  if (result.error) {
+    const errno = result.error as NodeJS.ErrnoException;
+    if (errno.code === "ENOENT") {
+      throw new Error(
+        "Tailscale CLI not found. Install Tailscale (https://tailscale.com/download) and ensure `tailscale` is on PATH."
+      );
+    }
+    throw new Error(`Failed to register tailscale serve: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    if (isConflictError(result.stderr, result.stdout)) {
+      throw new Error(
+        `Tailscale HTTPS port ${httpsPort} is already in use. ` +
+          "Stop the existing serve or let portless auto-assign a different port."
+      );
+    }
+    const details = normalizeSpace(result.stderr || result.stdout);
+    throw new Error(
+      `Failed to register tailscale serve on port ${httpsPort}: ${details || "unknown tailscale error"}`
+    );
+  }
+}
+
+/**
+ * Remove a `tailscale serve` mapping on the given HTTPS port.
+ */
+export function unregisterServe(
+  httpsPort: number,
+  options?: { ignoreMissing?: boolean; runner?: TailscaleCommandRunner }
+): void {
+  const runner = options?.runner ?? defaultRunner;
+  const result = runner(["serve", "--yes", `--https=${httpsPort}`, "off"]);
+  if (result.error) {
+    const errno = result.error as NodeJS.ErrnoException;
+    if (errno.code === "ENOENT") return;
+    throw new Error(`Failed to remove tailscale serve: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const text = `${result.stderr}\n${result.stdout}`.toLowerCase();
+    const looksLikeMissing =
+      text.includes("not found") ||
+      text.includes("no serve config") ||
+      text.includes("nothing to remove") ||
+      text.includes("does not exist");
+    if (options?.ignoreMissing && looksLikeMissing) return;
+    const details = normalizeSpace(result.stderr || result.stdout);
+    throw new Error(
+      `Failed to remove tailscale serve on port ${httpsPort}: ${details || "unknown tailscale error"}`
+    );
+  }
+}
+
+/**
+ * Register a `tailscale funnel` mapping: HTTPS on `httpsPort` proxying to
+ * `http://127.0.0.1:<localPort>`. Exposes the service to the public internet.
+ */
+export function registerFunnel(
+  localPort: number,
+  httpsPort: number,
+  options?: RegisterServeOptions
+): void {
+  const runner = options?.runner ?? defaultRunner;
+  const target = `http://127.0.0.1:${localPort}`;
+  const result = runner(["funnel", "--bg", "--yes", `--https=${httpsPort}`, target]);
+  if (result.error) {
+    const errno = result.error as NodeJS.ErrnoException;
+    if (errno.code === "ENOENT") {
+      throw new Error(
+        "Tailscale CLI not found. Install Tailscale (https://tailscale.com/download) and ensure `tailscale` is on PATH."
+      );
+    }
+    throw new Error(`Failed to register tailscale funnel: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    if (isConflictError(result.stderr, result.stdout)) {
+      throw new Error(
+        `Tailscale Funnel HTTPS port ${httpsPort} is already in use. ` +
+          "Tailscale Funnel supports ports 443, 8443, and 10000."
+      );
+    }
+    const details = normalizeSpace(result.stderr || result.stdout);
+    throw new Error(
+      `Failed to register tailscale funnel on port ${httpsPort}: ${details || "unknown tailscale error"}`
+    );
+  }
+}
+
+/**
+ * Remove a `tailscale funnel` mapping on the given HTTPS port.
+ */
+export function unregisterFunnel(
+  httpsPort: number,
+  options?: { ignoreMissing?: boolean; runner?: TailscaleCommandRunner }
+): void {
+  const runner = options?.runner ?? defaultRunner;
+  const result = runner(["funnel", "--yes", `--https=${httpsPort}`, "off"]);
+  if (result.error) {
+    const errno = result.error as NodeJS.ErrnoException;
+    if (errno.code === "ENOENT") return;
+    throw new Error(`Failed to remove tailscale funnel: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const text = `${result.stderr}\n${result.stdout}`.toLowerCase();
+    const looksLikeMissing =
+      text.includes("not found") ||
+      text.includes("no serve config") ||
+      text.includes("nothing to remove") ||
+      text.includes("does not exist");
+    if (options?.ignoreMissing && looksLikeMissing) return;
+    const details = normalizeSpace(result.stderr || result.stdout);
+    throw new Error(
+      `Failed to remove tailscale funnel on port ${httpsPort}: ${details || "unknown tailscale error"}`
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// URL formatting
+// ---------------------------------------------------------------------------
+
+/** Build a display URL, omitting the port for 443 (default HTTPS). */
+export function formatTailscaleUrl(baseUrl: string, httpsPort: number): string {
+  const trimmed = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
+  if (httpsPort === 443) return trimmed;
+  return `${trimmed}:${httpsPort}`;
+}

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -171,17 +171,19 @@ Portless stores its state (routes, PID file, port file) in `~/.portless`. Overri
 
 ### Environment variables
 
-| Variable              | Description                                                           |
-| --------------------- | --------------------------------------------------------------------- |
-| `PORTLESS_PORT`       | Override the default proxy port (default: 443 with HTTPS, 80 without) |
-| `PORTLESS_APP_PORT`   | Use a fixed port for the app (skip auto-assignment)                   |
-| `PORTLESS_HTTPS`      | HTTPS on by default; set to `0` to disable (same as `--no-tls`)       |
-| `PORTLESS_LAN`        | Set to `1` to always enable LAN mode (auto-detects LAN IP)            |
-| `PORTLESS_TLD`        | Use a custom TLD instead of localhost (e.g. test)                     |
-| `PORTLESS_WILDCARD`   | Set to `1` to allow unregistered subdomains to fall back to parent    |
-| `PORTLESS_SYNC_HOSTS` | Set to `0` to disable auto-sync of /etc/hosts (on by default)         |
-| `PORTLESS_STATE_DIR`  | Override the state directory                                          |
-| `PORTLESS=0`          | Bypass the proxy, run the command directly                            |
+| Variable              | Description                                                                 |
+| --------------------- | --------------------------------------------------------------------------- |
+| `PORTLESS_PORT`       | Override the default proxy port (default: 443 with HTTPS, 80 without)       |
+| `PORTLESS_APP_PORT`   | Use a fixed port for the app (skip auto-assignment)                         |
+| `PORTLESS_HTTPS`      | HTTPS on by default; set to `0` to disable (same as `--no-tls`)             |
+| `PORTLESS_LAN`        | Set to `1` to always enable LAN mode (auto-detects LAN IP)                  |
+| `PORTLESS_TLD`        | Use a custom TLD instead of localhost (e.g. test)                           |
+| `PORTLESS_WILDCARD`   | Set to `1` to allow unregistered subdomains to fall back to parent          |
+| `PORTLESS_SYNC_HOSTS` | Set to `0` to disable auto-sync of /etc/hosts (on by default)               |
+| `PORTLESS_TAILSCALE`  | Set to `1` to share apps on your Tailscale network (same as `--tailscale`)  |
+| `PORTLESS_FUNNEL`     | Set to `1` to share apps publicly via Tailscale Funnel (same as `--funnel`) |
+| `PORTLESS_STATE_DIR`  | Override the state directory                                                |
+| `PORTLESS=0`          | Bypass the proxy, run the command directly                                  |
 
 ### HTTP/2 + HTTPS
 
@@ -220,6 +222,22 @@ LAN mode depends on the system mDNS helpers that portless launches: macOS includ
 
 - **Expo / React Native**: portless always injects `--port`. React Native also gets `--host 127.0.0.1`. Expo gets `--host localhost` outside LAN mode, but in LAN mode portless leaves Metro on its default LAN host behavior instead of forcing `--host` or `HOST`.
 
+### Tailscale sharing
+
+Share dev servers with teammates on your Tailscale network using `--tailscale`, or expose to the public internet with `--funnel`:
+
+```bash
+portless myapp --tailscale next dev
+# -> https://myapp.localhost           (local)
+# -> https://devbox.yourteam.ts.net    (tailnet)
+
+portless myapp --funnel next dev
+# -> https://myapp.localhost           (local)
+# -> https://devbox.yourteam.ts.net    (public internet)
+```
+
+Each `--tailscale` app is root-mounted on its own Tailscale HTTPS port (443, then 8443, 8444, etc.) so no framework `basePath` configuration is needed. Set `PORTLESS_TAILSCALE=1` to share every app by default. `portless list` shows both local and tailnet URLs. Tailscale serve registrations are cleaned up when the app exits. Requires `tailscale` CLI installed and connected.
+
 ## CLI Reference
 
 | Command                                | Description                                                    |
@@ -251,6 +269,8 @@ LAN mode depends on the system mDNS helpers that portless launches: macOS includ
 | `portless hosts sync`                  | Add routes to /etc/hosts (fixes Safari)                        |
 | `portless hosts clean`                 | Remove portless entries from /etc/hosts                        |
 | `portless <name> --app-port <n> <cmd>` | Use a fixed port for the app instead of auto-assignment        |
+| `portless <name> --tailscale <cmd>`    | Share the app on your Tailscale network (tailnet)              |
+| `portless <name> --funnel <cmd>`       | Share the app publicly via Tailscale Funnel                    |
 | `portless <name> --force <cmd>`        | Kill the existing process and take over its route              |
 | `portless --name <name> <cmd>`         | Force `<name>` as app name (bypasses subcommand dispatch)      |
 | `portless <name> -- <cmd> [args...]`   | Stop flag parsing; everything after `--` is passed to child    |
@@ -378,8 +398,20 @@ proxy: {
 
 Portless automatically sets `NODE_EXTRA_CA_CERTS` in child processes so Node.js trusts the portless CA. If you run a separate Node.js process outside portless, point it at the CA manually: `NODE_EXTRA_CA_CERTS=~/.portless/ca.pem`. Alternatively, use `--no-tls` for plain HTTP.
 
+### Tailscale not working
+
+If `--tailscale` or `--funnel` fails:
+
+```bash
+tailscale status     # Check if connected
+tailscale up         # Connect to your tailnet
+```
+
+Requires the Tailscale CLI to be installed (https://tailscale.com/download) and on PATH.
+
 ### Requirements
 
 - Node.js 20+
 - macOS, Linux, or Windows
 - `openssl` (for `--https` cert generation; ships with macOS and most Linux distributions; on Windows, install via `winget install -e --id ShiningLight.OpenSSL.Dev` or use the copy bundled with Git for Windows)
+- `tailscale` CLI (optional, for `--tailscale` and `--funnel`)


### PR DESCRIPTION
## Summary

- Adds `--tailscale` and `--funnel` flags that let any portless app be shared over Tailscale with zero framework config
- Each app is root-mounted on its own Tailscale HTTPS port (443, 8443, 8444, ...) so no `basePath` configuration is needed
- Includes readiness checks, auto port allocation, stale serve cleanup, and 41 new tests

## Details

**New `tailscale.ts` module** encapsulates all `tailscale` CLI interactions with an injectable `TailscaleCommandRunner` for testability. Handles readiness checks, port allocation from a preferred pool, and serve/funnel registration and cleanup.

**CLI integration** supports three placement styles:

```bash
portless --tailscale myapp next dev    # global flag
portless myapp --tailscale next dev    # per-app flag
PORTLESS_TAILSCALE=1 portless myapp next dev  # env var
```

`--funnel` implies `--tailscale` and exposes the app publicly via Tailscale Funnel.

**Root-mount per HTTPS port** was chosen over path-based routing (`--set-path`) because frontend frameworks expect assets at absolute paths. Mounting at root avoids `basePath` configuration entirely.

**Route metadata** extended with optional `tailscaleUrl`, `tailscaleHttpsPort`, and `tailscaleFunnel` fields. `portless list` displays tailnet URLs alongside local URLs.

**Lifecycle management**: `portless prune` and `portless clean` remove stale `tailscale serve` registrations. `PORTLESS_TAILSCALE_URL` is injected into child process environment so apps can discover their public URL.