### PR TITLE
fix: support multi-segment custom TLDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,15 +200,15 @@ Put `portless run` in your `package.json` once and it works everywhere. The main
 
 ## Custom TLD
 
-By default, portless uses `.localhost` which auto-resolves to `127.0.0.1` in most browsers. If you prefer a different TLD (e.g. `.test`), use `--tld`:
+By default, portless uses `.localhost` which auto-resolves to `127.0.0.1` in most browsers. If you prefer a different TLD, including a multi-segment value such as `.local.example.dev`, use `--tld`:
 
 ```bash
-portless proxy start --tld test
+portless proxy start --tld local.example.dev
 portless myapp next dev
-# -> https://myapp.test
+# -> https://myapp.local.example.dev
 ```
 
-The proxy auto-syncs `/etc/hosts` for route hostnames (including `.test`), so those domains resolve on your machine.
+The proxy auto-syncs `/etc/hosts` for route hostnames (including custom TLDs), so those domains resolve on your machine.
 
 Recommended: `.test` (IANA-reserved, no collision risk). Avoid `.local` (conflicts with mDNS/Bonjour) and `.dev` (Google-owned, forces HTTPS via HSTS).
 
@@ -345,7 +345,7 @@ portless proxy stop              # Stop the proxy
 --cert <path>                    Use a custom TLS certificate
 --key <path>                     Use a custom TLS private key
 --foreground                     Run proxy in foreground instead of daemon
---tld <tld>                      Use a custom TLD instead of .localhost (e.g. test)
+--tld <tld>                      Use a custom TLD instead of .localhost (e.g. test, local.example.dev)
 --wildcard                       Allow unregistered subdomains to fall back to parent route
 --script <name>                  Run a specific package.json script (default: dev)
 --app-port <number>              Use a fixed port for the app (skip auto-assignment)
@@ -363,7 +363,7 @@ PORTLESS_PORT=<number>           Override the default proxy port
 PORTLESS_APP_PORT=<number>       Use a fixed port for the app (same as --app-port)
 PORTLESS_HTTPS=0                 Disable HTTPS (same as --no-tls)
 PORTLESS_LAN=1                   Enable LAN mode when set to 1 (auto-detects LAN IP)
-PORTLESS_TLD=<tld>               Use a custom TLD (e.g. test; default: localhost)
+PORTLESS_TLD=<tld>               Use a custom TLD (e.g. test, local.example.dev; default: localhost)
 PORTLESS_WILDCARD=1              Allow unregistered subdomains to fall back to parent route
 PORTLESS_SYNC_HOSTS=0            Disable auto-sync of /etc/hosts (on by default)
 PORTLESS_TAILSCALE=1             Share apps on your Tailscale network (same as --tailscale)

--- a/packages/portless/src/certs.test.ts
+++ b/packages/portless/src/certs.test.ts
@@ -269,6 +269,24 @@ describe("createSNICallback", () => {
     expect(cert.subjectAltName).toContain("DNS:chat.myapp.localhost");
   });
 
