### PR TITLE
Stop --tailscale hanging when HTTPS certificates are not set up

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ portless myapp --funnel next dev
 
 Set `PORTLESS_TAILSCALE=1` in your shell profile or `.env` to share every app by default. `portless list` shows both local and tailnet URLs. Tailscale serve registrations are cleaned up automatically when the app exits.
 
-Requires the Tailscale CLI to be installed and connected (`tailscale up`).
+Requires the Tailscale CLI to be installed and connected (`tailscale up`), with MagicDNS and HTTPS Certificates enabled on the active tailnet.
 
 ## Commands
 

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -1331,6 +1331,7 @@ describe("CLI", () => {
       expect(stdout).toContain("--tailscale");
       expect(stdout).toContain("--funnel");
       expect(stdout).toContain("PORTLESS_TAILSCALE");
+      expect(stdout).toContain("HTTPS Certificates");
     });
 
     it("fails with actionable message when tailscale is not installed", () => {

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -966,6 +966,8 @@ async function runApp(
       console.error(colors.red(`Error: ${message}`));
       if (message.includes("not found")) {
         console.error(colors.blue("Install Tailscale: https://tailscale.com/download"));
+      } else if (message.includes("HTTPS Certificates")) {
+        // The error already points at the required admin console setting.
       } else {
         console.error(colors.blue("Make sure Tailscale is connected:"));
         console.error(colors.cyan("  tailscale up"));
@@ -1490,7 +1492,8 @@ ${colors.bold("Tailscale sharing:")}
   Each app is root-mounted on its own Tailscale HTTPS port (443, then 8443,
   8444, etc.) so no basePath configuration is needed.
   Use --funnel to expose your dev server to the public internet via
-  Tailscale Funnel. Requires Tailscale CLI to be installed and connected.
+  Tailscale Funnel. Requires Tailscale CLI to be installed and connected,
+  with MagicDNS and HTTPS Certificates enabled on the active tailnet.
   ${colors.cyan("portless myapp --tailscale next dev")}
   ${colors.cyan("portless myapp --funnel next dev")}
 

--- a/packages/portless/src/tailscale.test.ts
+++ b/packages/portless/src/tailscale.test.ts
@@ -52,6 +52,7 @@ describe("tailscale", () => {
           status: 0,
           stdout: JSON.stringify({
             Self: { DNSName: "devbox.example.ts.net." },
+            CertDomains: ["devbox.example.ts.net"],
           }),
         },
       });
@@ -68,12 +69,53 @@ describe("tailscale", () => {
           stdout: JSON.stringify({
             Self: { HostName: "devbox" },
             CurrentTailnet: { MagicDNSSuffix: "example.ts.net." },
+            CertDomains: ["devbox.example.ts.net"],
           }),
         },
       });
       const ready = ensureTailscaleReady(runner);
       expect(ready.dnsName).toBe("devbox.example.ts.net");
     });
