### PR TITLE
Add multiplexed hostname routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ portless myapp next dev
 portless myapp vite dev
 ```
 
-If only one `myapp.localhost` app is running, requests go straight to it. If more than one app is running, portless shows a selector page the first time you visit the hostname. Your choice is stored in a host-scoped cookie so page loads, assets, API requests, and WebSockets keep going to the selected app. HTML responses also get a collapsed portless switcher that follows the system theme. Expand it to change the selected app and inspect host, port, PID, git branch, folder, and command details.
+If only one `myapp.localhost` app is running, requests go straight to it. If more than one app is running, portless shows a selector page the first time you visit the hostname, including host, port, PID, git branch, folder, and command details for each app. Your choice is stored in a host-scoped cookie so page loads, assets, API requests, and WebSockets keep going to the selected app. HTML responses also get a collapsed portless switcher that follows the system theme. Expand it to change or clear the selected app and inspect the same details.
 
 ## Git Worktrees
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ portless myapp next dev
 portless myapp vite dev
 ```
 
-If only one `myapp.localhost` app is running, requests go straight to it. If more than one app is running, portless shows a selector page the first time you visit the hostname. Your choice is stored in a host-scoped cookie so page loads, assets, API requests, and WebSockets keep going to the selected app. HTML responses also get a small portless switcher so you can change the selected app without clearing cookies.
+If only one `myapp.localhost` app is running, requests go straight to it. If more than one app is running, portless shows a selector page the first time you visit the hostname. Your choice is stored in a host-scoped cookie so page loads, assets, API requests, and WebSockets keep going to the selected app. HTML responses also get a collapsed portless switcher that follows the system theme. Expand it to change the selected app and inspect host, port, PID, git branch, folder, and command details.
 
 ## Git Worktrees
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,18 @@ portless docs.myapp next dev
 
 By default, only explicitly registered subdomains are routed (strict mode). Use `--wildcard` when starting the proxy to allow any subdomain of a registered route to fall back to that app (e.g. `tenant1.myapp.localhost` routes to the `myapp` app without extra registration).
 
+## Multiplexed Hostnames
+
+By default, registering the same hostname twice is a conflict. Start the proxy with `--multiplex` to allow multiple apps to share one hostname:
+
+```bash
+portless proxy start --multiplex
+portless myapp next dev
+portless myapp vite dev
+```
+
+If only one `myapp.localhost` app is running, requests go straight to it. If more than one app is running, portless shows a selector page the first time you visit the hostname. Your choice is stored in a host-scoped cookie so page loads, assets, API requests, and WebSockets keep going to the selected app. HTML responses also get a small portless switcher so you can change the selected app without clearing cookies.
+
 ## Git Worktrees
 
 `portless run` automatically detects git worktrees. In a linked worktree, the branch name is prepended as a subdomain so each worktree gets its own URL without any config changes:
@@ -331,6 +343,7 @@ portless proxy start --lan       # Start in LAN mode (mDNS .local for devices)
 portless proxy start -p 1355     # Start on a custom port (no sudo)
 portless proxy start --foreground  # Start in foreground (for debugging)
 portless proxy start --wildcard  # Allow unregistered subdomains to fall back to parent
