### PR TITLE
Add VitePress support to framework auto-port-injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ portless myapp next dev
 
 HTTPS with HTTP/2 is enabled by default. On first run, portless generates a local CA, trusts it, and binds port 443 (auto-elevates with sudo on macOS/Linux). Use `--no-tls` for plain HTTP.
 
-The proxy auto-starts when you run an app. A random port (4000-4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, VitePlus, Astro, React Router, Angular, Expo, React Native), portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag.
+The proxy auto-starts when you run an app. A random port (4000-4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, VitePlus, VitePress, Astro, React Router, Angular, Expo, React Native), portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag.
 
 When auto-starting, portless reuses the configuration (port, TLS, TLD) from the most recent proxy run, so a restart or reboot does not silently revert to defaults. Explicit env vars (`PORTLESS_PORT`, `PORTLESS_HTTPS`, etc.) always take priority.
 

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -377,6 +377,20 @@ describe("injectFrameworkFlags", () => {
     expect(args).toEqual(["vp", "dev", "--port", "4567", "--strictPort", "--host", "127.0.0.1"]);
   });
 
+  it("injects --port, --strictPort, and --host for vitepress command", () => {
+    const args = ["vitepress", "dev"];
+    injectFrameworkFlags(args, 4567);
+    expect(args).toEqual([
+      "vitepress",
+      "dev",
+      "--port",
+      "4567",
+      "--strictPort",
+      "--host",
+      "127.0.0.1",
+    ]);
+  });
+
   it("injects for react-router with --strictPort", () => {
     const args = ["react-router", "dev"];
     injectFrameworkFlags(args, 4567);

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -868,6 +868,7 @@ export function spawnCommand(
 const FRAMEWORKS_NEEDING_PORT: Record<string, { strictPort: boolean }> = {
   vite: { strictPort: true },
   vp: { strictPort: true },
+  vitepress: { strictPort: true },
   "react-router": { strictPort: true },
   rsbuild: { strictPort: false },
   astro: { strictPort: false },

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1460,7 +1460,7 @@ ${colors.bold("How it works:")}
      (apps get a random port in the 4000-4999 range via PORT)
   3. Access via https://<name>.localhost
   4. .localhost domains auto-resolve to 127.0.0.1
-  5. Frameworks that ignore PORT (Vite, VitePlus, Astro, React Router, Angular,
+  5. Frameworks that ignore PORT (Vite, VitePlus, VitePress, Astro, React Router, Angular,
      Expo, React Native) get --port and, when needed, --host flags
      injected automatically
 

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -163,7 +163,7 @@ PORTLESS=0 pnpm dev   # Bypasses proxy, uses default port
 
 `.localhost` domains resolve to `127.0.0.1` natively in Chrome, Firefox, and Edge. Safari relies on the system DNS resolver, which may not handle `.localhost` subdomains on all configurations. Run `portless hosts sync` to add entries to `/etc/hosts` if needed.
 
-Most frameworks (Next.js, Express, Nuxt, etc.) respect the `PORT` env var automatically. For frameworks that ignore `PORT` (Vite, VitePlus, Astro, React Router, Angular, Expo, React Native), portless auto-injects the correct `--port` flag and, when needed, a matching `--host` CLI flag.
+Most frameworks (Next.js, Express, Nuxt, etc.) respect the `PORT` env var automatically. For frameworks that ignore `PORT` (Vite, VitePlus, VitePress, Astro, React Router, Angular, Expo, React Native), portless auto-injects the correct `--port` flag and, when needed, a matching `--host` CLI flag.
 
 ### State directory
 
@@ -331,7 +331,7 @@ portless proxy start -p 8080
 
 ### Framework not respecting PORT
 
-Portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag for frameworks that ignore the `PORT` env var: **Vite**, **VitePlus** (`vp`), **Astro**, **React Router**, **Angular**, **Expo**, and **React Native**. SvelteKit uses Vite internally and is handled automatically.
+Portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag for frameworks that ignore the `PORT` env var: **Vite**, **VitePlus** (`vp`), **VitePress**, **Astro**, **React Router**, **Angular**, **Expo**, and **React Native**. SvelteKit uses Vite internally and is handled automatically.
 
 For other frameworks that don't read `PORT`, pass the port manually:
 


### PR DESCRIPTION
## Summary

Adds `vitepress` to the `FRAMEWORKS_NEEDING_PORT` map so portless auto-injects `--port`, `--strictPort`, and `--host` for VitePress dev servers, matching the existing behavior for plain Vite.

## Why

VitePress's CLI ignores the `PORT` env var and binds to its own default (5173), so the random port portless allocates goes unused and proxy requests return 404. Concretely, in a VitePress project:

```bash
$ portless run pnpm exec vitepress dev
PORT=4530 HOST=127.0.0.1 ... pnpm exec vitepress dev
  vitepress v2.0.0-alpha.17
  Local:   http://localhost:5173/      # ignored PORT, bound 5173
$ curl https://myapp.localhost/         # 404 with x-portless: 1
```

VitePress wraps Vite's dev server. In `vitepress/dist/node/chunk-*.js`:

```js
async function createServer(root, serverOptions = {}, ...) {
  const { base, ...server } = serverOptions;
  return createServer$1({ ..., server, ... });
}
```

Parsed argv flows through to Vite's `server` config unchanged, so `--port`, `--strictPort`, and `--host` all behave the same as they do for plain Vite. SvelteKit-style indirection isn't needed here because `vitepress` is the actual CLI basename; `findFrameworkBasename` matches it directly.

## Changes

- `packages/portless/src/cli-utils.ts`: add `vitepress: { strictPort: true }` to the framework map (one line)
- `packages/portless/src/cli-utils.test.ts`: add a unit test mirroring the `vp` test
- `packages/portless/src/cli.ts`: list VitePress in the `--help` framework enumeration
- `README.md` and `skills/portless/SKILL.md`: list VitePress alongside Vite/VitePlus per AGENTS.md docs-update rules

## Test plan

- [x] `pnpm -C packages/portless exec vitest run src/cli-utils.test.ts` passes (102 tests)
- [x] New `injects ... for vitepress command` test asserts the exact arg array
- [x] `pnpm exec prettier --check` passes on all modified files
- [x] Verified empirically with `vitepress@2.0.0-alpha.17`: without this change, portless allocates a port that VitePress ignores and the proxy 404s; with this change applied locally, the named URL serves the dev server end-to-end