### PR TITLE
Apply worktree prefix in monorepo default mode

### DIFF
--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -2843,6 +2843,8 @@ async function handleDefaultMulti(
     process.exit(1);
   }
 
+  const worktree = detectWorktreePrefix(wsRoot);
+
   const scriptName = globalScript ?? loaded?.config.script ?? "dev";
 
   // Infer the monorepo project name for use as the base domain.
@@ -2910,10 +2912,11 @@ async function handleDefaultMulti(
     let name: string;
     let label: string;
     if (appOverride.name) {
-      name = appOverride.name
+      const baseName = appOverride.name
         .split(".")
         .map((l) => truncateLabel(l))
         .join(".");
+      name = worktree ? `${worktree.prefix}.${baseName}` : baseName;
       label = appOverride.name;
     } else {
       let pkgLabel: string;
@@ -2923,7 +2926,8 @@ async function handleDefaultMulti(
       } else {
         pkgLabel = rel.replace(/\//g, "-");
       }
-      name = pkgLabel === projectName ? projectName : `${pkgLabel}.${projectName}`;
+      const baseName = pkgLabel === projectName ? projectName : `${pkgLabel}.${projectName}`;
+      name = worktree ? `${worktree.prefix}.${baseName}` : baseName;
       label = pkg.scope ? `@${pkg.scope}/${pkg.name}` : (pkg.name ?? rel);
     }
 


### PR DESCRIPTION
## Summary

Bare `portless` from a workspace root assigns the same hostnames in every git worktree, causing route collisions. `portless run --name <name>` works correctly. Only the bare-binary monorepo path is affected.

## Reproduction

```bash
# main checkout
cd ~/repo && portless
# -> https://app.localhost
# -> https://api.localhost

# linked worktree on branch "feature-x"
cd ~/repo/.worktrees/feature-x && portless
# -> https://app.localhost      (collides with main)
# -> https://api.localhost      (collides with main)
#
# expected:
# -> https://feature-x.app.localhost
# -> https://feature-x.api.localhost
```

Same behavior with or without a `portless.json` `apps` map. Reproduced on 0.11.1 and against current `main`.

## Root cause

In `packages/portless/src/cli.ts`:

- `handleDefaultSingle` calls `detectWorktreePrefix(cwd)` and prepends `worktree.prefix` to the resolved name.
- `handleDefaultMulti` never calls `detectWorktreePrefix`. The `name` is taken straight from `appOverride.name` or `${pkgLabel}.${projectName}` with no prefix.

The README's "Git Worktrees" section and the `name` config field doc ("Worktree prefix still applies") both suggest the prefix should apply in either path.

## Fix

Mirror what `handleDefaultSingle` already does. Detect the worktree once at the top of `handleDefaultMulti`, then in both branches that compute `name` extract the existing logic into a `baseName` local and prepend the prefix when a worktree is detected.

No behavior change in the main checkout: `detectWorktreePrefix` returns `null`, the ternary falls through to `baseName`, and the assigned `name` is byte-identical to the previous output.

## Verification

- `pnpm install`, `pnpm type-check`, `pnpm lint`, `pnpm build`, `pnpm test` all green (595/595 tests pass).
- Patched against an in-the-wild pnpm monorepo with two apps: main checkout produces `<app>.<project>.localhost`, linked worktree on branch `test-portless` produces `test-portless.<app>.<project>.localhost` as expected.

Happy to add a regression test if there's a preferred fixture pattern for `handleDefaultMulti` (the existing CLI tests cover the surface but I did not see one specifically exercising the multi + worktree combination).