+portless proxy start --multiplex # Allow multiple apps to share one hostname
 portless proxy stop              # Stop the proxy
 ```
 
@@ -347,6 +360,7 @@ portless proxy stop              # Stop the proxy
 --foreground                     Run proxy in foreground instead of daemon
 --tld <tld>                      Use a custom TLD instead of .localhost (e.g. test)
 --wildcard                       Allow unregistered subdomains to fall back to parent route
+--multiplex                      Allow multiple apps to share one hostname
 --script <name>                  Run a specific package.json script (default: dev)
 --app-port <number>              Use a fixed port for the app (skip auto-assignment)
 --tailscale                      Share the app on your Tailscale network (tailnet)
@@ -365,6 +379,7 @@ PORTLESS_HTTPS=0                 Disable HTTPS (same as --no-tls)
 PORTLESS_LAN=1                   Enable LAN mode when set to 1 (auto-detects LAN IP)
 PORTLESS_TLD=<tld>               Use a custom TLD (e.g. test; default: localhost)
 PORTLESS_WILDCARD=1              Allow unregistered subdomains to fall back to parent route
+PORTLESS_MULTIPLEX=1             Allow multiple apps to share one hostname
 PORTLESS_SYNC_HOSTS=0            Disable auto-sync of /etc/hosts (on by default)
 PORTLESS_TAILSCALE=1             Share apps on your Tailscale network (same as --tailscale)
 PORTLESS_FUNNEL=1                Share apps publicly via Tailscale Funnel (same as --funnel)

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -29,6 +29,7 @@ import {
   resolveStateDir,
   validateTld,
   writeLanMarker,
+  writeMultiplexMarker,
   writeTldFile,
   writeTlsMarker,
 } from "./cli-utils.js";
@@ -773,6 +774,7 @@ describe("buildProxyStartConfig", () => {
         lanIpExplicit: true,
         tld: "test",
         useWildcard: true,
+        multiplex: true,
         foreground: true,
         includePort: true,
         proxyPort: 8080,
@@ -788,6 +790,7 @@ describe("buildProxyStartConfig", () => {
         "--ip",
         "192.168.1.42",
         "--wildcard",
+        "--multiplex",
       ],
     });
   });
@@ -859,7 +862,6 @@ describe("readLanMarker / writeLanMarker", () => {
         port: 1355,
         tld: "local",
         lanMode: true,
-        lanIp: null,
       });
     } finally {
       if (prevStateDir === undefined) {
@@ -993,6 +995,14 @@ describe("readPersistedProxyState", () => {
     expect(state!.lanMode).toBe(true);
   });
 
+  it("reads multiplex mode from persisted state", () => {
+    fs.writeFileSync(path.join(tmpDir, "proxy.port"), "1355");
+    writeMultiplexMarker(tmpDir, true);
+    const state = readPersistedProxyState();
+    expect(state).not.toBeNull();
+    expect(state!.multiplex).toBe(true);
+  });
+
   it("returns full previous config for a custom proxy setup", () => {
     fs.writeFileSync(path.join(tmpDir, "proxy.port"), "1355");
     writeTlsMarker(tmpDir, true);
@@ -1004,6 +1014,7 @@ describe("readPersistedProxyState", () => {
       tls: true,
       tld: "local",
       lanMode: true,
+      multiplex: false,
     });
   });
 });

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -852,16 +852,18 @@ describe("readLanMarker / writeLanMarker", () => {
   it("uses the LAN marker to remember LAN mode when the proxy is stopped", async () => {
     const prevStateDir = process.env.PORTLESS_STATE_DIR;
     try {
-      fs.writeFileSync(path.join(tmpDir, "proxy.port"), "1355");
+      const port = await findFreePort();
+      fs.writeFileSync(path.join(tmpDir, "proxy.port"), String(port));
       writeTldFile(tmpDir, "local");
       writeLanMarker(tmpDir, "192.168.1.42");
       process.env.PORTLESS_STATE_DIR = tmpDir;
 
       await expect(discoverState()).resolves.toMatchObject({
         dir: tmpDir,
-        port: 1355,
+        port,
         tld: "local",
         lanMode: true,
+        lanIp: null,
       });
     } finally {
       if (prevStateDir === undefined) {

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -227,6 +227,29 @@ export function writeLanMarker(dir: string, ip: string | null): void {
   }
 }
 
+const MULTIPLEX_MARKER_FILE = "proxy.multiplex";
+
+export function readMultiplexMarker(dir: string): boolean {
+  try {
+    return fs.existsSync(path.join(dir, MULTIPLEX_MARKER_FILE));
+  } catch {
+    return false;
+  }
+}
+
+export function writeMultiplexMarker(dir: string, enabled: boolean): void {
+  const markerPath = path.join(dir, MULTIPLEX_MARKER_FILE);
+  if (enabled) {
+    fs.writeFileSync(markerPath, "1", { mode: 0o644 });
+  } else {
+    try {
+      fs.unlinkSync(markerPath);
+    } catch {
+      // Marker may already be absent; non-fatal
+    }
+  }
+}
+
 /** Default TLD when PORTLESS_TLD is not set. */
 export const DEFAULT_TLD = "localhost";
 
@@ -323,6 +346,11 @@ export function isWildcardEnvEnabled(): boolean {
   return val === "1" || val === "true";
 }
 
+export function isMultiplexEnvEnabled(): boolean {
+  const val = process.env.PORTLESS_MULTIPLEX;
+  return val === "1" || val === "true";
+}
+
 /**
  * Return whether LAN mode is requested via the PORTLESS_LAN env var.
  */
@@ -344,6 +372,7 @@ export function readPersistedProxyState(): {
   tls: boolean;
   tld: string;
   lanMode: boolean;
+  multiplex: boolean;
 } | null {
   const dir = process.env.PORTLESS_STATE_DIR || USER_STATE_DIR;
   const port = readPortFromDir(dir);
@@ -351,7 +380,8 @@ export function readPersistedProxyState(): {
     const tls = readTlsMarker(dir);
     const tld = readTldFromDir(dir);
     const lanIp = readLanMarker(dir);
-    return { port, tls, tld, lanMode: lanIp !== null || tld === "local" };
+    const multiplex = readMultiplexMarker(dir);
+    return { port, tls, tld, lanMode: lanIp !== null || tld === "local", multiplex };
   }
 
   return null;
@@ -366,6 +396,7 @@ export function buildProxyStartConfig(options: {
   lanIpExplicit?: boolean;
   tld: string;
   useWildcard?: boolean;
+  multiplex?: boolean;
   foreground?: boolean;
   includePort?: boolean;
   proxyPort?: number;
@@ -409,6 +440,10 @@ export function buildProxyStartConfig(options: {
     args.push("--wildcard");
   }
 
+  if (options.multiplex) {
+    args.push("--multiplex");
+  }
+
   if (options.skipTrust) {
     args.push("--skip-trust");
   }
@@ -429,6 +464,7 @@ export async function discoverState(): Promise<{
   tld: string;
   lanMode: boolean;
   lanIp: string | null;
+  multiplex: boolean;
 }> {
   // Env var override
   if (process.env.PORTLESS_STATE_DIR) {
@@ -438,7 +474,8 @@ export async function discoverState(): Promise<{
     if ((await isProxyRunning(port)) || (await isPortListening(port))) {
       const tls = readTlsMarker(dir);
       const tld = readTldFromDir(dir);
-      return { dir, port, tls, tld, lanMode: lanIp !== null || tld === "local", lanIp };
+      const multiplex = readMultiplexMarker(dir);
+      return { dir, port, tls, tld, lanMode: lanIp !== null || tld === "local", lanIp, multiplex };
     }
 
     return {
@@ -448,6 +485,7 @@ export async function discoverState(): Promise<{
       tld: readTldFromDir(dir),
       lanMode: lanIp !== null,
       lanIp: null,
+      multiplex: readMultiplexMarker(dir),
     };
   }
 
@@ -461,6 +499,7 @@ export async function discoverState(): Promise<{
       const tls = readTlsMarker(USER_STATE_DIR);
       const tld = readTldFromDir(USER_STATE_DIR);
       const lanIp = readLanMarker(USER_STATE_DIR);
+      const multiplex = readMultiplexMarker(USER_STATE_DIR);
       return {
         dir: USER_STATE_DIR,
         port: userPort,
@@ -468,6 +507,7 @@ export async function discoverState(): Promise<{
         tld,
         lanMode: lanIp !== null || tld === "local",
         lanIp,
+        multiplex,
       };
     }
   }
@@ -480,6 +520,7 @@ export async function discoverState(): Promise<{
       const tls = readTlsMarker(LEGACY_SYSTEM_STATE_DIR);
       const tld = readTldFromDir(LEGACY_SYSTEM_STATE_DIR);
       const lanIp = readLanMarker(LEGACY_SYSTEM_STATE_DIR);
+      const multiplex = readMultiplexMarker(LEGACY_SYSTEM_STATE_DIR);
       return {
         dir: LEGACY_SYSTEM_STATE_DIR,
         port: legacyPort,
@@ -487,6 +528,7 @@ export async function discoverState(): Promise<{
         tld,
         lanMode: lanIp !== null || tld === "local",
         lanIp,
+        multiplex,
       };
     }
   }
@@ -505,7 +547,8 @@ export async function discoverState(): Promise<{
       const tls = markerTls || port === getProtocolPort(true);
       const tld = readTldFromDir(dir);
       const lanIp = readLanMarker(dir);
-      return { dir, port, tls, tld, lanMode: lanIp !== null || tld === "local", lanIp };
+      const multiplex = readMultiplexMarker(dir);
+      return { dir, port, tls, tld, lanMode: lanIp !== null || tld === "local", lanIp, multiplex };
     }
   }
 
@@ -517,6 +560,7 @@ export async function discoverState(): Promise<{
     tld: readTldFromDir(dir),
     lanMode: readLanMarker(dir) !== null,
     lanIp: null,
+    multiplex: readMultiplexMarker(dir),
   };
 }
 

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -520,7 +520,6 @@ export async function discoverState(): Promise<{
       const tls = readTlsMarker(LEGACY_SYSTEM_STATE_DIR);
       const tld = readTldFromDir(LEGACY_SYSTEM_STATE_DIR);
       const lanIp = readLanMarker(LEGACY_SYSTEM_STATE_DIR);
-      const multiplex = readMultiplexMarker(LEGACY_SYSTEM_STATE_DIR);
       return {
         dir: LEGACY_SYSTEM_STATE_DIR,
         port: legacyPort,
@@ -528,7 +527,7 @@ export async function discoverState(): Promise<{
         tld,
         lanMode: lanIp !== null || tld === "local",
         lanIp,
-        multiplex,
+        multiplex: false,
       };
     }
   }

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -1279,6 +1279,23 @@ describe("CLI", () => {
       expect(stdout).toContain("from-start");
     });
 
+    it("--multiplex is accepted as a global flag", () => {
+      const { status, stdout } = run(
+        [
+          "--multiplex",
+          "run",
+          process.execPath,
+          "-e",
+          "console.log(process.env.PORTLESS_MULTIPLEX)",
+        ],
+        {
+          env: { PORTLESS: "0" },
+        }
+      );
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe("1");
+    });
+
     it("--name overrides portless.json name", () => {
       fs.writeFileSync(
         path.join(tmpDir, "package.json"),

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -101,6 +101,26 @@ import type { ManifestEntry } from "./turbo.js";
 
 const chalk = colors;
 
+function getGitBranch(cwd: string): string | undefined {
+  const result = spawnSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+    cwd,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  if (result.status !== 0) return undefined;
+  const branch = result.stdout.trim();
+  return branch && branch !== "HEAD" ? branch : undefined;
+}
+
+function getRouteMetadata(cwd: string, commandArgs: string[]) {
+  return {
+    cwd,
+    folder: path.basename(cwd),
+    gitBranch: getGitBranch(cwd),
+    command: commandArgs.join(" "),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -1093,7 +1113,14 @@ async function runApp(
   // Register route (--force kills the existing owner if any)
   let killedPid: number | undefined;
   try {
-    killedPid = store.addRoute(hostname, port, process.pid, force, multiplex);
+    killedPid = store.addRoute(
+      hostname,
+      port,
+      process.pid,
+      force,
+      multiplex,
+      getRouteMetadata(process.cwd(), commandArgs)
+    );
   } catch (err) {
     if (err instanceof RouteConflictError) {
       console.error(colors.red(`Error: ${err.message}`));
@@ -1232,7 +1259,7 @@ async function runApp(
         // Best-effort cleanup; non-fatal
       }
       try {
-        store.removeRoute(hostname, process.pid);
+        store.removeRoute(hostname, process.pid, port);
       } catch {
         // Lock acquisition may fail during cleanup; non-fatal
       }
@@ -2825,7 +2852,14 @@ async function spawnProxiedApp(
     displayUrl = url;
 
     hostname = parseHostname(app.name, tld);
-    store.addRoute(hostname, appPort, process.pid, false, multiplex);
+    store.addRoute(
+      hostname,
+      appPort,
+      process.pid,
+      false,
+      multiplex,
+      getRouteMetadata(app.pkg.dir, app.commandArgs)
+    );
 
     env = {
       ...pkgEnv,
@@ -3094,7 +3128,14 @@ async function runWithTurbo(
     appUrls.push({ label: app.label, url });
 
     const hostname = parseHostname(app.name, tld);
-    store.addRoute(hostname, appPort, process.pid, false, multiplex);
+    store.addRoute(
+      hostname,
+      appPort,
+      process.pid,
+      false,
+      multiplex,
+      getRouteMetadata(app.pkg.dir, app.commandArgs)
+    );
     routes.push({ hostname, port: appPort });
 
     const entry: ManifestEntry = {

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -45,6 +45,7 @@ import {
   getDefaultTld,
   injectFrameworkFlags,
   isHttpsEnvDisabled,
+  isMultiplexEnvEnabled,
   isPortListening,
   isWildcardEnvEnabled,
   isLanEnvEnabled,
@@ -52,6 +53,7 @@ import {
   isWindows,
   killTree,
   readLanMarker,
+  readMultiplexMarker,
   readPersistedProxyState,
   readTldFromDir,
   readTlsMarker,
@@ -61,6 +63,7 @@ import {
   validateTld,
   waitForProxy,
   writeLanMarker,
+  writeMultiplexMarker,
   writeTldFile,
   writeTlsMarker,
 } from "./cli-utils.js";
@@ -124,6 +127,7 @@ type ProxyConfigExplicitness = {
   lanIp: boolean;
   tld: boolean;
   useWildcard: boolean;
+  multiplex: boolean;
 };
 
 type ProxyConfig = {
@@ -135,6 +139,7 @@ type ProxyConfig = {
   lanIpExplicit: boolean;
   tld: string;
   useWildcard: boolean;
+  multiplex: boolean;
 };
 
 function defaultProxyConfig(tld: string, useHttps: boolean, lanMode: boolean): ProxyConfig {
@@ -147,6 +152,7 @@ function defaultProxyConfig(tld: string, useHttps: boolean, lanMode: boolean): P
     lanIpExplicit: false,
     tld: lanMode ? "local" : tld,
     useWildcard: false,
+    multiplex: false,
   };
 }
 
@@ -161,6 +167,7 @@ function resolveProxyConfig(options: {
   lanIp: string | null;
   tld: string;
   useWildcard: boolean;
+  multiplex: boolean;
 }): ProxyConfig {
   const config = defaultProxyConfig(
     options.defaultTld,
@@ -207,6 +214,10 @@ function resolveProxyConfig(options: {
     config.useWildcard = options.useWildcard;
   }
 
+  if (options.explicit.multiplex) {
+    config.multiplex = options.multiplex;
+  }
+
   if (!config.lanMode) {
     config.lanIp = null;
     config.lanIpExplicit = false;
@@ -240,6 +251,7 @@ function readCurrentProxyConfig(dir: string): ProxyConfig {
     lanIpExplicit: false,
     tld,
     useWildcard: false,
+    multiplex: readMultiplexMarker(dir),
   };
 }
 
@@ -278,6 +290,14 @@ function getProxyConfigMismatchMessages(
     );
   }
 
+  if (explicit.multiplex && desiredConfig.multiplex !== actualConfig.multiplex) {
+    messages.push(
+      desiredConfig.multiplex
+        ? "requested multiplex mode, but the running proxy is not using multiplex mode"
+        : "requested non-multiplex mode, but the running proxy is using multiplex mode"
+    );
+  }
+
   return messages;
 }
 
@@ -292,6 +312,7 @@ function formatProxyStartCommand(proxyPort: number, config: ProxyConfig): string
     lanIpExplicit: config.lanIpExplicit,
     tld: config.tld,
     useWildcard: config.useWildcard,
+    multiplex: config.multiplex,
     includePort: proxyPort !== getDefaultPort(config.useHttps),
     proxyPort,
   });
@@ -384,7 +405,8 @@ function startProxyServer(
   tld: string,
   tlsOptions?: { cert: Buffer; key: Buffer },
   lanIp?: string | null,
-  strict?: boolean
+  strict?: boolean,
+  multiplex = false
 ): void {
   store.ensureDir();
 
@@ -501,6 +523,7 @@ function startProxyServer(
     proxyPort,
     tld,
     strict,
+    multiplex,
     onError: (msg) => console.error(colors.red(msg)),
     tls: tlsOptions,
   });
@@ -546,12 +569,16 @@ function startProxyServer(
     writeTlsMarker(store.dir, isTls);
     writeTldFile(store.dir, tld);
     writeLanMarker(store.dir, activeLanIp);
+    writeMultiplexMarker(store.dir, multiplex);
     fixOwnership(store.dir, store.pidPath, store.portFilePath);
     const proto = isTls ? "HTTPS/2" : "HTTP";
     const tldLabel = tld !== DEFAULT_TLD ? ` (TLD: .${tld})` : "";
     const modeLabel = strict === false ? " (wildcard)" : "";
+    const multiplexLabel = multiplex ? " (multiplex)" : "";
     console.log(
-      colors.green(`${proto} proxy listening on port ${proxyPort}${tldLabel}${modeLabel}`)
+      colors.green(
+        `${proto} proxy listening on port ${proxyPort}${tldLabel}${modeLabel}${multiplexLabel}`
+      )
     );
     if (activeLanIp) {
       console.log(chalk.green(`LAN mode: ${activeLanIp}`));
@@ -604,6 +631,7 @@ function startProxyServer(
     writeTlsMarker(store.dir, false);
     writeTldFile(store.dir, DEFAULT_TLD);
     writeLanMarker(store.dir, null);
+    writeMultiplexMarker(store.dir, false);
     if (autoSyncHosts) cleanHostsFile();
     server.close(() => process.exit(0));
     // Force exit after a short timeout in case connections don't drain
@@ -656,6 +684,7 @@ async function stopProxy(store: RouteStore, proxyPort: number, _tls: boolean): P
           writeTlsMarker(store.dir, false);
           writeTldFile(store.dir, DEFAULT_TLD);
           writeLanMarker(store.dir, null);
+          writeMultiplexMarker(store.dir, false);
           console.log(colors.green(`Killed process ${pid}. Proxy stopped.`));
         } catch (err: unknown) {
           if (isErrnoException(err) && err.code === "EPERM") {
@@ -696,6 +725,7 @@ async function stopProxy(store: RouteStore, proxyPort: number, _tls: boolean): P
       writeTlsMarker(store.dir, false);
       writeTldFile(store.dir, DEFAULT_TLD);
       writeLanMarker(store.dir, null);
+      writeMultiplexMarker(store.dir, false);
       return;
     }
 
@@ -717,6 +747,7 @@ async function stopProxy(store: RouteStore, proxyPort: number, _tls: boolean): P
       writeTlsMarker(store.dir, false);
       writeTldFile(store.dir, DEFAULT_TLD);
       writeLanMarker(store.dir, null);
+      writeMultiplexMarker(store.dir, false);
       return;
     }
 
@@ -734,6 +765,7 @@ async function stopProxy(store: RouteStore, proxyPort: number, _tls: boolean): P
       writeTlsMarker(store.dir, false);
       writeTldFile(store.dir, DEFAULT_TLD);
       writeLanMarker(store.dir, null);
+      writeMultiplexMarker(store.dir, false);
       return;
     }
 
@@ -747,6 +779,7 @@ async function stopProxy(store: RouteStore, proxyPort: number, _tls: boolean): P
     writeTlsMarker(store.dir, false);
     writeTldFile(store.dir, DEFAULT_TLD);
     writeLanMarker(store.dir, null);
+    writeMultiplexMarker(store.dir, false);
     console.log(colors.green("Proxy stopped."));
   } catch (err: unknown) {
     if (isErrnoException(err) && err.code === "EPERM") {
@@ -807,6 +840,7 @@ function resolveProxyDesiredState(lanMode: boolean): ProxyDesiredState {
     lanIp: process.env.PORTLESS_LAN_IP !== undefined,
     tld: process.env.PORTLESS_TLD !== undefined,
     useWildcard: process.env.PORTLESS_WILDCARD !== undefined,
+    multiplex: process.env.PORTLESS_MULTIPLEX !== undefined,
   };
   const desiredConfig = resolveProxyConfig({
     persistedLanMode: lanMode,
@@ -819,6 +853,7 @@ function resolveProxyDesiredState(lanMode: boolean): ProxyDesiredState {
     lanIp: process.env.PORTLESS_LAN_IP || null,
     tld: envTld,
     useWildcard: isWildcardEnvEnabled(),
+    multiplex: isMultiplexEnvEnabled(),
   });
   return { explicit, desiredConfig, envTld };
 }
@@ -857,6 +892,9 @@ async function ensureProxyRunning(
     if (!explicit.lanMode && persisted.lanMode !== desiredConfig.lanMode) {
       startConfig.lanMode = persisted.lanMode;
     }
+    if (!explicit.multiplex && persisted.multiplex !== desiredConfig.multiplex) {
+      startConfig.multiplex = persisted.multiplex;
+    }
     const envPort = getDefaultPort(startConfig.useHttps);
     if (persisted.port !== envPort) {
       startPort = persisted.port;
@@ -893,6 +931,7 @@ async function ensureProxyRunning(
     lanIpExplicit: startConfig.lanIpExplicit,
     tld: startConfig.tld,
     useWildcard: startConfig.useWildcard,
+    multiplex: startConfig.multiplex,
     includePort: startPort !== undefined,
     proxyPort: startPort,
   });
@@ -943,7 +982,8 @@ async function runApp(
   autoInfo?: { nameSource: string; prefix?: string; prefixSource?: string },
   desiredPort?: number,
   lanMode = false,
-  lanIp?: string | null
+  lanIp?: string | null,
+  multiplex = false
 ) {
   let store = initialStore;
   console.log(chalk.blue.bold(`\nportless\n`));
@@ -994,6 +1034,7 @@ async function runApp(
     tls = ensureResult.state.tls;
     lanMode = ensureResult.state.lanMode;
     lanIp = ensureResult.state.lanIp;
+    multiplex = ensureResult.state.multiplex;
     store = new RouteStore(stateDir, {
       onWarning: (msg: string) => console.warn(colors.yellow(msg)),
     });
@@ -1013,6 +1054,7 @@ async function runApp(
     }
     lanMode = runningConfig.lanMode;
     lanIp = runningConfig.lanIp;
+    multiplex = runningConfig.multiplex;
     console.log(chalk.gray("-- Proxy is running"));
   }
 
@@ -1051,7 +1093,7 @@ async function runApp(
   // Register route (--force kills the existing owner if any)
   let killedPid: number | undefined;
   try {
-    killedPid = store.addRoute(hostname, port, process.pid, force);
+    killedPid = store.addRoute(hostname, port, process.pid, force, multiplex);
   } catch (err) {
     if (err instanceof RouteConflictError) {
       console.error(colors.red(`Error: ${err.message}`));
@@ -1108,11 +1150,15 @@ async function runApp(
     }
 
     try {
-      store.updateRoute(hostname, {
-        tailscaleUrl: tailscaleUrl,
-        tailscaleHttpsPort,
-        tailscaleFunnel: wantsFunnel || undefined,
-      });
+      store.updateRoute(
+        hostname,
+        {
+          tailscaleUrl: tailscaleUrl,
+          tailscaleHttpsPort,
+          tailscaleFunnel: wantsFunnel || undefined,
+        },
+        process.pid
+      );
     } catch {
       // Non-fatal: route display metadata only
     }
@@ -1186,7 +1232,7 @@ async function runApp(
         // Best-effort cleanup; non-fatal
       }
       try {
-        store.removeRoute(hostname);
+        store.removeRoute(hostname, process.pid);
       } catch {
         // Lock acquisition may fail during cleanup; non-fatal
       }
@@ -1509,6 +1555,7 @@ ${colors.bold("Options:")}
   --foreground                  Run proxy in foreground (for debugging)
   --tld <tld>                   Use a custom TLD instead of .localhost (e.g. test, dev)
   --wildcard                    Allow unregistered subdomains to fall back to parent route
+  --multiplex                   Allow multiple apps to share the same hostname
   --app-port <number>           Use a fixed port for the app (skip auto-assignment)
   --tailscale                   Share the app on your Tailscale network (tailnet)
   --funnel                      Share the app publicly via Tailscale Funnel
@@ -1523,6 +1570,7 @@ ${colors.bold("Environment variables:")}
   PORTLESS_LAN=1                Enable LAN mode when set to 1 (set in .bashrc / .zshrc)
   PORTLESS_TLD=<tld>            Use a custom TLD (e.g. test, dev; default: localhost)
   PORTLESS_WILDCARD=1           Allow unregistered subdomains to fall back to parent route
+  PORTLESS_MULTIPLEX=1          Allow multiple apps to share the same hostname
   PORTLESS_SYNC_HOSTS=0         Disable auto-sync of ${HOSTS_DISPLAY} (on by default)
   PORTLESS_TAILSCALE=1          Share apps on your Tailscale network (same as --tailscale)
   PORTLESS_FUNNEL=1             Share apps publicly via Tailscale Funnel (same as --funnel)
@@ -1892,7 +1940,7 @@ ${colors.bold("Examples:")}
       console.error(colors.red(`Error: No alias found for "${hostname}".`));
       process.exit(1);
     }
-    store.removeRoute(hostname);
+    store.removeRoute(hostname, 0);
     console.log(colors.green(`Removed alias: ${hostname}`));
     return;
   }
@@ -2071,6 +2119,7 @@ ${colors.bold("Usage:")}
   ${colors.cyan("portless proxy start -p 1355")}        Start on a custom port (no sudo)
   ${colors.cyan("portless proxy start --tld test")}     Use .test instead of .localhost
   ${colors.cyan("portless proxy start --wildcard")}     Allow unregistered subdomains to fall back to parent
+  ${colors.cyan("portless proxy start --multiplex")}    Allow multiple apps to share one hostname
   ${colors.cyan("portless proxy stop")}                 Stop the proxy
 
 ${colors.bold("LAN mode (--lan):")}
@@ -2166,6 +2215,7 @@ ${colors.bold("LAN mode (--lan):")}
   }
   // Parse --wildcard flag (disables the default strict subdomain matching)
   const useWildcard = args.includes("--wildcard") || isWildcardEnvEnabled();
+  const multiplex = args.includes("--multiplex") || isMultiplexEnvEnabled();
 
   const explicit: ProxyConfigExplicitness = {
     useHttps:
@@ -2179,6 +2229,7 @@ ${colors.bold("LAN mode (--lan):")}
     lanIp: process.env.PORTLESS_LAN_IP !== undefined,
     tld: tldIdx !== -1 || process.env.PORTLESS_TLD !== undefined,
     useWildcard: args.includes("--wildcard") || process.env.PORTLESS_WILDCARD !== undefined,
+    multiplex: args.includes("--multiplex") || process.env.PORTLESS_MULTIPLEX !== undefined,
   };
 
   // Resolve state directory based on the port
@@ -2208,6 +2259,7 @@ ${colors.bold("LAN mode (--lan):")}
     lanIp: process.env.PORTLESS_LAN_IP || null,
     tld,
     useWildcard,
+    multiplex,
   });
   const lanMode = desiredConfig.lanMode;
   useHttps = desiredConfig.useHttps;
@@ -2215,6 +2267,7 @@ ${colors.bold("LAN mode (--lan):")}
   customKeyPath = desiredConfig.customKeyPath;
   tld = desiredConfig.tld;
   const desiredWildcard = desiredConfig.useWildcard;
+  const desiredMultiplex = desiredConfig.multiplex;
   let lanIp: string | null = desiredConfig.lanIpExplicit ? desiredConfig.lanIp : null;
 
   if (!hasExplicitPort && runningPort === null) {
@@ -2318,6 +2371,7 @@ ${colors.bold("LAN mode (--lan):")}
     lanIpExplicit: desiredConfig.lanIpExplicit,
     tld,
     useWildcard: desiredWildcard,
+    multiplex: desiredMultiplex,
   };
 
   // Privileged ports require root on Unix. Auto-elevate with sudo when
@@ -2337,6 +2391,7 @@ ${colors.bold("LAN mode (--lan):")}
         lanIpExplicit: desiredConfig.lanIpExplicit,
         tld,
         useWildcard: desiredWildcard,
+        multiplex: desiredMultiplex,
         foreground: isForeground,
         includePort: true,
         proxyPort,
@@ -2478,7 +2533,15 @@ ${colors.bold("LAN mode (--lan):")}
   // Foreground mode: run the proxy directly in this process
   if (isForeground) {
     console.log(chalk.blue.bold("\nportless proxy\n"));
-    startProxyServer(store, proxyPort, tld, tlsOptions, lanIp, desiredWildcard ? false : undefined);
+    startProxyServer(
+      store,
+      proxyPort,
+      tld,
+      tlsOptions,
+      lanIp,
+      desiredWildcard ? false : undefined,
+      desiredMultiplex
+    );
     return;
   }
 
@@ -2507,6 +2570,7 @@ ${colors.bold("LAN mode (--lan):")}
         lanIpExplicit: desiredConfig.lanIpExplicit,
         tld,
         useWildcard: desiredWildcard,
+        multiplex: desiredMultiplex,
         foreground: true,
         includePort: true,
         proxyPort,
@@ -2643,7 +2707,7 @@ async function handleDefaultSingle(
   const worktree = detectWorktreePrefix(cwd);
   const effectiveName = worktree ? `${worktree.prefix}.${baseName}` : baseName;
 
-  const { dir, port, tls, tld, lanMode, lanIp } = await discoverState();
+  const { dir, port, tls, tld, lanMode, lanIp, multiplex } = await discoverState();
   const store = new RouteStore(dir, {
     onWarning: (msg) => console.warn(colors.yellow(msg)),
   });
@@ -2659,7 +2723,8 @@ async function handleDefaultSingle(
     { nameSource, prefix: worktree?.prefix, prefixSource: worktree?.source },
     appConfig?.appPort,
     lanMode,
-    lanIp
+    lanIp,
+    multiplex
   );
 }
 
@@ -2725,11 +2790,12 @@ async function spawnProxiedApp(
   proxyPort: number,
   tls: boolean,
   tld: string,
+  multiplex: boolean,
   exitCodes: Map<string, number | null>
 ): Promise<{
   child: ReturnType<typeof spawn>;
   displayUrl: string;
-  route: { store: RouteStore; hostname: string } | null;
+  route: { store: RouteStore; hostname: string; pid: number; port: number } | null;
 }> {
   const usesPortless = app.commandArgs[0] === "portless";
 
@@ -2739,6 +2805,7 @@ async function spawnProxiedApp(
   let env: Record<string, string | undefined>;
   let store: RouteStore | null = null;
   let hostname: string | null = null;
+  let registeredPort: number | null = null;
   let displayUrl: string;
 
   if (usesPortless) {
@@ -2750,6 +2817,7 @@ async function spawnProxiedApp(
     });
 
     const appPort = app.appPort ?? (await findFreePort());
+    registeredPort = appPort;
     const protocol = tls ? "https" : "http";
     const portSuffix =
       (tls && proxyPort === 443) || (!tls && proxyPort === 80) ? "" : `:${proxyPort}`;
@@ -2757,7 +2825,7 @@ async function spawnProxiedApp(
     displayUrl = url;
 
     hostname = parseHostname(app.name, tld);
-    store.addRoute(hostname, appPort, process.pid);
+    store.addRoute(hostname, appPort, process.pid, false, multiplex);
 
     env = {
       ...pkgEnv,
@@ -2788,14 +2856,17 @@ async function spawnProxiedApp(
     }
     if (capturedStore && capturedHostname) {
       try {
-        capturedStore.removeRoute(capturedHostname);
+        capturedStore.removeRoute(capturedHostname, process.pid, registeredPort ?? undefined);
       } catch {
         // non-fatal
       }
     }
   });
 
-  const route = store && hostname ? { store, hostname } : null;
+  const route =
+    store && hostname && registeredPort !== null
+      ? { store, hostname, pid: process.pid, port: registeredPort }
+      : null;
   return { child, displayUrl, route };
 }
 
@@ -2941,7 +3012,7 @@ async function handleDefaultMulti(
 
   console.log(chalk.blue.bold(`\nportless\n`));
 
-  let { dir, port, tls, tld } = await discoverState();
+  let { dir, port, tls, tld, multiplex } = await discoverState();
 
   if (proxiedApps.length > 0) {
     let multiDesired: ProxyDesiredState;
@@ -2957,9 +3028,10 @@ async function handleDefaultMulti(
       port = ensureResult.state.port;
       tls = ensureResult.state.tls;
       tld = ensureResult.state.tld;
+      multiplex = ensureResult.state.multiplex;
     } else {
       // Proxy was already running; re-discover to pick up current state.
-      ({ dir, port, tls, tld } = await discoverState());
+      ({ dir, port, tls, tld, multiplex } = await discoverState());
     }
 
     if (tls && !isCATrusted(dir)) {
@@ -2970,9 +3042,20 @@ async function handleDefaultMulti(
   const useTurbo = loaded?.config.turbo !== false && hasTurboConfig(wsRoot);
 
   if (useTurbo) {
-    await runWithTurbo(wsRoot, dir, port, tls, tld, scriptName, proxiedApps, taskApps, extraArgs);
+    await runWithTurbo(
+      wsRoot,
+      dir,
+      port,
+      tls,
+      tld,
+      multiplex,
+      scriptName,
+      proxiedApps,
+      taskApps,
+      extraArgs
+    );
   } else {
-    await runWithDirectSpawn(dir, port, tls, tld, proxiedApps, taskApps);
+    await runWithDirectSpawn(dir, port, tls, tld, multiplex, proxiedApps, taskApps);
   }
 }
 
@@ -2982,6 +3065,7 @@ async function runWithTurbo(
   proxyPort: number,
   tls: boolean,
   tld: string,
+  multiplex: boolean,
   scriptName: string,
   proxiedApps: MultiAppEntry[],
   taskApps: MultiAppEntry[],
@@ -2992,7 +3076,7 @@ async function runWithTurbo(
   });
 
   const manifest: Record<string, ManifestEntry> = {};
-  const routes: { hostname: string }[] = [];
+  const routes: { hostname: string; port: number }[] = [];
   const appUrls: { label: string; url: string }[] = [];
 
   for (const app of proxiedApps) {
@@ -3010,8 +3094,8 @@ async function runWithTurbo(
     appUrls.push({ label: app.label, url });
 
     const hostname = parseHostname(app.name, tld);
-    store.addRoute(hostname, appPort, process.pid);
-    routes.push({ hostname });
+    store.addRoute(hostname, appPort, process.pid, false, multiplex);
+    routes.push({ hostname, port: appPort });
 
     const entry: ManifestEntry = {
       PORT: String(appPort),
@@ -3073,9 +3157,9 @@ async function runWithTurbo(
       }
     }, SIGKILL_TIMEOUT_MS).unref();
 
-    for (const { hostname } of routes) {
+    for (const { hostname, port } of routes) {
       try {
-        store.removeRoute(hostname);
+        store.removeRoute(hostname, process.pid, port);
       } catch {
         // non-fatal
       }
@@ -3102,13 +3186,14 @@ async function runWithDirectSpawn(
   proxyPort: number,
   tls: boolean,
   tld: string,
+  multiplex: boolean,
   proxiedApps: MultiAppEntry[],
   taskApps: MultiAppEntry[]
 ): Promise<void> {
   const children: ReturnType<typeof spawn>[] = [];
   const exitCodes = new Map<string, number | null>();
   const appUrls: { label: string; url: string }[] = [];
-  const routeEntries: { store: RouteStore; hostname: string }[] = [];
+  const routeEntries: { store: RouteStore; hostname: string; pid: number; port: number }[] = [];
 
   // Sequential: each spawnProxiedApp calls findFreePort() which binds/releases
   // a port, so parallel spawning could cause port collisions.
@@ -3119,6 +3204,7 @@ async function runWithDirectSpawn(
       proxyPort,
       tls,
       tld,
+      multiplex,
       exitCodes
     );
     children.push(child);
@@ -3160,9 +3246,9 @@ async function runWithDirectSpawn(
       }
     }, SIGKILL_TIMEOUT_MS).unref();
 
-    for (const { store, hostname } of routeEntries) {
+    for (const { store, hostname, pid, port } of routeEntries) {
       try {
-        store.removeRoute(hostname);
+        store.removeRoute(hostname, pid, port);
       } catch {
         // non-fatal
       }
@@ -3244,7 +3330,7 @@ async function handleRunMode(args: string[], globalScript?: string): Promise<voi
   const worktree = detectWorktreePrefix();
   const effectiveName = worktree ? `${worktree.prefix}.${baseName}` : baseName;
 
-  const { dir, port, tls, tld, lanMode, lanIp } = await discoverState();
+  const { dir, port, tls, tld, lanMode, lanIp, multiplex } = await discoverState();
   const store = new RouteStore(dir, {
     onWarning: (msg) => console.warn(colors.yellow(msg)),
   });
@@ -3260,7 +3346,8 @@ async function handleRunMode(args: string[], globalScript?: string): Promise<voi
     { nameSource, prefix: worktree?.prefix, prefixSource: worktree?.source },
     parsed.appPort,
     lanMode,
-    lanIp
+    lanIp,
+    multiplex
   );
 }
 
@@ -3289,7 +3376,7 @@ async function handleNamedMode(args: string[]): Promise<void> {
     .map((label) => truncateLabel(label))
     .join(".");
 
-  const { dir, port, tls, tld, lanMode, lanIp } = await discoverState();
+  const { dir, port, tls, tld, lanMode, lanIp, multiplex } = await discoverState();
   const store = new RouteStore(dir, {
     onWarning: (msg) => console.warn(colors.yellow(msg)),
   });
@@ -3305,7 +3392,8 @@ async function handleNamedMode(args: string[]): Promise<void> {
     undefined,
     parsed.appPort,
     lanMode,
-    lanIp
+    lanIp,
+    multiplex
   );
 }
 
@@ -3393,6 +3481,9 @@ async function main() {
   if (stripGlobalFlag("--funnel", false)) {
     process.env.PORTLESS_FUNNEL = "1";
     process.env.PORTLESS_TAILSCALE = "1";
+  }
+  if (stripGlobalFlag("--multiplex", false)) {
+    process.env.PORTLESS_MULTIPLEX = "1";
   }
 
   // --script flag: override the default "dev" script for zero-arg mode.

--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -280,8 +280,26 @@ describe("createProxyServer", () => {
       if (!addr || typeof addr === "string") throw new Error("no addr");
 
       const routes: RouteInfo[] = [
-        { id: "one", hostname: "myapp.localhost", port: 4001, pid: 111 },
-        { id: "two", hostname: "myapp.localhost", port: addr.port, pid: 222 },
+        {
+          id: "one",
+          hostname: "myapp.localhost",
+          port: 4001,
+          pid: 111,
+          folder: "api",
+          gitBranch: "feature-auth",
+          cwd: "/repo/apps/api",
+          command: "pnpm dev",
+        },
+        {
+          id: "two",
+          hostname: "myapp.localhost",
+          port: addr.port,
+          pid: 222,
+          folder: "web",
+          gitBranch: "feature-auth",
+          cwd: "/repo/apps/web",
+          command: "next dev",
+        },
       ];
       const server = trackServer(
         createProxyServer({
@@ -298,8 +316,14 @@ describe("createProxyServer", () => {
       });
       expect(res.status).toBe(200);
       expect(res.body).toContain("<main>hello</main>");
-      expect(res.body).toContain("portless myapp.localhost");
+      expect(res.body).toContain("pl-switcher");
+      expect(res.body).toContain('class="pl-icon"');
+      expect(res.body).toContain("@media (prefers-color-scheme:dark)");
+      expect(res.body).toContain("<strong>myapp.localhost</strong>");
       expect(res.body).toContain("/__portless__/select?id=one");
+      expect(res.body).toContain("feature-auth");
+      expect(res.body).toContain("/repo/apps/web");
+      expect(res.body).toContain("next dev");
     });
 
     it("routes wildcard subdomain to matching parent route when strict is false", async () => {

--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -155,8 +155,26 @@ describe("createProxyServer", () => {
 
     it("shows selector for duplicate hostnames in multiplex mode", async () => {
       const routes: RouteInfo[] = [
-        { id: "one", hostname: "myapp.localhost", port: 4001, pid: 111 },
-        { id: "two", hostname: "myapp.localhost", port: 4002, pid: 222 },
+        {
+          id: "one",
+          hostname: "myapp.localhost",
+          port: 4001,
+          pid: 111,
+          folder: "api",
+          gitBranch: "feature-auth",
+          cwd: "/repo/apps/api",
+          command: "pnpm dev",
+        },
+        {
+          id: "two",
+          hostname: "myapp.localhost",
+          port: 4002,
+          pid: 222,
+          folder: "web",
+          gitBranch: "feature-auth",
+          cwd: "/repo/apps/web",
+          command: "next dev",
+        },
       ];
       const server = trackServer(
         createProxyServer({
@@ -172,6 +190,11 @@ describe("createProxyServer", () => {
       expect(res.body).toContain("Select App");
       expect(res.body).toContain("127.0.0.1:4001");
       expect(res.body).toContain("127.0.0.1:4002");
+      expect(res.body).toContain("feature-auth");
+      expect(res.body).toContain("/repo/apps/api");
+      expect(res.body).toContain("pnpm dev");
+      expect(res.body).toContain(">Select</a>");
+      expect(res.body).not.toContain("Clear selection");
     });
 
     it("routes duplicate hostnames by selection cookie in multiplex mode", async () => {

--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -18,7 +18,7 @@ type AnyServer = http.Server | ProxyServer;
 
 function request(
   server: AnyServer,
-  options: { host?: string; path?: string; method?: string }
+  options: { host?: string; path?: string; method?: string; headers?: http.OutgoingHttpHeaders }
 ): Promise<{ status: number; headers: http.IncomingHttpHeaders; body: string }> {
   return new Promise((resolve, reject) => {
     const addr = server.address();
@@ -31,7 +31,7 @@ function request(
         port: addr.port,
         path: options.path || "/",
         method: options.method || "GET",
-        headers: { host: options.host || "" },
+        headers: { host: options.host || "", ...options.headers },
       },
       (res) => {
         let body = "";
@@ -151,6 +151,155 @@ describe("createProxyServer", () => {
       const res = await request(server, { host: "myapp.localhost" });
       expect(res.status).toBe(200);
       expect(res.body).toBe("hello from backend");
+    });
+
+    it("shows selector for duplicate hostnames in multiplex mode", async () => {
+      const routes: RouteInfo[] = [
+        { id: "one", hostname: "myapp.localhost", port: 4001, pid: 111 },
+        { id: "two", hostname: "myapp.localhost", port: 4002, pid: 222 },
+      ];
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => routes,
+          proxyPort: TEST_PROXY_PORT,
+          multiplex: true,
+        })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "myapp.localhost" });
+      expect(res.status).toBe(200);
+      expect(res.body).toContain("Select App");
+      expect(res.body).toContain("127.0.0.1:4001");
+      expect(res.body).toContain("127.0.0.1:4002");
+    });
+
+    it("routes duplicate hostnames by selection cookie in multiplex mode", async () => {
+      const firstBackend = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("first");
+        })
+      );
+      await listen(firstBackend);
+      const firstAddr = firstBackend.address();
+      if (!firstAddr || typeof firstAddr === "string") throw new Error("no addr");
+
+      const secondBackend = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("second");
+        })
+      );
+      await listen(secondBackend);
+      const secondAddr = secondBackend.address();
+      if (!secondAddr || typeof secondAddr === "string") throw new Error("no addr");
+
+      const routes: RouteInfo[] = [
+        { id: "one", hostname: "myapp.localhost", port: firstAddr.port, pid: 111 },
+        { id: "two", hostname: "myapp.localhost", port: secondAddr.port, pid: 222 },
+      ];
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => routes,
+          proxyPort: TEST_PROXY_PORT,
+          multiplex: true,
+        })
+      );
+      await listen(server);
+
+      const res = await request(server, {
+        host: "myapp.localhost",
+        headers: { cookie: "portless_app=two" },
+      });
+      expect(res.status).toBe(200);
+      expect(res.body).toBe("second");
+    });
+
+    it("sets selection cookie from the multiplex selector", async () => {
+      const routes: RouteInfo[] = [
+        { id: "one", hostname: "myapp.localhost", port: 4001, pid: 111 },
+        { id: "two", hostname: "myapp.localhost", port: 4002, pid: 222 },
+      ];
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => routes,
+          proxyPort: TEST_PROXY_PORT,
+          multiplex: true,
+        })
+      );
+      await listen(server);
+
+      const res = await request(server, {
+        host: "myapp.localhost",
+        path: "/__portless__/select?id=two&next=/dashboard",
+      });
+      expect(res.status).toBe(302);
+      expect(res.headers.location).toBe("/dashboard");
+      expect(res.headers["set-cookie"]?.[0]).toContain("portless_app=two");
+    });
+
+    it("does not reserve the control path when multiplex has only one matching route", async () => {
+      const backend = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("backend control path");
+        })
+      );
+      await listen(backend);
+      const addr = backend.address();
+      if (!addr || typeof addr === "string") throw new Error("no addr");
+
+      const routes: RouteInfo[] = [{ id: "one", hostname: "myapp.localhost", port: addr.port }];
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => routes,
+          proxyPort: TEST_PROXY_PORT,
+          multiplex: true,
+        })
+      );
+      await listen(server);
+
+      const res = await request(server, {
+        host: "myapp.localhost",
+        path: "/__portless__/select?id=one",
+      });
+      expect(res.status).toBe(200);
+      expect(res.body).toBe("backend control path");
+    });
+
+    it("injects a switcher into selected HTML responses in multiplex mode", async () => {
+      const backend = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/html" });
+          res.end("<html><body><main>hello</main></body></html>");
+        })
+      );
+      await listen(backend);
+      const addr = backend.address();
+      if (!addr || typeof addr === "string") throw new Error("no addr");
+
+      const routes: RouteInfo[] = [
+        { id: "one", hostname: "myapp.localhost", port: 4001, pid: 111 },
+        { id: "two", hostname: "myapp.localhost", port: addr.port, pid: 222 },
+      ];
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => routes,
+          proxyPort: TEST_PROXY_PORT,
+          multiplex: true,
+        })
+      );
+      await listen(server);
+
+      const res = await request(server, {
+        host: "myapp.localhost",
+        headers: { cookie: "portless_app=two" },
+      });
+      expect(res.status).toBe(200);
+      expect(res.body).toContain("<main>hello</main>");
+      expect(res.body).toContain("portless myapp.localhost");
+      expect(res.body).toContain("/__portless__/select?id=one");
     });
 
     it("routes wildcard subdomain to matching parent route when strict is false", async () => {

--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -321,6 +321,10 @@ describe("createProxyServer", () => {
       expect(res.body).toContain("@media (prefers-color-scheme:dark)");
       expect(res.body).toContain("<strong>myapp.localhost</strong>");
       expect(res.body).toContain("/__portless__/select?id=one");
+      expect(res.body).toContain(">Select</a>");
+      expect(res.body).toContain(">Selected</a>");
+      expect(res.body).toContain("/__portless__/clear?next=%2F");
+      expect(res.body).toContain("Clear selection");
       expect(res.body).toContain("feature-auth");
       expect(res.body).toContain("/repo/apps/web");
       expect(res.body).toContain("next dev");

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -132,12 +132,22 @@ function isPortlessPath(url: string | undefined): boolean {
   return (url || "/").startsWith(CONTROL_PREFIX);
 }
 
+function getRouteDetails(route: ProxyRoute): [string, string][] {
+  const pid = route.pid === 0 ? "alias" : String(route.pid ?? "unknown");
+  return [
+    ["host", route.hostname],
+    ["port", `127.0.0.1:${route.port}`],
+    ["pid", pid],
+    ["branch", route.gitBranch || "unknown"],
+    ["folder", route.cwd || route.folder || "unknown"],
+    ["command", route.command || "unknown"],
+  ];
+}
+
 function renderSelectorPage(
   status: number,
   host: string,
   routes: ProxyRoute[],
-  proxyPort: number,
-  tls: boolean,
   currentId?: string,
   next = "/"
 ): string {
@@ -148,12 +158,28 @@ function renderSelectorPage(
       const id = getRouteId(route);
       const selected = currentId === id ? " selected" : "";
       const href = `${CONTROL_PREFIX}/select?id=${encodeURIComponent(id)}&next=${safeNext}`;
-      const label = route.pid === 0 ? "alias" : `pid ${route.pid ?? "unknown"}`;
-      return `<li><a href="${href}" class="card-link${selected}"><span class="name">${escapeHtml(route.hostname)}</span><span class="meta"><code class="port">127.0.0.1:${escapeHtml(String(route.port))}</code><code class="port">${escapeHtml(label)}</code><span class="arrow">${ARROW_SVG}</span></span></a></li>`;
+      const detailRows = getRouteDetails(route)
+        .map(
+          ([label, value]) =>
+            `<span class="selector-row"><span>${escapeHtml(label)}</span><code>${escapeHtml(value)}</code></span>`
+        )
+        .join("");
+      return `<li><div class="selector-app${selected}"><div class="selector-top"><span class="name">${escapeHtml(route.folder || route.hostname)}</span><code class="port">${escapeHtml(String(route.port))}</code></div><div class="selector-details">${detailRows}</div><div class="selector-actions"><a class="selector-button" href="${href}">${selected ? "Selected" : "Select"}</a></div></div></li>`;
     })
     .join("");
-  const clearUrl = `${CONTROL_PREFIX}/clear?next=${safeNext}`;
-  const body = `<div class="content"><p class="desc">Multiple apps are registered for <strong>${safeHost}</strong>. Choose which one this browser should use.</p><div class="section"><p class="label">Available apps</p><ul class="card">${items}</ul></div><div class="section"><p class="desc"><a href="${clearUrl}">Clear selection</a> for ${escapeHtml(formatUrl(host, proxyPort, tls))}</p></div></div>`;
+  const body = `<style>
+.selector-app{display:block;padding:14px 16px;color:inherit}
+.selector-app.selected{background:var(--surface)}
+.selector-top{display:grid;grid-template-columns:minmax(0,1fr) auto;align-items:center;gap:12px}
+.selector-details{display:grid;grid-template-columns:1fr 1fr;gap:8px 12px;margin-top:12px}
+.selector-row{min-width:0}
+.selector-row span{display:block;margin-bottom:2px;color:var(--text-3);font-size:10px;font-weight:500;text-transform:uppercase;letter-spacing:0}
+.selector-row code{display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--fg);font-family:var(--font-mono);font-size:12px}
+.selector-actions{display:flex;justify-content:flex-end;margin-top:12px}
+.selector-button{display:inline-flex;align-items:center;justify-content:center;min-height:30px;padding:0 12px;border-radius:6px;background:var(--fg);color:var(--bg);font-size:13px;font-weight:500;text-decoration:none}
+.selector-app.selected .selector-button{border:1px solid var(--border);background:transparent;color:var(--fg)}
+@media (max-width:520px){.selector-details{grid-template-columns:1fr}}
+</style><div class="content"><p class="desc">Multiple apps are registered for <strong>${safeHost}</strong>. Choose which one this browser should use.</p><div class="section"><p class="label">Available apps</p><ul class="card">${items}</ul></div></div>`;
   return renderPage(status, "Select App", body);
 }
 
@@ -188,9 +214,7 @@ function handlePortlessControl(
   req: http.IncomingMessage,
   res: http.ServerResponse,
   host: string,
-  routes: ProxyRoute[],
-  proxyPort: number,
-  tls: boolean
+  routes: ProxyRoute[]
 ): boolean {
   const url = req.url || "/";
   if (!isPortlessPath(url)) return false;
@@ -213,7 +237,7 @@ function handlePortlessControl(
   }
   const currentId = parseCookies(req.headers.cookie)[SELECTOR_COOKIE];
   res.writeHead(200, { "Content-Type": "text/html" });
-  res.end(renderSelectorPage(200, host, routes, proxyPort, tls, currentId, getRedirectTarget(url)));
+  res.end(renderSelectorPage(200, host, routes, currentId, getRedirectTarget(url)));
   return true;
 }
 
@@ -262,16 +286,7 @@ async function injectSwitcher(
       const id = getRouteId(route);
       const selected = id === currentId;
       const href = `${CONTROL_PREFIX}/select?id=${encodeURIComponent(id)}&next=${next}`;
-      const pid = route.pid === 0 ? "alias" : String(route.pid ?? "unknown");
-      const details = [
-        ["host", route.hostname],
-        ["port", `127.0.0.1:${route.port}`],
-        ["pid", pid],
-        ["branch", route.gitBranch || "unknown"],
-        ["folder", route.cwd || route.folder || "unknown"],
-        ["command", route.command || "unknown"],
-      ];
-      const detailRows = details
+      const detailRows = getRouteDetails(route)
         .map(
           ([label, value]) =>
             `<span class="pl-row"><span>${escapeHtml(label)}</span><code>${escapeHtml(value)}</code></span>`
@@ -387,7 +402,7 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
 
     const matchingRoutes = findRoutes(routes, host, strict);
     if (multiplex && matchingRoutes.length > 1) {
-      if (handlePortlessControl(req, res, host, matchingRoutes, proxyPort, reqTls)) {
+      if (handlePortlessControl(req, res, host, matchingRoutes)) {
         return;
       }
     }
@@ -399,17 +414,7 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
     if (!route) {
       if (multiplex && matchingRoutes.length > 1) {
         res.writeHead(200, { "Content-Type": "text/html" });
-        res.end(
-          renderSelectorPage(
-            200,
-            host,
-            matchingRoutes,
-            proxyPort,
-            reqTls,
-            undefined,
-            req.url || "/"
-          )
-        );
+        res.end(renderSelectorPage(200, host, matchingRoutes, undefined, req.url || "/"));
         return;
       }
       const safeHost = escapeHtml(host);

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -81,7 +81,16 @@ const SELECTOR_COOKIE = "portless_app";
 const CONTROL_PREFIX = "/__portless__";
 const MAX_SWITCHER_INJECTION_BYTES = 2 * 1024 * 1024;
 
-type ProxyRoute = { id?: string; hostname: string; port: number; pid?: number };
+type ProxyRoute = {
+  id?: string;
+  hostname: string;
+  port: number;
+  pid?: number;
+  cwd?: string;
+  folder?: string;
+  gitBranch?: string;
+  command?: string;
+};
 
 function getRouteId(route: ProxyRoute): string {
   return route.id || `${route.hostname}:${route.port}:${route.pid ?? 0}`;
@@ -246,13 +255,60 @@ async function injectSwitcher(
   const html = decoded.toString("utf-8");
   const next = encodeURIComponent(reqUrl || "/");
   const currentId = getRouteId(currentRoute);
+  const routeCount = String(routes.length);
   const links = routes
     .map((route) => {
-      const selected = getRouteId(route) === currentId ? "font-weight:600;" : "";
-      return `<a style="${selected}display:block;padding:6px 8px;color:inherit;text-decoration:none" href="${CONTROL_PREFIX}/select?id=${encodeURIComponent(getRouteId(route))}&next=${next}">${escapeHtml(String(route.pid ?? route.port))} <span style="color:#777">127.0.0.1:${escapeHtml(String(route.port))}</span></a>`;
+      const id = getRouteId(route);
+      const selected = id === currentId;
+      const href = `${CONTROL_PREFIX}/select?id=${encodeURIComponent(id)}&next=${next}`;
+      const pid = route.pid === 0 ? "alias" : String(route.pid ?? "unknown");
+      const details = [
+        ["host", route.hostname],
+        ["port", `127.0.0.1:${route.port}`],
+        ["pid", pid],
+        ["branch", route.gitBranch || "unknown"],
+        ["folder", route.cwd || route.folder || "unknown"],
+        ["command", route.command || "unknown"],
+      ];
+      const detailRows = details
+        .map(
+          ([label, value]) =>
+            `<span class="pl-row"><span>${escapeHtml(label)}</span><code>${escapeHtml(value)}</code></span>`
+        )
+        .join("");
+      return `<a class="pl-app${selected ? " pl-active" : ""}" href="${href}"><span class="pl-app-top"><span class="pl-dot"></span><span class="pl-title">${escapeHtml(route.folder || route.hostname)}</span><span class="pl-port">${escapeHtml(String(route.port))}</span></span><span class="pl-details">${detailRows}</span></a>`;
     })
     .join("");
-  const widget = `<div style="position:fixed;right:12px;bottom:12px;z-index:2147483647;font:13px system-ui,-apple-system,Segoe UI,sans-serif;color:#111;background:#fff;border:1px solid rgba(0,0,0,.14);box-shadow:0 8px 24px rgba(0,0,0,.16);border-radius:8px;overflow:hidden"><div style="padding:7px 10px;border-bottom:1px solid rgba(0,0,0,.08);font-weight:600">portless ${escapeHtml(host)}</div>${links}</div>`;
+  const widget = `<div class="pl-switcher" aria-label="Portless app switcher"><input id="pl-switcher-toggle" type="checkbox" class="pl-toggle"><label for="pl-switcher-toggle" class="pl-icon" title="Switch portless app"><span class="pl-mark">p</span><span class="pl-count">${escapeHtml(routeCount)}</span></label><div class="pl-panel"><div class="pl-head"><div><p>portless</p><strong>${escapeHtml(host)}</strong></div><label for="pl-switcher-toggle" aria-label="Collapse portless app switcher">close</label></div><div class="pl-list">${links}</div></div><style>
+.pl-switcher{--pl-bg:#fff;--pl-fg:#111;--pl-muted:#666;--pl-soft:#f6f6f6;--pl-border:rgba(0,0,0,.13);--pl-active:#eef6ff;--pl-active-border:#60a5fa;position:fixed;right:16px;bottom:16px;z-index:2147483647;font:13px/1.35 ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;color:var(--pl-fg)}
+@media (prefers-color-scheme:dark){.pl-switcher{--pl-bg:#0b0b0b;--pl-fg:#f4f4f5;--pl-muted:#a1a1aa;--pl-soft:#18181b;--pl-border:rgba(255,255,255,.16);--pl-active:#082f49;--pl-active-border:#38bdf8}}
+.pl-switcher *{box-sizing:border-box}
+.pl-toggle{position:absolute;inline-size:1px;block-size:1px;opacity:0;pointer-events:none}
+.pl-icon{display:flex;align-items:center;justify-content:center;inline-size:46px;block-size:46px;border:1px solid var(--pl-border);border-radius:999px;background:var(--pl-bg);box-shadow:0 14px 40px rgba(0,0,0,.22);cursor:pointer;user-select:none}
+.pl-mark{font-weight:700;letter-spacing:0;color:var(--pl-fg)}
+.pl-count{position:absolute;right:-2px;top:-3px;min-inline-size:18px;block-size:18px;padding:0 5px;border-radius:999px;background:var(--pl-fg);color:var(--pl-bg);font-size:11px;font-weight:700;line-height:18px;text-align:center}
+.pl-panel{display:none;inline-size:min(440px,calc(100vw - 32px));max-block-size:min(620px,calc(100vh - 32px));overflow:hidden;border:1px solid var(--pl-border);border-radius:8px;background:var(--pl-bg);box-shadow:0 22px 70px rgba(0,0,0,.28)}
+.pl-toggle:checked~.pl-icon{display:none}
+.pl-toggle:checked~.pl-panel{display:block}
+.pl-head{display:flex;align-items:flex-start;justify-content:space-between;gap:20px;padding:14px 14px 12px;border-bottom:1px solid var(--pl-border)}
+.pl-head p{margin:0 0 2px;color:var(--pl-muted);font-size:11px;font-weight:650;text-transform:uppercase;letter-spacing:0}
+.pl-head strong{display:block;max-inline-size:300px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:14px}
+.pl-head label{color:var(--pl-muted);font-size:12px;cursor:pointer}
+.pl-list{display:grid;gap:8px;max-block-size:520px;overflow:auto;padding:10px}
+.pl-app{display:block;padding:10px;border:1px solid var(--pl-border);border-radius:8px;background:var(--pl-soft);color:inherit;text-decoration:none}
+.pl-app:hover{border-color:var(--pl-active-border)}
+.pl-active{background:var(--pl-active);border-color:var(--pl-active-border)}
+.pl-app-top{display:grid;grid-template-columns:10px minmax(0,1fr) auto;align-items:center;gap:8px}
+.pl-dot{inline-size:7px;block-size:7px;border-radius:999px;background:var(--pl-muted)}
+.pl-active .pl-dot{background:var(--pl-active-border)}
+.pl-title{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-weight:700}
+.pl-port{color:var(--pl-muted);font:12px ui-monospace,SFMono-Regular,Menlo,monospace}
+.pl-details{display:grid;grid-template-columns:1fr 1fr;gap:6px 10px;margin-top:10px}
+.pl-row{min-width:0}
+.pl-row span{display:block;margin-bottom:2px;color:var(--pl-muted);font-size:10px;font-weight:650;text-transform:uppercase;letter-spacing:0}
+.pl-row code{display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--pl-fg);font:12px ui-monospace,SFMono-Regular,Menlo,monospace}
+@media (max-width:460px){.pl-switcher{right:10px;bottom:10px}.pl-details{grid-template-columns:1fr}.pl-head strong{max-inline-size:230px}}
+</style></div>`;
   const injected = html.includes("</body>")
     ? html.replace("</body>", `${widget}</body>`)
     : `${html}${widget}`;

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -1,6 +1,7 @@
 import * as http from "node:http";
 import * as http2 from "node:http2";
 import * as net from "node:net";
+import * as zlib from "node:zlib";
 import type { ProxyServerOptions } from "./types.js";
 import { escapeHtml, formatUrl } from "./utils.js";
 import { ARROW_SVG, renderPage } from "./pages.js";
@@ -76,6 +77,16 @@ const PORTLESS_HOPS_HEADER = "x-portless-hops";
  */
 const MAX_PROXY_HOPS = 5;
 
+const SELECTOR_COOKIE = "portless_app";
+const CONTROL_PREFIX = "/__portless__";
+const MAX_SWITCHER_INJECTION_BYTES = 2 * 1024 * 1024;
+
+type ProxyRoute = { id?: string; hostname: string; port: number; pid?: number };
+
+function getRouteId(route: ProxyRoute): string {
+  return route.id || `${route.hostname}:${route.port}:${route.pid ?? 0}`;
+}
+
 /**
  * Find the route matching a given host. Matches exact hostname first, then
  * falls back to wildcard subdomain matching (e.g. tenant.myapp.localhost
@@ -84,15 +95,168 @@ const MAX_PROXY_HOPS = 5;
  * When `strict` is true, only exact matches are returned; unregistered
  * subdomain prefixes will not fall back to the base service.
  */
-function findRoute(
-  routes: { hostname: string; port: number }[],
+function findRoutes(routes: ProxyRoute[], host: string, strict?: boolean): ProxyRoute[] {
+  const exact = routes.filter((r) => r.hostname === host);
+  if (exact.length > 0 || strict) return exact;
+  return routes.filter((r) => host.endsWith("." + r.hostname));
+}
+
+function parseCookies(header: string | string[] | undefined): Record<string, string> {
+  const raw = Array.isArray(header) ? header.join(";") : header || "";
+  const cookies: Record<string, string> = {};
+  for (const part of raw.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    const key = part.slice(0, eq).trim();
+    const value = part.slice(eq + 1).trim();
+    if (!key) continue;
+    try {
+      cookies[key] = decodeURIComponent(value);
+    } catch {
+      cookies[key] = value;
+    }
+  }
+  return cookies;
+}
+
+function isPortlessPath(url: string | undefined): boolean {
+  return (url || "/").startsWith(CONTROL_PREFIX);
+}
+
+function renderSelectorPage(
+  status: number,
   host: string,
-  strict?: boolean
-): { hostname: string; port: number } | undefined {
-  return (
-    routes.find((r) => r.hostname === host) ||
-    (strict ? undefined : routes.find((r) => host.endsWith("." + r.hostname)))
+  routes: ProxyRoute[],
+  proxyPort: number,
+  tls: boolean,
+  currentId?: string,
+  next = "/"
+): string {
+  const safeHost = escapeHtml(host);
+  const safeNext = encodeURIComponent(next || "/");
+  const items = routes
+    .map((route) => {
+      const id = getRouteId(route);
+      const selected = currentId === id ? " selected" : "";
+      const href = `${CONTROL_PREFIX}/select?id=${encodeURIComponent(id)}&next=${safeNext}`;
+      const label = route.pid === 0 ? "alias" : `pid ${route.pid ?? "unknown"}`;
+      return `<li><a href="${href}" class="card-link${selected}"><span class="name">${escapeHtml(route.hostname)}</span><span class="meta"><code class="port">127.0.0.1:${escapeHtml(String(route.port))}</code><code class="port">${escapeHtml(label)}</code><span class="arrow">${ARROW_SVG}</span></span></a></li>`;
+    })
+    .join("");
+  const clearUrl = `${CONTROL_PREFIX}/clear?next=${safeNext}`;
+  const body = `<div class="content"><p class="desc">Multiple apps are registered for <strong>${safeHost}</strong>. Choose which one this browser should use.</p><div class="section"><p class="label">Available apps</p><ul class="card">${items}</ul></div><div class="section"><p class="desc"><a href="${clearUrl}">Clear selection</a> for ${escapeHtml(formatUrl(host, proxyPort, tls))}</p></div></div>`;
+  return renderPage(status, "Select App", body);
+}
+
+function routeFromCookie(routes: ProxyRoute[], cookieHeader: string | string[] | undefined) {
+  const selected = parseCookies(cookieHeader)[SELECTOR_COOKIE];
+  if (!selected) return undefined;
+  return routes.find((route) => getRouteId(route) === selected);
+}
+
+function setSelectionCookie(res: http.ServerResponse, routeId: string): void {
+  res.setHeader(
+    "Set-Cookie",
+    `${SELECTOR_COOKIE}=${encodeURIComponent(routeId)}; Path=/; HttpOnly; SameSite=Lax`
   );
+}
+
+function clearSelectionCookie(res: http.ServerResponse): void {
+  res.setHeader("Set-Cookie", `${SELECTOR_COOKIE}=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax`);
+}
+
+function getRedirectTarget(reqUrl: string | undefined): string {
+  try {
+    const parsed = new URL(reqUrl || "/", "http://portless.local");
+    const next = parsed.searchParams.get("next") || "/";
+    return next.startsWith("/") && !next.startsWith("//") ? next : "/";
+  } catch {
+    return "/";
+  }
+}
+
+function handlePortlessControl(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  host: string,
+  routes: ProxyRoute[],
+  proxyPort: number,
+  tls: boolean
+): boolean {
+  const url = req.url || "/";
+  if (!isPortlessPath(url)) return false;
+  if (url.startsWith(`${CONTROL_PREFIX}/select`)) {
+    const parsed = new URL(url, "http://portless.local");
+    const id = parsed.searchParams.get("id");
+    const route = routes.find((candidate) => getRouteId(candidate) === id);
+    if (route) {
+      setSelectionCookie(res, getRouteId(route));
+      res.writeHead(302, { Location: getRedirectTarget(url) });
+      res.end();
+      return true;
+    }
+  }
+  if (url.startsWith(`${CONTROL_PREFIX}/clear`)) {
+    clearSelectionCookie(res);
+    res.writeHead(302, { Location: getRedirectTarget(url) });
+    res.end();
+    return true;
+  }
+  const currentId = parseCookies(req.headers.cookie)[SELECTOR_COOKIE];
+  res.writeHead(200, { "Content-Type": "text/html" });
+  res.end(renderSelectorPage(200, host, routes, proxyPort, tls, currentId, getRedirectTarget(url)));
+  return true;
+}
+
+function decodeBody(body: Buffer, encoding: string): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    if (encoding === "gzip")
+      zlib.gunzip(body, (err, result) => (err ? reject(err) : resolve(result)));
+    else if (encoding === "br")
+      zlib.brotliDecompress(body, (err, result) => (err ? reject(err) : resolve(result)));
+    else if (encoding === "deflate")
+      zlib.inflate(body, (err, result) => (err ? reject(err) : resolve(result)));
+    else resolve(body);
+  });
+}
+
+function encodeBody(body: Buffer, encoding: string): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    if (encoding === "gzip")
+      zlib.gzip(body, (err, result) => (err ? reject(err) : resolve(result)));
+    else if (encoding === "br")
+      zlib.brotliCompress(body, (err, result) => (err ? reject(err) : resolve(result)));
+    else if (encoding === "deflate")
+      zlib.deflate(body, (err, result) => (err ? reject(err) : resolve(result)));
+    else resolve(body);
+  });
+}
+
+async function injectSwitcher(
+  chunks: Buffer[],
+  headers: http.OutgoingHttpHeaders,
+  host: string,
+  routes: ProxyRoute[],
+  currentRoute: ProxyRoute,
+  reqUrl: string | undefined
+): Promise<Buffer> {
+  const encoding = String(headers["content-encoding"] || "").toLowerCase();
+  const raw = Buffer.concat(chunks);
+  const decoded = await decodeBody(raw, encoding);
+  const html = decoded.toString("utf-8");
+  const next = encodeURIComponent(reqUrl || "/");
+  const currentId = getRouteId(currentRoute);
+  const links = routes
+    .map((route) => {
+      const selected = getRouteId(route) === currentId ? "font-weight:600;" : "";
+      return `<a style="${selected}display:block;padding:6px 8px;color:inherit;text-decoration:none" href="${CONTROL_PREFIX}/select?id=${encodeURIComponent(getRouteId(route))}&next=${next}">${escapeHtml(String(route.pid ?? route.port))} <span style="color:#777">127.0.0.1:${escapeHtml(String(route.port))}</span></a>`;
+    })
+    .join("");
+  const widget = `<div style="position:fixed;right:12px;bottom:12px;z-index:2147483647;font:13px system-ui,-apple-system,Segoe UI,sans-serif;color:#111;background:#fff;border:1px solid rgba(0,0,0,.14);box-shadow:0 8px 24px rgba(0,0,0,.16);border-radius:8px;overflow:hidden"><div style="padding:7px 10px;border-bottom:1px solid rgba(0,0,0,.08);font-weight:600">portless ${escapeHtml(host)}</div>${links}</div>`;
+  const injected = html.includes("</body>")
+    ? html.replace("</body>", `${widget}</body>`)
+    : `${html}${widget}`;
+  return encodeBody(Buffer.from(injected), encoding);
 }
 
 /** Server type returned by createProxyServer (plain HTTP/1.1 or net.Server TLS wrapper). */
@@ -115,6 +279,7 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
     proxyPort,
     tld = "localhost",
     strict = true,
+    multiplex = false,
     onError = (msg: string) => console.error(msg),
     tls,
   } = options;
@@ -156,9 +321,33 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
       return;
     }
 
-    const route = findRoute(routes, host, strict);
+    const matchingRoutes = findRoutes(routes, host, strict);
+    if (multiplex && matchingRoutes.length > 1) {
+      if (handlePortlessControl(req, res, host, matchingRoutes, proxyPort, reqTls)) {
+        return;
+      }
+    }
+    const route =
+      multiplex && matchingRoutes.length > 1
+        ? routeFromCookie(matchingRoutes, req.headers.cookie)
+        : matchingRoutes[0];
 
     if (!route) {
+      if (multiplex && matchingRoutes.length > 1) {
+        res.writeHead(200, { "Content-Type": "text/html" });
+        res.end(
+          renderSelectorPage(
+            200,
+            host,
+            matchingRoutes,
+            proxyPort,
+            reqTls,
+            undefined,
+            req.url || "/"
+          )
+        );
+        return;
+      }
       const safeHost = escapeHtml(host);
       const strippedHost = host.endsWith(tldSuffix) ? host.slice(0, -tldSuffix.length) : host;
       const safeSuggestion = escapeHtml(strippedHost);
@@ -205,7 +394,18 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
             delete responseHeaders[h];
           }
         }
-        res.writeHead(proxyRes.statusCode || 502, responseHeaders);
+        const contentType = String(proxyRes.headers["content-type"] || "");
+        const contentEncoding = String(proxyRes.headers["content-encoding"] || "").toLowerCase();
+        const canInject =
+          multiplex &&
+          matchingRoutes.length > 1 &&
+          req.method !== "HEAD" &&
+          !isPortlessPath(req.url) &&
+          contentType.includes("text/html") &&
+          ["", "gzip", "br", "deflate"].includes(contentEncoding);
+        if (!canInject) {
+          res.writeHead(proxyRes.statusCode || 502, responseHeaders);
+        }
         proxyRes.on("error", () => {
           if (!res.headersSent) {
             res.writeHead(502, { "Content-Type": "text/plain" });
@@ -217,7 +417,52 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
             res.destroy();
           }
         });
-        proxyRes.pipe(res);
+        if (canInject) {
+          const chunks: Buffer[] = [];
+          let bufferedBytes = 0;
+          let passthrough = false;
+          const startPassthrough = () => {
+            passthrough = true;
+            delete responseHeaders["content-length"];
+            res.writeHead(proxyRes.statusCode || 502, responseHeaders);
+            for (const buffered of chunks) {
+              res.write(buffered);
+            }
+            chunks.length = 0;
+          };
+          proxyRes.on("data", (chunk: Buffer) => {
+            if (passthrough) {
+              res.write(chunk);
+              return;
+            }
+            bufferedBytes += chunk.length;
+            chunks.push(chunk);
+            if (bufferedBytes > MAX_SWITCHER_INJECTION_BYTES) {
+              startPassthrough();
+            }
+          });
+          proxyRes.on("end", () => {
+            if (passthrough) {
+              res.end();
+              return;
+            }
+            injectSwitcher(chunks, responseHeaders, host, matchingRoutes, route, req.url)
+              .then((body) => {
+                delete responseHeaders["transfer-encoding"];
+                responseHeaders["content-length"] = String(body.length);
+                res.writeHead(proxyRes.statusCode || 502, responseHeaders);
+                res.end(body);
+              })
+              .catch(() => {
+                delete responseHeaders["content-length"];
+                res.writeHead(proxyRes.statusCode || 502, responseHeaders);
+                for (const chunk of chunks) res.write(chunk);
+                res.end();
+              });
+          });
+        } else {
+          proxyRes.pipe(res);
+        }
       }
     );
 
@@ -278,7 +523,11 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
 
     const routes = getRoutes();
     const host = getRequestHost(req).split(":")[0];
-    const route = findRoute(routes, host, strict);
+    const matchingRoutes = findRoutes(routes, host, strict);
+    const route =
+      multiplex && matchingRoutes.length > 1
+        ? routeFromCookie(matchingRoutes, req.headers.cookie)
+        : matchingRoutes[0];
 
     if (!route) {
       socket.destroy();

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -256,6 +256,7 @@ async function injectSwitcher(
   const next = encodeURIComponent(reqUrl || "/");
   const currentId = getRouteId(currentRoute);
   const routeCount = String(routes.length);
+  const clearHref = `${CONTROL_PREFIX}/clear?next=${next}`;
   const links = routes
     .map((route) => {
       const id = getRouteId(route);
@@ -276,10 +277,10 @@ async function injectSwitcher(
             `<span class="pl-row"><span>${escapeHtml(label)}</span><code>${escapeHtml(value)}</code></span>`
         )
         .join("");
-      return `<a class="pl-app${selected ? " pl-active" : ""}" href="${href}"><span class="pl-app-top"><span class="pl-dot"></span><span class="pl-title">${escapeHtml(route.folder || route.hostname)}</span><span class="pl-port">${escapeHtml(String(route.port))}</span></span><span class="pl-details">${detailRows}</span></a>`;
+      return `<div class="pl-app${selected ? " pl-active" : ""}"><div class="pl-app-top"><span class="pl-dot"></span><span class="pl-title">${escapeHtml(route.folder || route.hostname)}</span><span class="pl-port">${escapeHtml(String(route.port))}</span></div><div class="pl-details">${detailRows}</div><div class="pl-actions"><a class="pl-select" href="${href}">${selected ? "Selected" : "Select"}</a></div></div>`;
     })
     .join("");
-  const widget = `<div class="pl-switcher" aria-label="Portless app switcher"><input id="pl-switcher-toggle" type="checkbox" class="pl-toggle"><label for="pl-switcher-toggle" class="pl-icon" title="Switch portless app"><span class="pl-mark">p</span><span class="pl-count">${escapeHtml(routeCount)}</span></label><div class="pl-panel"><div class="pl-head"><div><p>portless</p><strong>${escapeHtml(host)}</strong></div><label for="pl-switcher-toggle" aria-label="Collapse portless app switcher">close</label></div><div class="pl-list">${links}</div></div><style>
+  const widget = `<div class="pl-switcher" aria-label="Portless app switcher"><input id="pl-switcher-toggle" type="checkbox" class="pl-toggle"><label for="pl-switcher-toggle" class="pl-icon" title="Switch portless app"><span class="pl-mark">p</span><span class="pl-count">${escapeHtml(routeCount)}</span></label><div class="pl-panel"><div class="pl-head"><div><p>portless</p><strong>${escapeHtml(host)}</strong></div><label for="pl-switcher-toggle" aria-label="Collapse portless app switcher">close</label></div><div class="pl-list">${links}</div><div class="pl-foot"><a class="pl-clear" href="${clearHref}">Clear selection</a></div></div><style>
 .pl-switcher{--pl-bg:#fff;--pl-fg:#111;--pl-muted:#666;--pl-soft:#f6f6f6;--pl-border:rgba(0,0,0,.13);--pl-active:#eef6ff;--pl-active-border:#60a5fa;position:fixed;right:16px;bottom:16px;z-index:2147483647;font:13px/1.35 ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;color:var(--pl-fg)}
 @media (prefers-color-scheme:dark){.pl-switcher{--pl-bg:#0b0b0b;--pl-fg:#f4f4f5;--pl-muted:#a1a1aa;--pl-soft:#18181b;--pl-border:rgba(255,255,255,.16);--pl-active:#082f49;--pl-active-border:#38bdf8}}
 .pl-switcher *{box-sizing:border-box}
@@ -295,7 +296,7 @@ async function injectSwitcher(
 .pl-head strong{display:block;max-inline-size:300px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:14px}
 .pl-head label{color:var(--pl-muted);font-size:12px;cursor:pointer}
 .pl-list{display:grid;gap:8px;max-block-size:520px;overflow:auto;padding:10px}
-.pl-app{display:block;padding:10px;border:1px solid var(--pl-border);border-radius:8px;background:var(--pl-soft);color:inherit;text-decoration:none}
+.pl-app{display:block;padding:10px;border:1px solid var(--pl-border);border-radius:8px;background:var(--pl-soft);color:inherit}
 .pl-app:hover{border-color:var(--pl-active-border)}
 .pl-active{background:var(--pl-active);border-color:var(--pl-active-border)}
 .pl-app-top{display:grid;grid-template-columns:10px minmax(0,1fr) auto;align-items:center;gap:8px}
@@ -307,6 +308,13 @@ async function injectSwitcher(
 .pl-row{min-width:0}
 .pl-row span{display:block;margin-bottom:2px;color:var(--pl-muted);font-size:10px;font-weight:650;text-transform:uppercase;letter-spacing:0}
 .pl-row code{display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--pl-fg);font:12px ui-monospace,SFMono-Regular,Menlo,monospace}
+.pl-actions{display:flex;justify-content:flex-end;margin-top:10px}
+.pl-select,.pl-clear{display:inline-flex;align-items:center;justify-content:center;min-block-size:30px;border-radius:6px;text-decoration:none;font-weight:700}
+.pl-select{padding:0 11px;background:var(--pl-fg);color:var(--pl-bg)}
+.pl-active .pl-select{border:1px solid var(--pl-border);background:transparent;color:var(--pl-fg)}
+.pl-foot{display:flex;justify-content:flex-end;padding:0 10px 10px}
+.pl-clear{padding:0 10px;border:1px solid var(--pl-border);color:var(--pl-muted);background:transparent}
+.pl-clear:hover{color:var(--pl-fg);border-color:var(--pl-active-border)}
 @media (max-width:460px){.pl-switcher{right:10px;bottom:10px}.pl-details{grid-template-columns:1fr}.pl-head strong{max-inline-size:230px}}
 </style></div>`;
   const injected = html.includes("</body>")

--- a/packages/portless/src/routes.test.ts
+++ b/packages/portless/src/routes.test.ts
@@ -436,6 +436,21 @@ describe("RouteStore", () => {
   });
 
   describe("tailscale metadata", () => {
+    it("persists app metadata from addRoute", () => {
+      store.addRoute("myapp.localhost", 4123, process.pid, false, false, {
+        cwd: "/repo/apps/web",
+        folder: "web",
+        gitBranch: "feature-auth",
+        command: "pnpm dev",
+      });
+      const routes = store.loadRoutes();
+      expect(routes).toHaveLength(1);
+      expect(routes[0].cwd).toBe("/repo/apps/web");
+      expect(routes[0].folder).toBe("web");
+      expect(routes[0].gitBranch).toBe("feature-auth");
+      expect(routes[0].command).toBe("pnpm dev");
+    });
+
     it("persists and loads tailscale fields via updateRoute", () => {
       store.addRoute("myapp.localhost", 4123, process.pid);
       store.updateRoute("myapp.localhost", {

--- a/packages/portless/src/routes.test.ts
+++ b/packages/portless/src/routes.test.ts
@@ -162,16 +162,51 @@ describe("RouteStore", () => {
       store.addRoute("myapp.localhost", 4001, process.pid);
       const routes = store.loadRoutes();
       expect(routes).toHaveLength(1);
-      expect(routes[0]).toEqual({
+      expect(routes[0]).toMatchObject({
         hostname: "myapp.localhost",
         port: 4001,
         pid: process.pid,
       });
+      expect(routes[0].id).toBe(`myapp.localhost:4001:${process.pid}`);
     });
 
     it("replaces existing route with same hostname", () => {
       store.addRoute("myapp.localhost", 4001, process.pid);
       store.addRoute("myapp.localhost", 4002, process.pid);
+      const routes = store.loadRoutes();
+      expect(routes).toHaveLength(1);
+      expect(routes[0].port).toBe(4002);
+    });
+
+    it("allows duplicate hostnames when multiplex is enabled", () => {
+      store.addRoute("myapp.localhost", 4001, process.pid);
+      store.addRoute("myapp.localhost", 4002, 0, false, true);
+      const routes = store.loadRoutes();
+      expect(routes).toHaveLength(2);
+      expect(routes.map((r) => r.port).sort()).toEqual([4001, 4002]);
+    });
+
+    it("allows duplicate multiplex hostnames owned by the same PID when ports differ", () => {
+      store.addRoute("myapp.localhost", 4001, process.pid, false, true);
+      store.addRoute("myapp.localhost", 4002, process.pid, false, true);
+      const routes = store.loadRoutes();
+      expect(routes).toHaveLength(2);
+      expect(routes.map((r) => r.port).sort()).toEqual([4001, 4002]);
+    });
+
+    it("removes only the matching PID when one is provided", () => {
+      store.addRoute("myapp.localhost", 4001, process.pid);
+      store.addRoute("myapp.localhost", 4002, 0, false, true);
+      store.removeRoute("myapp.localhost", process.pid);
+      const routes = store.loadRoutes();
+      expect(routes).toHaveLength(1);
+      expect(routes[0].port).toBe(4002);
+    });
+
+    it("removes only the matching port when PID and port are provided", () => {
+      store.addRoute("myapp.localhost", 4001, process.pid, false, true);
+      store.addRoute("myapp.localhost", 4002, process.pid, false, true);
+      store.removeRoute("myapp.localhost", process.pid, 4001);
       const routes = store.loadRoutes();
       expect(routes).toHaveLength(1);
       expect(routes[0].port).toBe(4002);

--- a/packages/portless/src/routes.ts
+++ b/packages/portless/src/routes.ts
@@ -22,6 +22,7 @@ export const FILE_MODE = 0o644;
 export const DIR_MODE = 0o755;
 
 export interface RouteMapping extends RouteInfo {
+  id: string;
   pid: number;
   tailscaleUrl?: string;
   tailscaleHttpsPort?: number;
@@ -35,8 +36,13 @@ function isValidRoute(value: unknown): value is RouteMapping {
     value !== null &&
     typeof (value as RouteMapping).hostname === "string" &&
     typeof (value as RouteMapping).port === "number" &&
-    typeof (value as RouteMapping).pid === "number"
+    typeof (value as RouteMapping).pid === "number" &&
+    ((value as RouteMapping).id === undefined || typeof (value as RouteMapping).id === "string")
   );
+}
+
+function routeId(hostname: string, port: number, pid: number): string {
+  return `${hostname}:${port}:${pid}`;
 }
 
 /**
@@ -178,7 +184,10 @@ export class RouteStore {
         this.onWarning?.(`Corrupted routes file (expected array): ${this.routesPath}`);
         return [];
       }
-      const routes: RouteMapping[] = parsed.filter(isValidRoute);
+      const routes: RouteMapping[] = parsed.filter(isValidRoute).map((route) => ({
+        ...route,
+        id: route.id || routeId(route.hostname, route.port, route.pid),
+      }));
       // Filter out stale routes whose owning process is no longer alive
       const alive = routes.filter((r) => r.pid === 0 || this.isProcessAlive(r.pid));
       if (persistCleanup && alive.length !== routes.length) {
@@ -209,7 +218,13 @@ export class RouteStore {
    * replaced. Returns the PID of the killed process (if any) so the caller can
    * log it.
    */
-  addRoute(hostname: string, port: number, pid: number, force = false): number | undefined {
+  addRoute(
+    hostname: string,
+    port: number,
+    pid: number,
+    force = false,
+    multiplex = false
+  ): number | undefined {
     this.ensureDir();
     if (!this.acquireLock()) {
       throw new Error("Failed to acquire route lock");
@@ -217,21 +232,33 @@ export class RouteStore {
     let killedPid: number | undefined;
     try {
       const routes = this.loadRoutes(true);
-      const existing = routes.find((r) => r.hostname === hostname);
-      if (existing && existing.pid !== pid && this.isProcessAlive(existing.pid)) {
-        if (!force) {
-          throw new RouteConflictError(hostname, existing.pid);
+      const existingRoutes = routes.filter((r) => r.hostname === hostname && r.pid !== pid);
+      const liveExisting = existingRoutes.filter((r) => r.pid === 0 || this.isProcessAlive(r.pid));
+      if (liveExisting.length > 0) {
+        if (!force && !multiplex) {
+          throw new RouteConflictError(hostname, liveExisting[0].pid);
         }
-        // --force: kill the existing process before taking over
-        try {
-          process.kill(existing.pid, "SIGTERM");
-          killedPid = existing.pid;
-        } catch {
-          // Process may have exited between the check and the kill; non-fatal
+        if (force) {
+          for (const existing of liveExisting) {
+            // --force: kill the existing process before taking over
+            if (existing.pid !== 0) {
+              try {
+                process.kill(existing.pid, "SIGTERM");
+                killedPid ??= existing.pid;
+              } catch {
+                // Process may have exited between the check and the kill; non-fatal
+              }
+            }
+          }
         }
       }
-      const filtered = routes.filter((r) => r.hostname !== hostname);
-      const entry: RouteMapping = { hostname, port, pid };
+      const filtered = routes.filter((r) => {
+        if (r.hostname !== hostname) return true;
+        if (force) return false;
+        if (multiplex) return r.pid !== pid || r.port !== port;
+        return r.pid !== pid;
+      });
+      const entry: RouteMapping = { id: routeId(hostname, port, pid), hostname, port, pid };
       filtered.push(entry);
       this.saveRoutes(filtered);
     } finally {
@@ -260,7 +287,10 @@ export class RouteStore {
       if (!Array.isArray(parsed)) {
         return [];
       }
-      return parsed.filter(isValidRoute);
+      return parsed.filter(isValidRoute).map((route) => ({
+        ...route,
+        id: route.id || routeId(route.hostname, route.port, route.pid),
+      }));
     } catch {
       return [];
     }
@@ -301,7 +331,9 @@ export class RouteStore {
    */
   updateRoute(
     hostname: string,
-    fields: Partial<Pick<RouteMapping, "tailscaleUrl" | "tailscaleHttpsPort" | "tailscaleFunnel">>
+    fields: Partial<Pick<RouteMapping, "tailscaleUrl" | "tailscaleHttpsPort" | "tailscaleFunnel">>,
+    pid?: number,
+    port?: number
   ): void {
     this.ensureDir();
     if (!this.acquireLock()) {
@@ -309,7 +341,12 @@ export class RouteStore {
     }
     try {
       const routes = this.loadRoutes(true);
-      const route = routes.find((r) => r.hostname === hostname);
+      const route = routes.find(
+        (r) =>
+          r.hostname === hostname &&
+          (pid === undefined || r.pid === pid) &&
+          (port === undefined || r.port === port)
+      );
       if (!route) return;
       if (fields.tailscaleUrl !== undefined) route.tailscaleUrl = fields.tailscaleUrl;
       if (fields.tailscaleHttpsPort !== undefined)
@@ -321,13 +358,18 @@ export class RouteStore {
     }
   }
 
-  removeRoute(hostname: string): void {
+  removeRoute(hostname: string, pid?: number, port?: number): void {
     this.ensureDir();
     if (!this.acquireLock()) {
       throw new Error("Failed to acquire route lock");
     }
     try {
-      const routes = this.loadRoutes(true).filter((r) => r.hostname !== hostname);
+      const routes = this.loadRoutes(true).filter(
+        (r) =>
+          r.hostname !== hostname ||
+          (pid !== undefined && r.pid !== pid) ||
+          (port !== undefined && r.port !== port)
+      );
       this.saveRoutes(routes);
     } finally {
       this.releaseLock();

--- a/packages/portless/src/routes.ts
+++ b/packages/portless/src/routes.ts
@@ -24,6 +24,10 @@ export const DIR_MODE = 0o755;
 export interface RouteMapping extends RouteInfo {
   id: string;
   pid: number;
+  cwd?: string;
+  folder?: string;
+  gitBranch?: string;
+  command?: string;
   tailscaleUrl?: string;
   tailscaleHttpsPort?: number;
   tailscaleFunnel?: boolean;
@@ -37,7 +41,15 @@ function isValidRoute(value: unknown): value is RouteMapping {
     typeof (value as RouteMapping).hostname === "string" &&
     typeof (value as RouteMapping).port === "number" &&
     typeof (value as RouteMapping).pid === "number" &&
-    ((value as RouteMapping).id === undefined || typeof (value as RouteMapping).id === "string")
+    ((value as RouteMapping).id === undefined || typeof (value as RouteMapping).id === "string") &&
+    ((value as RouteMapping).cwd === undefined ||
+      typeof (value as RouteMapping).cwd === "string") &&
+    ((value as RouteMapping).folder === undefined ||
+      typeof (value as RouteMapping).folder === "string") &&
+    ((value as RouteMapping).gitBranch === undefined ||
+      typeof (value as RouteMapping).gitBranch === "string") &&
+    ((value as RouteMapping).command === undefined ||
+      typeof (value as RouteMapping).command === "string")
   );
 }
 
@@ -223,7 +235,8 @@ export class RouteStore {
     port: number,
     pid: number,
     force = false,
-    multiplex = false
+    multiplex = false,
+    metadata: Partial<Pick<RouteMapping, "cwd" | "folder" | "gitBranch" | "command">> = {}
   ): number | undefined {
     this.ensureDir();
     if (!this.acquireLock()) {
@@ -258,7 +271,13 @@ export class RouteStore {
         if (multiplex) return r.pid !== pid || r.port !== port;
         return r.pid !== pid;
       });
-      const entry: RouteMapping = { id: routeId(hostname, port, pid), hostname, port, pid };
+      const entry: RouteMapping = {
+        id: routeId(hostname, port, pid),
+        hostname,
+        port,
+        pid,
+        ...metadata,
+      };
       filtered.push(entry);
       this.saveRoutes(filtered);
     } finally {

--- a/packages/portless/src/types.ts
+++ b/packages/portless/src/types.ts
@@ -1,7 +1,9 @@
 /** Route info used by the proxy server to map hostnames to ports. */
 export interface RouteInfo {
+  id?: string;
   hostname: string;
   port: number;
+  pid?: number;
 }
 
 export interface ProxyServerOptions {
@@ -17,6 +19,8 @@ export interface ProxyServerOptions {
    * Defaults to true.
    */
   strict?: boolean;
+  /** When true, duplicate hostnames show an app selector instead of conflicting. */
+  multiplex?: boolean;
   /** Optional error logger; defaults to console.error. */
   onError?: (message: string) => void;
   /** When provided, enables HTTP/2 over TLS (HTTPS). */

--- a/packages/portless/src/types.ts
+++ b/packages/portless/src/types.ts
@@ -4,6 +4,10 @@ export interface RouteInfo {
   hostname: string;
   port: number;
   pid?: number;
+  cwd?: string;
+  folder?: string;
+  gitBranch?: string;
+  command?: string;
 }
 
 export interface ProxyServerOptions {

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -133,6 +133,18 @@ portless docs.myapp next dev     # https://docs.myapp.localhost
 
 By default, only explicitly registered subdomains are routed (strict mode). Start the proxy with `--wildcard` to allow any subdomain of a registered route to fall back to that app (e.g. `tenant1.myapp.localhost` routes to the `myapp` app). Exact matches always take priority over wildcards.
 
+### Multiplexed hostnames
+
+By default, duplicate hostnames conflict. Start the proxy with `--multiplex` when multiple apps should intentionally share one hostname:
+
+```bash
+portless proxy start --multiplex
+portless myapp next dev
+portless myapp vite dev
+```
+
+When one app is registered for the hostname, portless routes directly to it. When multiple apps are registered, portless shows a selector page and stores the selection in a host-scoped cookie. HTML responses include a small switcher for changing the selected app. Use `PORTLESS_MULTIPLEX=1` to make this the default proxy mode.
+
 ### Git worktrees
 
 `portless run` automatically detects git worktrees. In a linked worktree, the branch name is prepended as a subdomain prefix so each worktree gets a unique URL:
@@ -179,6 +191,7 @@ Portless stores its state (routes, PID file, port file) in `~/.portless`. Overri
 | `PORTLESS_LAN`        | Set to `1` to always enable LAN mode (auto-detects LAN IP)                  |
 | `PORTLESS_TLD`        | Use a custom TLD instead of localhost (e.g. test)                           |
 | `PORTLESS_WILDCARD`   | Set to `1` to allow unregistered subdomains to fall back to parent          |
+| `PORTLESS_MULTIPLEX`  | Set to `1` to allow multiple apps to share the same hostname                |
 | `PORTLESS_SYNC_HOSTS` | Set to `0` to disable auto-sync of /etc/hosts (on by default)               |
 | `PORTLESS_TAILSCALE`  | Set to `1` to share apps on your Tailscale network (same as `--tailscale`)  |
 | `PORTLESS_FUNNEL`     | Set to `1` to share apps publicly via Tailscale Funnel (same as `--funnel`) |
@@ -262,6 +275,7 @@ Each `--tailscale` app is root-mounted on its own Tailscale HTTPS port (443, the
 | `portless proxy start --tld test`      | Use .test instead of .localhost                                |
 | `portless proxy start --foreground`    | Start the proxy in foreground (for debugging)                  |
 | `portless proxy start --wildcard`      | Allow unregistered subdomains to fall back to parent route     |
+| `portless proxy start --multiplex`     | Allow multiple apps to share the same hostname                 |
 | `portless proxy stop`                  | Stop the proxy                                                 |
 | `portless alias <name> <port>`         | Register a static route (e.g. for Docker containers)           |
 | `portless alias <name> <port> --force` | Overwrite an existing route                                    |

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -143,7 +143,7 @@ portless myapp next dev
 portless myapp vite dev
 ```
 
-When one app is registered for the hostname, portless routes directly to it. When multiple apps are registered, portless shows a selector page and stores the selection in a host-scoped cookie. HTML responses include a collapsed switcher that follows the system theme. Expand it to change the selected app and inspect host, port, PID, git branch, folder, and command details. Use `PORTLESS_MULTIPLEX=1` to make this the default proxy mode.
+When one app is registered for the hostname, portless routes directly to it. When multiple apps are registered, portless shows a selector page with host, port, PID, git branch, folder, and command details for each app, then stores the selection in a host-scoped cookie. HTML responses include a collapsed switcher that follows the system theme. Expand it to change or clear the selected app and inspect the same details. Use `PORTLESS_MULTIPLEX=1` to make this the default proxy mode.
 
 ### Git worktrees
 

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -143,7 +143,7 @@ portless myapp next dev
 portless myapp vite dev
 ```
 
-When one app is registered for the hostname, portless routes directly to it. When multiple apps are registered, portless shows a selector page and stores the selection in a host-scoped cookie. HTML responses include a small switcher for changing the selected app. Use `PORTLESS_MULTIPLEX=1` to make this the default proxy mode.
+When one app is registered for the hostname, portless routes directly to it. When multiple apps are registered, portless shows a selector page and stores the selection in a host-scoped cookie. HTML responses include a collapsed switcher that follows the system theme. Expand it to change the selected app and inspect host, port, PID, git branch, folder, and command details. Use `PORTLESS_MULTIPLEX=1` to make this the default proxy mode.
 
 ### Git worktrees
 


### PR DESCRIPTION
**AI generated PR disclosure**

https://github.com/user-attachments/assets/f21ad4a7-51cc-44f3-9b77-27cda23b86aa

Overall pretty happy with this, behavior:
- If just one app is running, it works like normal
- If multiple apps are running, it prompts you to select and app and saves your choice
- There's a button in the bottom right to swap between selected apps and clear selection
- Worktrees redirect you to the right location

Use case is for redirects with auth. Manually reviewed the code and am happy with it, the HTML insertion is ugly but works.


AI Summary below:
----


## Summary

- add multiplexed hostname routing behind `--multiplex` / `PORTLESS_MULTIPLEX=1`
- show a selector when multiple apps share the same hostname and persist the selected app in a cookie
- inject a small app switcher into HTML responses when multiple apps are available
- update route persistence, CLI behavior, docs, and tests for multiplex mode

## Validation

- `pnpm --filter portless build`
- `pnpm --filter portless type-check`
- `pnpm --filter portless lint`
- `pnpm --filter portless test -- src/routes.test.ts src/proxy.test.ts src/cli-utils.test.ts src/cli.test.ts`
- `pnpm --filter portless test`

## Notes

- Manually tested two apps on `mux.localhost:1355` with the portless proxy in multiplex mode.