+  it("generates per-hostname cert for multi-segment TLDs", async () => {
+    const sniCallback = createSNICallback(tmpDir, defaultCert, defaultKey, "local.example.dev");
+    const ctx = await new Promise<tls.SecureContext | undefined>((resolve, reject) => {
+      sniCallback("myapp.local.example.dev", (err, ctx) => {
+        if (err) reject(err);
+        else resolve(ctx);
+      });
+    });
+
+    expect(ctx).toBeDefined();
+
+    const hostCertPath = path.join(tmpDir, "host-certs", "myapp_local_example_dev.pem");
+    expect(fs.existsSync(hostCertPath)).toBe(true);
+
+    const cert = new crypto.X509Certificate(fs.readFileSync(hostCertPath));
+    expect(cert.subjectAltName).toContain("DNS:myapp.local.example.dev");
+  });
+
   it("generates cert for a hostname longer than 64 characters (X.509 CN limit)", async () => {
     // Construct a hostname that exceeds the 64-char CN limit:
     // "inngest.ap.very-long-branch-name-that-exceeds-the-cn-limit.dev" = 63+ chars

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -747,6 +747,11 @@ describe("getDefaultTld", () => {
     expect(getDefaultTld()).toBe("test");
   });
 
+  it("returns multi-segment PORTLESS_TLD when set", () => {
+    process.env.PORTLESS_TLD = "local.example.dev";
+    expect(getDefaultTld()).toBe("local.example.dev");
+  });
+
   it("lowercases the value", () => {
     process.env.PORTLESS_TLD = "TEST";
     expect(getDefaultTld()).toBe("test");
@@ -817,6 +822,19 @@ describe("buildProxyStartConfig", () => {
     ).toEqual({
       effectiveTld: "test",
       args: ["--no-tls", "--tld", "test"],
+    });
+  });
+
+  it("keeps multi-segment custom TLDs outside LAN mode", () => {
+    expect(
+      buildProxyStartConfig({
+        useHttps: false,
+        lanMode: false,
+        tld: "local.example.dev",
+      })
+    ).toEqual({
+      effectiveTld: "local.example.dev",
+      args: ["--no-tls", "--tld", "local.example.dev"],
     });
   });
 });
@@ -911,6 +929,11 @@ describe("validateTld", () => {
     expect(validateTld("localhost")).toBeNull();
     expect(validateTld("test")).toBeNull();
     expect(validateTld("internal")).toBeNull();
+    expect(validateTld("x")).toBeNull();
+    expect(validateTld("a.example.dev")).toBeNull();
+    expect(validateTld("local.example.dev")).toBeNull();
+    expect(validateTld("dev.receipts.beauty")).toBeNull();
+    expect(validateTld("my-tld.example")).toBeNull();
   });
 
   it("rejects empty string", () => {
@@ -918,10 +941,13 @@ describe("validateTld", () => {
   });
 
   it("rejects TLDs with invalid characters", () => {
-    expect(validateTld("my-tld")).toMatch(/must contain only/);
-    expect(validateTld("my.tld")).toMatch(/must contain only/);
-    expect(validateTld("MY_TLD")).toMatch(/must contain only/);
-    expect(validateTld("tld!")).toMatch(/must contain only/);
+    expect(validateTld("MY_TLD")).toMatch(/labels must contain only/);
+    expect(validateTld("tld!")).toMatch(/labels must contain only/);
+    expect(validateTld("foo..bar")).toMatch(/labels cannot be empty/);
+    expect(validateTld("-foo.bar")).toMatch(/labels must contain only/);
+    expect(validateTld("foo.bar-")).toMatch(/labels must contain only/);
+    expect(validateTld(`${"a".repeat(64)}.bar`)).toMatch(/exceeds 63-character/);
+    expect(validateTld(`${"a".repeat(250)}.bar`)).toMatch(/exceeds 253-character/);
   });
 
   it("allows public TLDs (they produce warnings elsewhere)", () => {

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -251,8 +251,22 @@ export const RISKY_TLDS = new Map<string, string>([
  */
 export function validateTld(tld: string): string | null {
   if (!tld) return "TLD cannot be empty";
-  if (!/^[a-z0-9]+$/.test(tld)) {
-    return `Invalid TLD "${tld}": must contain only lowercase letters and digits`;
+  if (tld.length > 253) {
+    return `Invalid TLD "${tld}": exceeds 253-character DNS limit`;
+  }
+
+  const labelRe = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+  const labels = tld.split(".");
+  for (const label of labels) {
+    if (!label) {
+      return `Invalid TLD "${tld}": labels cannot be empty`;
+    }
+    if (label.length > 63) {
+      return `Invalid TLD "${tld}": label "${label}" exceeds 63-character DNS limit`;
+    }
+    if (!labelRe.test(label)) {
+      return `Invalid TLD "${tld}": labels must contain only lowercase letters, digits, and interior hyphens`;
+    }
   }
   return null;
 }

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -370,6 +370,48 @@ describe("CLI", () => {
     });
   });
 
+  describe("--tld flag", () => {
+    it("accepts leading multi-segment TLDs before run mode", () => {
+      const { status, stdout } = run(["--tld", "local.example.dev", "run", "echo", "ok"], {
+        env: { PORTLESS: "0" },
+      });
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe("ok");
+    });
+
+    it("accepts leading multi-segment TLDs before named mode", () => {
+      const { status, stdout } = run(["--tld", "local.example.dev", "myapp", "echo", "ok"], {
+        env: { PORTLESS: "0" },
+      });
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe("ok");
+    });
+
+    it("accepts multi-segment TLDs in run mode", () => {
+      const { status, stdout } = run(["run", "--tld", "local.example.dev", "echo", "ok"], {
+        env: { PORTLESS: "0" },
+      });
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe("ok");
+    });
+
+    it("accepts multi-segment TLDs in named mode", () => {
+      const { status, stdout } = run(["myapp", "--tld", "local.example.dev", "echo", "ok"], {
+        env: { PORTLESS: "0" },
+      });
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe("ok");
+    });
+
+    it("rejects invalid multi-segment TLDs in named mode", () => {
+      const { status, stderr } = run(["myapp", "--tld", "foo..bar", "echo", "ok"], {
+        env: { PORTLESS: "0" },
+      });
+      expect(status).toBe(1);
+      expect(stderr).toContain("labels cannot be empty");
+    });
+  });
+
   describe("alias subcommand", () => {
     it("prints help with --help", () => {
       const { status, stdout } = run(["alias", "--help"]);

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1202,6 +1202,8 @@ interface ParsedRunArgs {
   force: boolean;
   /** Fixed app port (overrides automatic assignment). */
   appPort?: number;
+  /** Custom TLD for the proxy. */
+  tld?: string;
   /** Override the inferred base name (from --name flag). */
   name?: string;
   /** The child command and its arguments, passed through untouched. */
@@ -1237,6 +1239,20 @@ function appPortFromEnv(): number | undefined {
   return port;
 }
 
+function parseTldFlag(value: string | undefined): string {
+  if (!value || value.startsWith("-")) {
+    console.error(colors.red("Error: --tld requires a TLD value (e.g. test, local.example.dev)."));
+    process.exit(1);
+  }
+  const tld = value.trim().toLowerCase();
+  const err = validateTld(tld);
+  if (err) {
+    console.error(colors.red(`Error: ${err}`));
+    process.exit(1);
+  }
+  return tld;
+}
+
 function applyTailscaleFlag(flag: string): boolean {
   if (flag === "--tailscale") {
     process.env.PORTLESS_TAILSCALE = "1";
@@ -1253,13 +1269,14 @@ function applyTailscaleFlag(flag: string): boolean {
 /**
  * Parse `run` subcommand arguments: `[--name <name>] [--force] [--] <command...>`
  *
- * `--name`, `--force`, and `--app-port` are recognized. `--` stops flag
+ * `--name`, `--force`, `--app-port`, and `--tld` are recognized. `--` stops flag
  * parsing. Everything after the flag region is the child command, passed
  * through untouched.
  */
 function parseRunArgs(args: string[]): ParsedRunArgs {
   let force = false;
   let appPort: number | undefined;
+  let tld: string | undefined;
   let name: string | undefined;
   let i = 0;
 
@@ -1281,6 +1298,7 @@ ${colors.bold("Options:")}
   --name <name>          Override the inferred base name (worktree prefix still applies)
   --force                Kill the existing process and take over its route
   --app-port <number>    Use a fixed port for the app (skip auto-assignment)
+  --tld <tld>            Use a custom TLD instead of .localhost
   --help, -h             Show this help
 
 ${colors.bold("Name inference (in order):")}
@@ -1297,6 +1315,7 @@ ${colors.bold("Examples:")}
   portless run                        # Run dev script through proxy
   portless run next dev               # -> https://<project>.localhost
   portless run --name myapp next dev  # -> https://myapp.localhost
+  portless run --tld local.example.dev next dev
   portless run vite dev               # -> https://<project>.localhost
   portless run --app-port 3000 pnpm start
 `);
@@ -1306,6 +1325,9 @@ ${colors.bold("Examples:")}
     } else if (args[i] === "--app-port") {
       i++;
       appPort = parseAppPort(args[i]);
+    } else if (args[i] === "--tld") {
+      i++;
+      tld = parseTldFlag(args[i]);
     } else if (args[i] === "--name") {
       i++;
       if (!args[i] || args[i].startsWith("-")) {
@@ -1319,7 +1341,9 @@ ${colors.bold("Examples:")}
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
       console.error(
-        colors.blue("Known flags: --name, --force, --app-port, --tailscale, --funnel, --help")
+        colors.blue(
+          "Known flags: --name, --force, --app-port, --tld, --tailscale, --funnel, --help"
+        )
       );
       process.exit(1);
     }
@@ -1328,19 +1352,20 @@ ${colors.bold("Examples:")}
 
   if (!appPort) appPort = appPortFromEnv();
 
-  return { force, appPort, name, commandArgs: args.slice(i) };
+  return { force, appPort, tld, name, commandArgs: args.slice(i) };
 }
 
 /**
  * Parse named-mode arguments: `[--force] <name> [--force] [--] <command...>`
  *
- * `--force` is recognized before and after the name. `--` stops flag
+ * `--force`, `--app-port`, and `--tld` are recognized before and after the name. `--` stops flag
  * parsing. Everything after the flag region is the child command.
  * Unrecognized `--` flags are rejected to catch typos.
  */
 function parseAppArgs(args: string[]): ParsedAppArgs {
   let force = false;
   let appPort: number | undefined;
+  let tld: string | undefined;
   let i = 0;
 
   // Consume leading flags before name
@@ -1353,11 +1378,14 @@ function parseAppArgs(args: string[]): ParsedAppArgs {
     } else if (args[i] === "--app-port") {
       i++;
       appPort = parseAppPort(args[i]);
+    } else if (args[i] === "--tld") {
+      i++;
+      tld = parseTldFlag(args[i]);
     } else if (applyTailscaleFlag(args[i])) {
       // handled
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
-      console.error(colors.blue("Known flags: --force, --app-port, --tailscale, --funnel"));
+      console.error(colors.blue("Known flags: --force, --app-port, --tld, --tailscale, --funnel"));
       process.exit(1);
     }
     i++;
@@ -1377,11 +1405,14 @@ function parseAppArgs(args: string[]): ParsedAppArgs {
     } else if (args[i] === "--app-port") {
       i++;
       appPort = parseAppPort(args[i]);
+    } else if (args[i] === "--tld") {
+      i++;
+      tld = parseTldFlag(args[i]);
     } else if (applyTailscaleFlag(args[i])) {
       // handled
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
-      console.error(colors.blue("Known flags: --force, --app-port, --tailscale, --funnel"));
+      console.error(colors.blue("Known flags: --force, --app-port, --tld, --tailscale, --funnel"));
       process.exit(1);
     }
     i++;
@@ -1389,7 +1420,7 @@ function parseAppArgs(args: string[]): ParsedAppArgs {
 
   if (!appPort) appPort = appPortFromEnv();
 
-  return { force, appPort, name, commandArgs: args.slice(i) };
+  return { force, appPort, tld, name, commandArgs: args.slice(i) };
 }
 
 // ---------------------------------------------------------------------------
@@ -1507,7 +1538,7 @@ ${colors.bold("Options:")}
   --cert <path>                 Use a custom TLS certificate
   --key <path>                  Use a custom TLS private key
   --foreground                  Run proxy in foreground (for debugging)
-  --tld <tld>                   Use a custom TLD instead of .localhost (e.g. test, dev)
+  --tld <tld>                   Use a custom TLD instead of .localhost (e.g. test, local.example.dev)
   --wildcard                    Allow unregistered subdomains to fall back to parent route
   --app-port <number>           Use a fixed port for the app (skip auto-assignment)
   --tailscale                   Share the app on your Tailscale network (tailnet)
@@ -1521,7 +1552,7 @@ ${colors.bold("Environment variables:")}
   PORTLESS_APP_PORT=<number>    Use a fixed port for the app (same as --app-port)
   PORTLESS_HTTPS=0              Disable HTTPS (same as --no-tls)
   PORTLESS_LAN=1                Enable LAN mode when set to 1 (set in .bashrc / .zshrc)
-  PORTLESS_TLD=<tld>            Use a custom TLD (e.g. test, dev; default: localhost)
+  PORTLESS_TLD=<tld>            Use a custom TLD (e.g. test, local.example.dev; default: localhost)
   PORTLESS_WILDCARD=1           Allow unregistered subdomains to fall back to parent route
   PORTLESS_SYNC_HOSTS=0         Disable auto-sync of ${HOSTS_DISPLAY} (on by default)
   PORTLESS_TAILSCALE=1          Share apps on your Tailscale network (same as --tailscale)
@@ -2069,7 +2100,7 @@ ${colors.bold("Usage:")}
   ${colors.cyan("portless proxy start --lan")}          Enable LAN mode (mDNS, .local TLD)
   ${colors.cyan("portless proxy start --foreground")}   Start in foreground (for debugging)
   ${colors.cyan("portless proxy start -p 1355")}        Start on a custom port (no sudo)
-  ${colors.cyan("portless proxy start --tld test")}     Use .test instead of .localhost
+  ${colors.cyan("portless proxy start --tld local.test")}   Use .local.test instead of .localhost
   ${colors.cyan("portless proxy start --wildcard")}     Allow unregistered subdomains to fall back to parent
   ${colors.cyan("portless proxy stop")}                 Stop the proxy
 
@@ -3194,6 +3225,9 @@ async function runWithDirectSpawn(
 
 async function handleRunMode(args: string[], globalScript?: string): Promise<void> {
   const parsed = parseRunArgs(args);
+  if (parsed.tld) {
+    process.env.PORTLESS_TLD = parsed.tld;
+  }
 
   const appConfig = loadAppConfig();
 
@@ -3266,6 +3300,9 @@ async function handleRunMode(args: string[], globalScript?: string): Promise<voi
 
 async function handleNamedMode(args: string[]): Promise<void> {
   const parsed = parseAppArgs(args);
+  if (parsed.tld) {
+    process.env.PORTLESS_TLD = parsed.tld;
+  }
 
   if (parsed.commandArgs.length === 0) {
     console.error(colors.red("Error: No command provided."));
@@ -3403,6 +3440,13 @@ async function main() {
     process.exit(1);
   }
   const globalScript = typeof scriptResult === "string" ? scriptResult : undefined;
+
+  // --tld can be used as a leading global flag before `run`, named mode, or
+  // proxy commands. Mode-specific parsers also accept it after the command.
+  if (args[0] === "--tld") {
+    process.env.PORTLESS_TLD = parseTldFlag(args[1]);
+    args.splice(0, 2);
+  }
 
   // --name flag: treat the next arg as an explicit app name, bypassing
   // subcommand dispatch. Useful when the app name collides with a reserved

--- a/packages/portless/src/utils.test.ts
+++ b/packages/portless/src/utils.test.ts
@@ -178,6 +178,14 @@ describe("parseHostname", () => {
       expect(parseHostname("api.myapp", "test")).toBe("api.myapp.test");
     });
 
+    it("handles multi-segment custom TLDs", () => {
+      expect(parseHostname("myapp", "local.example.dev")).toBe("myapp.local.example.dev");
+      expect(parseHostname("api.myapp", "local.example.dev")).toBe("api.myapp.local.example.dev");
+      expect(parseHostname("myapp.local.example.dev", "local.example.dev")).toBe(
+        "myapp.local.example.dev"
+      );
+    });
+
     it("throws on empty input with custom TLD", () => {
       expect(() => parseHostname("", "test")).toThrow("Hostname cannot be empty");
     });

--- a/skills/oauth/SKILL.md
+++ b/skills/oauth/SKILL.md
@@ -26,24 +26,24 @@ Google and Apple are the strictest. Microsoft and GitHub are more lenient with l
 Use a valid TLD so the redirect URI passes provider validation:
 
 ```bash
-portless proxy start --tld dev
+portless proxy start --tld local.yourcompany.dev
 portless myapp next dev
-# -> https://myapp.dev
-```
-
-Any TLD in the Public Suffix List works: `.dev`, `.app`, `.com`, `.io`, etc.
-
-### Use a domain you own
-
-Bare TLDs like `.dev` mean `myapp.dev` could collide with a real domain. Use a subdomain of a domain you control:
-
-```bash
-portless proxy start --tld dev
-portless myapp.local.yourcompany next dev
 # -> https://myapp.local.yourcompany.dev
 ```
 
-This ensures no outbound traffic reaches something you don't own. For teams, set a wildcard DNS record (`*.local.yourcompany.dev -> 127.0.0.1`) so every developer gets resolution without `/etc/hosts`.
+Any DNS-safe suffix ending in a TLD from the Public Suffix List works: `.dev`, `.app`, `.com`, `.io`, etc.
+
+### Use a domain you own
+
+Bare public TLDs like `.dev` mean `myapp.dev` could collide with a real domain. Use a subdomain of a domain you control:
+
+```bash
+portless proxy start --tld local.yourcompany.dev
+portless myapp next dev
+# -> https://myapp.local.yourcompany.dev
+```
+
+This ensures no outbound traffic reaches something you don't own while keeping the app name clean. For teams, set a wildcard DNS record (`*.local.yourcompany.dev -> 127.0.0.1`) so every developer gets resolution without `/etc/hosts`.
 
 ## Provider Setup
 
@@ -51,8 +51,8 @@ This ensures no outbound traffic reaches something you don't own. For teams, set
 
 1. Go to [Google Cloud Console > Credentials](https://console.cloud.google.com/apis/credentials)
 2. Create or edit an OAuth 2.0 Client ID (Web application)
-3. Add the portless domain to **Authorized JavaScript origins**: `https://myapp.dev`
-4. Add the callback to **Authorized redirect URIs**: `https://myapp.dev/api/auth/callback/google`
+3. Add the portless domain to **Authorized JavaScript origins**: `https://myapp.local.yourcompany.dev`
+4. Add the callback to **Authorized redirect URIs**: `https://myapp.local.yourcompany.dev/api/auth/callback/google`
 
 Google validates domains against the Public Suffix List. The domain must end with a recognized TLD. `.localhost` subdomains fail this check; `.dev`, `.app`, `.com`, etc. all pass.
 
@@ -64,7 +64,7 @@ Apple Sign In does not allow `localhost` or IP addresses at all.
 
 1. Go to [Apple Developer > Certificates, Identifiers & Profiles](https://developer.apple.com/account/resources)
 2. Register a Services ID
-3. Configure Sign In with Apple, adding the portless domain as a **Return URL**: `https://myapp.dev/api/auth/callback/apple`
+3. Configure Sign In with Apple, adding the portless domain as a **Return URL**: `https://myapp.local.yourcompany.dev/api/auth/callback/apple`
 
 The domain must be a real, publicly-resolvable domain name. Since portless maps the domain to 127.0.0.1 locally, the browser resolves it but Apple's server-side validation may require the domain to resolve publicly too. If Apple rejects the domain, add a public DNS A record pointing to 127.0.0.1 for your dev subdomain.
 
@@ -72,21 +72,21 @@ The domain must be a real, publicly-resolvable domain name. Since portless maps 
 
 1. Go to [Azure Portal > App registrations](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps)
 2. Create or edit an app registration
-3. Under **Authentication**, add a **Web** redirect URI: `https://myapp.dev/api/auth/callback/azure-ad`
+3. Under **Authentication**, add a **Web** redirect URI: `https://myapp.local.yourcompany.dev/api/auth/callback/azure-ad`
 
 Microsoft allows `http://localhost` with any port for development. It also accepts `.localhost` subdomains in most cases. Using a custom TLD with portless is still recommended for consistency across providers.
 
 ### Facebook (Meta)
 
 1. Go to [Meta for Developers > App Dashboard](https://developers.facebook.com/apps/)
-2. Under **Facebook Login > Settings**, add the portless URL to **Valid OAuth Redirect URIs**: `https://myapp.dev/api/auth/callback/facebook`
+2. Under **Facebook Login > Settings**, add the portless URL to **Valid OAuth Redirect URIs**: `https://myapp.local.yourcompany.dev/api/auth/callback/facebook`
 
 Facebook requires each redirect URI to be registered exactly (no wildcards). Strict Mode (enabled by default) enforces exact matching.
 
 ### GitHub
 
 1. Go to [GitHub Developer Settings > OAuth Apps](https://github.com/settings/developers)
-2. Set **Authorization callback URL**: `https://myapp.dev/api/auth/callback/github`
+2. Set **Authorization callback URL**: `https://myapp.local.yourcompany.dev/api/auth/callback/github`
 
 GitHub is permissive with localhost and subdomains. A custom TLD is not strictly required but keeps the setup consistent.
 
@@ -97,7 +97,7 @@ GitHub is permissive with localhost and subdomains. A custom TLD is not strictly
 Set `NEXTAUTH_URL` to match the portless domain:
 
 ```env
-NEXTAUTH_URL=https://myapp.dev
+NEXTAUTH_URL=https://myapp.local.yourcompany.dev
 ```
 
 NextAuth uses this to construct callback URLs. Without it, callbacks may use `localhost` and cause a mismatch.
@@ -114,7 +114,7 @@ new GoogleStrategy({
 });
 ```
 
-Set `BASE_URL=https://myapp.dev` in your environment.
+Set `BASE_URL=https://myapp.local.yourcompany.dev` in your environment.
 
 ### Generic / Manual
 
@@ -140,7 +140,7 @@ The redirect URI sent during the OAuth flow doesn't match what's registered with
 `.dev` and `.app` TLDs are HSTS-preloaded, so browsers force HTTPS. Start the proxy:
 
 ```bash
-portless proxy start --tld dev
+portless proxy start --tld local.yourcompany.dev
 ```
 
 Portless defaults to HTTPS on port 443 (auto-elevates with sudo). Run `portless trust` to add the local CA to your system trust store and eliminate browser warnings.
@@ -159,10 +159,10 @@ Or use a wildcard: `*.local.yourcompany.dev  A  127.0.0.1`.
 
 The auth library is constructing the callback URL from `localhost` instead of the portless domain. Set the appropriate environment variable:
 
-- **NextAuth**: `NEXTAUTH_URL=https://myapp.dev`
-- **Auth.js v5**: `AUTH_URL=https://myapp.dev`
+- **NextAuth**: `NEXTAUTH_URL=https://myapp.local.yourcompany.dev`
+- **Auth.js v5**: `AUTH_URL=https://myapp.local.yourcompany.dev`
 - **Manual**: `PORTLESS_URL` is injected automatically; use it as the base URL
 
 ## Example
 
-See [`examples/google-oauth`](../../examples/google-oauth) for a complete working example with Next.js + NextAuth + Google OAuth using `--tld dev`.
+See [`examples/google-oauth`](../../examples/google-oauth) for a complete working example with Next.js + NextAuth + Google OAuth using a custom TLD.

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -177,7 +177,7 @@ Portless stores its state (routes, PID file, port file) in `~/.portless`. Overri
 | `PORTLESS_APP_PORT`   | Use a fixed port for the app (skip auto-assignment)                         |
 | `PORTLESS_HTTPS`      | HTTPS on by default; set to `0` to disable (same as `--no-tls`)             |
 | `PORTLESS_LAN`        | Set to `1` to always enable LAN mode (auto-detects LAN IP)                  |
-| `PORTLESS_TLD`        | Use a custom TLD instead of localhost (e.g. test)                           |
+| `PORTLESS_TLD`        | Use a custom TLD instead of localhost (e.g. test, local.example.dev)        |
 | `PORTLESS_WILDCARD`   | Set to `1` to allow unregistered subdomains to fall back to parent          |
 | `PORTLESS_SYNC_HOSTS` | Set to `0` to disable auto-sync of /etc/hosts (on by default)               |
 | `PORTLESS_TAILSCALE`  | Set to `1` to share apps on your Tailscale network (same as `--tailscale`)  |
@@ -259,7 +259,7 @@ Each `--tailscale` app is root-mounted on its own Tailscale HTTPS port (443, the
 | `portless proxy start --no-tls`        | Start without HTTPS (plain HTTP on port 80)                    |
 | `portless proxy start --lan`           | Start in LAN mode (mDNS `.local`, auto-follows LAN IP changes) |
 | `portless proxy start -p <number>`     | Start the proxy on a custom port                               |
-| `portless proxy start --tld test`      | Use .test instead of .localhost                                |
+| `portless proxy start --tld local.example.dev` | Use .local.example.dev instead of .localhost                    |
 | `portless proxy start --foreground`    | Start the proxy in foreground (for debugging)                  |
 | `portless proxy start --wildcard`      | Allow unregistered subdomains to fall back to parent route     |
 | `portless proxy stop`                  | Stop the proxy                                                 |


### PR DESCRIPTION
## Summary

Refs #260.

Allow custom TLDs to be multi-segment DNS suffixes such as `local.example.dev` or `dev.example.com`.

This means users can now run:

```bash
portless --tld local.example.dev run --name myapp vite dev
# https://myapp.local.example.dev
```

The change also keeps the app name clean. The previous workaround was to use a single final label as `PORTLESS_TLD` and put the rest of the domain into the app name, for example `PORTLESS_TLD=dev` with `--name myapp.local.example`. That can produce a usable URL, but it treats domain structure as app naming. This PR makes the configured TLD itself multi-segment.

## Context

Related issues and discussions:

- #260 asks for production-parity local dev domains such as `app.dev.example.com`. This PR addresses the core validation, parsing, routing, and SNI certificate support. It does not implement the optional single-wildcard-cert mode discussed there.
- #58 covers the Google OAuth callback problem with `.localhost` style origins. Multi-segment TLDs let users point OAuth providers at a domain they own, such as `https://myapp.local.example.dev/api/auth/callback/google`.
- #148 is related historical context around long hostnames and TLS cert generation pain. Current cert generation already uses SANs for hostname validation, and this PR adds multi-segment TLD coverage to that path.

## What Changed

- Allow `validateTld` to accept dot-separated DNS labels.
- Enforce DNS-safe label rules, 63-character label limits, and 253-character total length.
- Accept `--tld` in run mode and named app mode, including leading placement before `run` or the app name.
- Preserve multi-segment `PORTLESS_TLD` through proxy start config.
- Add regression coverage for validation, env handling, proxy start args, CLI parsing, hostname construction, and SNI certificate SAN generation.
- Update README, CLI help, `skills/portless/SKILL.md`, and `skills/oauth/SKILL.md`.

## Certificate Behavior

#260 mentions a possible single wildcard cert for `*.dev.example.com`. This PR does not add a new wildcard-cert mode.

Instead, it keeps the existing SNI certificate strategy and verifies that multi-segment TLD app hosts get a valid per-host certificate. For example, `myapp.local.example.dev` receives SANs like:

```text
DNS:myapp.local.example.dev
DNS:*.local.example.dev
```

That keeps the fix focused while covering browser and curl hostname validation for the actual app URL.

## Hosts Resolution

Existing per-host `/etc/hosts` sync continues to work unchanged: each registered app writes its full `<app>.<tld>` entry. Users with `PORTLESS_SYNC_HOSTS=0` can still use DNS they control or explicit resolver overrides. The manual smoke test used `curl --resolve` to verify the proxy path without mutating the hosts file.

## Validation

- `pnpm --filter portless type-check`
- `pnpm test`
- Manual smoke test with `curl --cacert ... --resolve myapp.local.example.dev:<port>:127.0.0.1 https://myapp.local.example.dev:<port>/check`

Trimmed smoke-test output:

```text
{"host":"127.0.0.1:4576","url":"/check","proto":"https","port":"4576","urlEnv":"https://myapp.local.example.dev:13556"}
```

The manual smoke test verified route registration, `PORTLESS_URL`, HTTPS proxying, and the generated certificate SAN for a multi-segment TLD.
