### PR TITLE
Inject --port and --ip for wrangler dev (fixes #263)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ portless myapp next dev
 
 HTTPS with HTTP/2 is enabled by default. On first run, portless generates a local CA, trusts it, and binds port 443 (auto-elevates with sudo on macOS/Linux). Use `--no-tls` for plain HTTP.
 
-The proxy auto-starts when you run an app. A random port (4000-4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, VitePlus, Astro, React Router, Angular, Expo, React Native), portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag.
+The proxy auto-starts when you run an app. A random port (4000-4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, VitePlus, Astro, React Router, Angular, Expo, React Native, Wrangler), portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag (or `--ip` for Wrangler).
 
 When auto-starting, portless reuses the configuration (port, TLS, TLD) from the most recent proxy run, so a restart or reboot does not silently revert to defaults. Explicit env vars (`PORTLESS_PORT`, `PORTLESS_HTTPS`, etc.) always take priority.
 

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -434,6 +434,41 @@ describe("injectFrameworkFlags", () => {
     }
   });
 
+  // Wrangler doesn't honor PORT (issue #263). Wrangler uses --ip for the
+  // bind address; --host has a different meaning (route hostname).
+  it("injects --port and --ip for wrangler dev", () => {
+    const args = ["wrangler", "dev"];
+    injectFrameworkFlags(args, 4567);
+    expect(args).toEqual(["wrangler", "dev", "--port", "4567", "--ip", "127.0.0.1"]);
+  });
+
+  it("skips --ip injection for wrangler when --ip is already present", () => {
+    const args = ["wrangler", "dev", "--ip", "0.0.0.0"];
+    injectFrameworkFlags(args, 4567);
+    expect(args).toEqual(["wrangler", "dev", "--ip", "0.0.0.0", "--port", "4567"]);
+  });
+
+  it("does not inject --host for wrangler (route hostname, not bind address)", () => {
+    const args = ["wrangler", "dev", "--host", "example.com"];
+    injectFrameworkFlags(args, 4567);
+    expect(args).toEqual([
+      "wrangler",
+      "dev",
+      "--host",
+      "example.com",
+      "--port",
+      "4567",
+      "--ip",
+      "127.0.0.1",
+    ]);
+  });
+
+  it("injects flags for npx wrangler dev", () => {
+    const args = ["npx", "wrangler", "dev"];
+    injectFrameworkFlags(args, 4567);
+    expect(args).toEqual(["npx", "wrangler", "dev", "--port", "4567", "--ip", "127.0.0.1"]);
+  });
+
   it("does not inject for frameworks that read PORT", () => {
     const nextArgs = ["next", "dev"];
     injectFrameworkFlags(nextArgs, 4567);

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -861,11 +861,13 @@ export function spawnCommand(
  * Frameworks that ignore the `PORT` env var. Maps command basename to the
  * flags needed. `strictPort` indicates whether `--strictPort` is supported
  * (prevents the framework from silently picking a different port).
+ * `hostFlag` overrides the default `--host` flag name for frameworks that
+ * use a different flag for the bind address (e.g. wrangler uses `--ip`).
  *
  * SvelteKit is not listed because its dev server is Vite under the hood,
  * so the `vite` entry already covers it.
  */
-const FRAMEWORKS_NEEDING_PORT: Record<string, { strictPort: boolean }> = {
+const FRAMEWORKS_NEEDING_PORT: Record<string, { strictPort: boolean; hostFlag?: string }> = {
   vite: { strictPort: true },
   vp: { strictPort: true },
   "react-router": { strictPort: true },
@@ -874,6 +876,7 @@ const FRAMEWORKS_NEEDING_PORT: Record<string, { strictPort: boolean }> = {
   ng: { strictPort: false },
   "react-native": { strictPort: false },
   expo: { strictPort: false },
+  wrangler: { strictPort: false, hostFlag: "--ip" },
 };
 
 /** Known package runners. Values list subcommands that run a package. */
@@ -950,13 +953,14 @@ export function injectFrameworkFlags(commandArgs: string[], port: number): void 
     }
   }
 
-  if (!commandArgs.includes("--host")) {
+  const hostFlag = framework.hostFlag ?? "--host";
+  if (!commandArgs.includes(hostFlag)) {
     // In LAN mode, let Expo use its default (LAN) — injecting --host alongside
     // HOST=127.0.0.1 causes Metro's HMR WebSocket to break after a few reloads.
     const isExpoLan = basename === "expo" && isLanEnvEnabled();
     if (isExpoLan) return;
     const hostValue = basename === "expo" ? "localhost" : "127.0.0.1";
-    commandArgs.push("--host", hostValue);
+    commandArgs.push(hostFlag, hostValue);
   }
 }
 

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1461,8 +1461,8 @@ ${colors.bold("How it works:")}
   3. Access via https://<name>.localhost
   4. .localhost domains auto-resolve to 127.0.0.1
   5. Frameworks that ignore PORT (Vite, VitePlus, Astro, React Router, Angular,
-     Expo, React Native) get --port and, when needed, --host flags
-     injected automatically
+     Expo, React Native, Wrangler) get --port and, when needed, --host or
+     --ip flags injected automatically
 
 ${colors.bold("HTTP/2 + HTTPS (default):")}
   HTTPS with HTTP/2 multiplexing is enabled by default (faster page loads).

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -163,7 +163,7 @@ PORTLESS=0 pnpm dev   # Bypasses proxy, uses default port
 
 `.localhost` domains resolve to `127.0.0.1` natively in Chrome, Firefox, and Edge. Safari relies on the system DNS resolver, which may not handle `.localhost` subdomains on all configurations. Run `portless hosts sync` to add entries to `/etc/hosts` if needed.
 
-Most frameworks (Next.js, Express, Nuxt, etc.) respect the `PORT` env var automatically. For frameworks that ignore `PORT` (Vite, VitePlus, Astro, React Router, Angular, Expo, React Native), portless auto-injects the correct `--port` flag and, when needed, a matching `--host` CLI flag.
+Most frameworks (Next.js, Express, Nuxt, etc.) respect the `PORT` env var automatically. For frameworks that ignore `PORT` (Vite, VitePlus, Astro, React Router, Angular, Expo, React Native, Wrangler), portless auto-injects the correct `--port` flag and, when needed, a matching `--host` CLI flag (or `--ip` for Wrangler).
 
 ### State directory
 
@@ -331,7 +331,7 @@ portless proxy start -p 8080
 
 ### Framework not respecting PORT
 
-Portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag for frameworks that ignore the `PORT` env var: **Vite**, **VitePlus** (`vp`), **Astro**, **React Router**, **Angular**, **Expo**, and **React Native**. SvelteKit uses Vite internally and is handled automatically.
+Portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag for frameworks that ignore the `PORT` env var: **Vite**, **VitePlus** (`vp`), **Astro**, **React Router**, **Angular**, **Expo**, **React Native**, and **Wrangler** (uses `--ip` instead of `--host`). SvelteKit uses Vite internally and is handled automatically.
 
 For other frameworks that don't read `PORT`, pass the port manually:
 


### PR DESCRIPTION
## Summary

- Fixes #263. Wrangler does not honor the `PORT` env var, so portless was unable to route the auto-assigned port to wrangler-based apps.
- Adds `wrangler` to the framework auto-injection table so portless appends `--port <port>` to the spawned command.
- Wrangler uses `--ip` for the bind address (its `--host` flag refers to the route hostname, not where to listen), so this PR also introduces a per-framework `hostFlag` override and emits `--ip 127.0.0.1` for wrangler.
- Updates README, SKILL.md, and `--help` output to reflect the new framework.

## Test plan

- [x] `pnpm --filter portless test` (599 tests pass, including 4 new wrangler cases in `cli-utils.test.ts`)
- [x] `pnpm lint`
- [x] `pnpm --filter portless run type-check`
- [x] `pnpm --filter portless run build`
- [ ] Manual smoke test: `portless run wrangler dev` against a Worker project on a fresh proxy and confirm the dashboard shows the auto-assigned port

🤖 Generated with [Claude Code](https://claude.com/claude-code)