+
+    it("accepts certificate domains with trailing dots", () => {
+      const runner = createRunner({
+        version: { status: 0 },
+        "status --json": {
+          status: 0,
+          stdout: JSON.stringify({
+            Self: { DNSName: "devbox.example.ts.net." },
+            CertDomains: ["devbox.example.ts.net."],
+          }),
+        },
+      });
+      const ready = ensureTailscaleReady(runner);
+      expect(ready.dnsName).toBe("devbox.example.ts.net");
+    });
+
+    it.each([
+      ["missing", undefined],
+      ["null", null],
+      ["empty", []],
+      ["mismatched", ["other.example.ts.net"]],
+    ] as Array<[string, string[] | null | undefined]>)(
+      "throws when HTTPS Certificates are %s",
+      (_label, certDomains) => {
+        const status: { Self: { DNSName: string }; CertDomains?: string[] | null } = {
+          Self: { DNSName: "devbox.example.ts.net." },
+        };
+        if (certDomains !== undefined) {
+          status.CertDomains = certDomains;
+        }
+        const runner = createRunner({
+          version: { status: 0 },
+          "status --json": {
+            status: 0,
+            stdout: JSON.stringify(status),
+          },
+        });
+        expect(() => ensureTailscaleReady(runner)).toThrow("HTTPS Certificates");
+      }
+    );
 
     it("throws when tailscale CLI is missing", () => {
       const enoent = Object.assign(new Error("spawn tailscale ENOENT"), {

--- a/packages/portless/src/tailscale.ts
+++ b/packages/portless/src/tailscale.ts
@@ -30,6 +30,7 @@ interface TailscaleStatusJson {
   CurrentTailnet?: {
     MagicDNSSuffix?: string;
   };
+  CertDomains?: string[] | null;
 }
 
 export interface TailscaleReadyResult {
@@ -107,8 +108,25 @@ function statusToDnsName(status: TailscaleStatusJson): string {
   );
 }
 
+function ensureHttpsCertificatesEnabled(status: TailscaleStatusJson, dnsName: string): void {
+  const certDomains = status.CertDomains;
+  const normalizedDnsName = trimDot(dnsName).toLowerCase();
+  const hasCertDomain =
+    Array.isArray(certDomains) &&
+    certDomains.some(
+      (domain) => typeof domain === "string" && trimDot(domain).toLowerCase() === normalizedDnsName
+    );
+
+  if (!hasCertDomain) {
+    throw new Error(
+      `Tailscale HTTPS Certificates are not enabled for ${dnsName}. ` +
+        "Enable MagicDNS and HTTPS Certificates in the Tailscale admin console DNS page, then retry."
+    );
+  }
+}
+
 /**
- * Verify that the Tailscale CLI is installed and the node is connected.
+ * Verify that the Tailscale CLI is installed, connected, and ready for Serve.
  * Returns the node's DNS name and base URL.
  */
 export function ensureTailscaleReady(
@@ -118,6 +136,7 @@ export function ensureTailscaleReady(
   const statusResult = runOrThrow(["status", "--json"], "read tailscale status", runner);
   const status = parseStatusJson(statusResult.stdout);
   const dnsName = statusToDnsName(status);
+  ensureHttpsCertificatesEnabled(status, dnsName);
   return {
     dnsName,
     baseUrl: `https://${dnsName}`,

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -236,7 +236,7 @@ portless myapp --funnel next dev
 # -> https://devbox.yourteam.ts.net    (public internet)
 ```
 
-Each `--tailscale` app is root-mounted on its own Tailscale HTTPS port (443, then 8443, 8444, etc.) so no framework `basePath` configuration is needed. Set `PORTLESS_TAILSCALE=1` to share every app by default. `portless list` shows both local and tailnet URLs. Tailscale serve registrations are cleaned up when the app exits. Requires `tailscale` CLI installed and connected.
+Each `--tailscale` app is root-mounted on its own Tailscale HTTPS port (443, then 8443, 8444, etc.) so no framework `basePath` configuration is needed. Set `PORTLESS_TAILSCALE=1` to share every app by default. `portless list` shows both local and tailnet URLs. Tailscale serve registrations are cleaned up when the app exits. Requires `tailscale` CLI installed and connected, with MagicDNS and HTTPS Certificates enabled on the active tailnet.
 
 ## CLI Reference
 
@@ -407,7 +407,7 @@ tailscale status     # Check if connected
 tailscale up         # Connect to your tailnet
 ```
 
-Requires the Tailscale CLI to be installed (https://tailscale.com/download) and on PATH.
+Requires the Tailscale CLI to be installed (https://tailscale.com/download) and on PATH, with MagicDNS and HTTPS Certificates enabled on the active tailnet.
 
 ### Requirements
 


### PR DESCRIPTION
## Summary

- Add a Tailscale HTTPS Certificates preflight before using `--tailscale` or `--funnel`
- Fail fast with an actionable error when the active tailnet is missing HTTPS Certificates instead of letting `tailscale serve` enter its interactive setup flow
- Document the MagicDNS and HTTPS Certificates requirement in CLI help, README, and the portless skill

## Testing

- `pnpm --filter portless build`
- `pnpm --filter portless test`
- `pnpm --filter portless lint`
- Manually verified `--tailscale` fails before enabling HTTPS Certificates and succeeds after enabling them on the local tailnet`