### PR TITLE
Fix WebSocket-over-HTTP/2 (RFC 8441 Extended CONNECT) for Turbopack and Vite HMR

### DIFF
--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterAll, afterEach, beforeAll } from "vitest";
+import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as http from "node:http";
 import * as http2 from "node:http2";
@@ -12,6 +13,18 @@ import type { RouteInfo } from "./types.js";
 import { ensureCerts } from "./certs.js";
 
 const TEST_PROXY_PORT = 1355;
+
+// RFC 6455 magic GUID, used to derive Sec-WebSocket-Accept from
+// Sec-WebSocket-Key. Must match the constant used inside proxy.ts so the
+// HTTP/2 Extended CONNECT bridge accepts the test backend's 101 response.
+const WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+function computeWsAccept(key: string): string {
+  return crypto
+    .createHash("sha1")
+    .update(key + WS_GUID)
+    .digest("base64");
+}
 
 /** Helper type covering both http.Server and http2.Http2SecureServer */
 type AnyServer = http.Server | ProxyServer;
@@ -1469,4 +1482,289 @@ describe("createProxyServer with TLS (HTTP/2)", () => {
     },
     15_000
   );
+
+  describe("RFC 8441 Extended CONNECT (WebSocket-over-HTTP/2)", () => {
+    it("advertises SETTINGS_ENABLE_CONNECT_PROTOCOL to HTTP/2 clients", async () => {
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => [],
+          proxyPort: TEST_PROXY_PORT,
+          tls: { cert: tlsCert, key: tlsKey },
+        })
+      );
+      await listen(server);
+
+      const addr = server.address();
+      if (!addr || typeof addr === "string") throw new Error("no addr");
+
+      const enabled = await new Promise<boolean>((resolve, reject) => {
+        const client = http2.connect(`https://127.0.0.1:${addr.port}`, {
+          rejectUnauthorized: false,
+        });
+        client.on("error", reject);
+        client.on("remoteSettings", (settings) => {
+          const value = (settings as { enableConnectProtocol?: boolean }).enableConnectProtocol;
+          client.close();
+          resolve(value === true);
+        });
+      });
+
+      expect(enabled).toBe(true);
+    });
+
+    it("bridges Extended CONNECT WebSocket to HTTP/1.1 backend, frames round-trip", async () => {
+      // Backend computes a real Sec-WebSocket-Accept from the client key,
+      // then echoes any subsequent bytes. Mirrors what dev servers (Next.js
+      // Turbopack, Vite) do for HMR sockets.
+      const backend = trackServer(http.createServer());
+      backend.on("upgrade", (req, socket) => {
+        const key = req.headers["sec-websocket-key"] as string;
+        const accept = computeWsAccept(key);
+        socket.write(
+          "HTTP/1.1 101 Switching Protocols\r\n" +
+            "Upgrade: websocket\r\n" +
+            "Connection: Upgrade\r\n" +
+            `Sec-WebSocket-Accept: ${accept}\r\n` +
+            "\r\n"
+        );
+        socket.on("data", (chunk: Buffer) => socket.write(chunk));
+      });
+      await listen(backend);
+      const backendAddr = backend.address();
+      if (!backendAddr || typeof backendAddr === "string") throw new Error("no addr");
+
+      const routes: RouteInfo[] = [{ hostname: "ws.localhost", port: backendAddr.port }];
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => routes,
+          proxyPort: TEST_PROXY_PORT,
+          tls: { cert: tlsCert, key: tlsKey },
+        })
+      );
+      await listen(server);
+
+      const addr = server.address();
+      if (!addr || typeof addr === "string") throw new Error("no addr");
+
+      const result = await new Promise<{ status: number; echoed: string }>((resolve, reject) => {
+        const client = http2.connect(`https://127.0.0.1:${addr.port}`, {
+          rejectUnauthorized: false,
+        });
+        client.on("error", reject);
+
+        // Wait for SETTINGS so the server has acknowledged Extended CONNECT
+        // before we send the CONNECT request.
+        client.on("remoteSettings", () => {
+          const req = client.request(
+            {
+              ":method": "CONNECT",
+              ":protocol": "websocket",
+              ":path": "/",
+              ":authority": "ws.localhost",
+              ":scheme": "https",
+              "sec-websocket-version": "13",
+              "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+            },
+            { endStream: false }
+          );
+
+          let status = 0;
+          const chunks: Buffer[] = [];
+          req.on("response", (headers) => {
+            status = headers[":status"] as number;
+            // Send raw bytes through the tunnel; backend echoes them back.
+            req.write("ping");
+          });
+          req.on("data", (chunk: Buffer) => {
+            chunks.push(chunk);
+            if (Buffer.concat(chunks).toString("utf8") === "ping") {
+              req.close();
+              client.close();
+              resolve({ status, echoed: Buffer.concat(chunks).toString("utf8") });
+            }
+          });
+          req.on("error", reject);
+        });
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.echoed).toBe("ping");
+    });
+
+    it("destroys stream when backend rejects WebSocket upgrade with non-101", async () => {
+      const backend = trackServer(http.createServer());
+      backend.on("upgrade", (_req, socket) => {
+        socket.write("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n");
+        socket.end();
+      });
+      await listen(backend);
+      const backendAddr = backend.address();
+      if (!backendAddr || typeof backendAddr === "string") throw new Error("no addr");
+
+      const routes: RouteInfo[] = [{ hostname: "ws.localhost", port: backendAddr.port }];
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => routes,
+          proxyPort: TEST_PROXY_PORT,
+          tls: { cert: tlsCert, key: tlsKey },
+        })
+      );
+      await listen(server);
+
+      const addr = server.address();
+      if (!addr || typeof addr === "string") throw new Error("no addr");
+
+      const outcome = await new Promise<{ gotResponse: boolean; closed: boolean }>(
+        (resolve, reject) => {
+          const client = http2.connect(`https://127.0.0.1:${addr.port}`, {
+            rejectUnauthorized: false,
+          });
+          client.on("error", reject);
+          client.on("remoteSettings", () => {
+            const req = client.request(
+              {
+                ":method": "CONNECT",
+                ":protocol": "websocket",
+                ":path": "/",
+                ":authority": "ws.localhost",
+                ":scheme": "https",
+                "sec-websocket-version": "13",
+                "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+              },
+              { endStream: false }
+            );
+            let gotResponse = false;
+            req.on("response", () => {
+              gotResponse = true;
+            });
+            req.on("error", () => {});
+            req.on("close", () => {
+              client.close();
+              resolve({ gotResponse, closed: true });
+            });
+          });
+        }
+      );
+
+      // We always respond :status 200 synchronously to claim the stream
+      // before async backend wiring; rejection surfaces as stream close.
+      expect(outcome.gotResponse).toBe(true);
+      expect(outcome.closed).toBe(true);
+    });
+
+    it("destroys stream when backend returns 101 with mismatched Sec-WebSocket-Accept", async () => {
+      const backend = trackServer(http.createServer());
+      backend.on("upgrade", (_req, socket) => {
+        // Lie about Sec-WebSocket-Accept; the bridge must catch this.
+        socket.write(
+          "HTTP/1.1 101 Switching Protocols\r\n" +
+            "Upgrade: websocket\r\n" +
+            "Connection: Upgrade\r\n" +
+            "Sec-WebSocket-Accept: AAAAAAAAAAAAAAAAAAAAAAAAAAA=\r\n" +
+            "\r\n"
+        );
+      });
+      await listen(backend);
+      const backendAddr = backend.address();
+      if (!backendAddr || typeof backendAddr === "string") throw new Error("no addr");
+
+      const routes: RouteInfo[] = [{ hostname: "ws.localhost", port: backendAddr.port }];
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => routes,
+          proxyPort: TEST_PROXY_PORT,
+          tls: { cert: tlsCert, key: tlsKey },
+        })
+      );
+      await listen(server);
+
+      const addr = server.address();
+      if (!addr || typeof addr === "string") throw new Error("no addr");
+
+      const outcome = await new Promise<{
+        gotResponse: boolean;
+        closed: boolean;
+        gotData: boolean;
+      }>((resolve, reject) => {
+        const client = http2.connect(`https://127.0.0.1:${addr.port}`, {
+          rejectUnauthorized: false,
+        });
+        client.on("error", reject);
+        client.on("remoteSettings", () => {
+          const req = client.request(
+            {
+              ":method": "CONNECT",
+              ":protocol": "websocket",
+              ":path": "/",
+              ":authority": "ws.localhost",
+              ":scheme": "https",
+              "sec-websocket-version": "13",
+              "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+            },
+            { endStream: false }
+          );
+          let gotResponse = false;
+          let gotData = false;
+          req.on("response", () => {
+            gotResponse = true;
+          });
+          req.on("data", () => {
+            gotData = true;
+          });
+          req.on("error", () => {});
+          req.on("close", () => {
+            client.close();
+            resolve({ gotResponse, closed: true, gotData });
+          });
+        });
+      });
+
+      expect(outcome.gotResponse).toBe(true);
+      expect(outcome.closed).toBe(true);
+      // Payload bytes must never reach the client when accept validation fails.
+      expect(outcome.gotData).toBe(false);
+    });
+
+    it("destroys stream for Extended CONNECT to non-existent route", async () => {
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => [],
+          proxyPort: TEST_PROXY_PORT,
+          tls: { cert: tlsCert, key: tlsKey },
+        })
+      );
+      await listen(server);
+
+      const addr = server.address();
+      if (!addr || typeof addr === "string") throw new Error("no addr");
+
+      const outcome = await new Promise<{ closed: boolean }>((resolve, reject) => {
+        const client = http2.connect(`https://127.0.0.1:${addr.port}`, {
+          rejectUnauthorized: false,
+        });
+        client.on("error", reject);
+        client.on("remoteSettings", () => {
+          const req = client.request(
+            {
+              ":method": "CONNECT",
+              ":protocol": "websocket",
+              ":path": "/",
+              ":authority": "nope.localhost",
+              ":scheme": "https",
+              "sec-websocket-version": "13",
+              "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+            },
+            { endStream: false }
+          );
+          req.on("error", () => {});
+          req.on("close", () => {
+            client.close();
+            resolve({ closed: true });
+          });
+        });
+      });
+
+      expect(outcome.closed).toBe(true);
+    });
+  });
 });

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -1,9 +1,17 @@
 import * as http from "node:http";
 import * as http2 from "node:http2";
 import * as net from "node:net";
+import * as crypto from "node:crypto";
 import type { ProxyServerOptions } from "./types.js";
 import { escapeHtml, formatUrl } from "./utils.js";
 import { ARROW_SVG, renderPage } from "./pages.js";
+
+/**
+ * RFC 6455 magic GUID — used to derive Sec-WebSocket-Accept from
+ * Sec-WebSocket-Key when bridging HTTP/2 Extended CONNECT (RFC 8441) to an
+ * HTTP/1.1 backend that expects the classic WebSocket handshake.
+ */
+const WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
 /** Response header used to identify a portless proxy (for health checks). */
 export const PORTLESS_HEADER = "X-Portless";
@@ -362,11 +370,218 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
     proxyReq.end();
   };
 
+  /**
+   * Bridge an incoming HTTP/2 Extended CONNECT (RFC 8441) WebSocket request
+   * to an HTTP/1.1 backend that speaks classic RFC 6455.
+   *
+   * Flow:
+   *   browser → portless (h2 stream, :method=CONNECT, :protocol=websocket)
+   *   portless → backend (http.request with Upgrade: websocket)
+   *   backend → portless (101 Switching Protocols + Sec-WebSocket-Accept)
+   *   portless → browser (HTTP/2 :status=200, no Sec-WebSocket-Accept needed
+   *                       per RFC 8441 §4)
+   *   ↔ pipe raw WebSocket frames in both directions
+   */
+  const handleH2WebSocket = (
+    stream: http2.ServerHttp2Stream,
+    headers: http2.IncomingHttpHeaders
+  ) => {
+    stream.on("error", () => stream.destroy());
+
+    const authority = (headers[":authority"] as string) || "";
+    const host = authority.split(":")[0];
+    const path = (headers[":path"] as string) || "/";
+
+    // CRITICAL: respond synchronously *now* to claim the stream. When both a
+    // 'request' and a 'stream' listener are registered (our case — the
+    // 'request' listener serves regular HTTPS), Node's HTTP/2 compatibility
+    // layer auto-responds 405 to CONNECT requests if the stream hasn't been
+    // responded to yet. Our async backend wiring below would lose that race.
+    // Per RFC 8441, the server responds `:status: 200` to accept the
+    // WebSocket; we then bridge to the HTTP/1.1 backend and pipe frames.
+    // If the backend rejects, we destroy the stream — the client treats it
+    // as a disconnect and retries, same as any transient WS failure.
+    try {
+      stream.respond({ ":status": 200 });
+    } catch {
+      stream.destroy();
+      return;
+    }
+
+    if (!host) {
+      stream.destroy();
+      return;
+    }
+
+    const hops =
+      parseInt(headers[PORTLESS_HOPS_HEADER] as string, 10) || 0;
+    if (hops >= MAX_PROXY_HOPS) {
+      onError(
+        `WebSocket loop detected for ${host}: request has passed through portless ${hops} times.`
+      );
+      stream.destroy();
+      return;
+    }
+
+    const routes = getRoutes();
+    const route = findRoute(routes, host, strict);
+    if (!route) {
+      stream.destroy();
+      return;
+    }
+
+    // Build classic WebSocket Upgrade headers for the HTTP/1.1 backend. The
+    // browser-supplied Sec-WebSocket-Key (if any) isn't strictly meaningful
+    // under RFC 8441, but pass it through if present for diagnostic clarity;
+    // otherwise generate one.
+    const wsKey =
+      (headers["sec-websocket-key"] as string) ||
+      crypto.randomBytes(16).toString("base64");
+
+    const fakeReq = {
+      socket: stream.session?.socket,
+      headers: { ...headers, host: authority },
+    } as unknown as http.IncomingMessage;
+    const forwardedHeaders = buildForwardedHeaders(fakeReq, true);
+
+    const backendHeaders: http.OutgoingHttpHeaders = {
+      host: authority,
+      connection: "Upgrade",
+      upgrade: "websocket",
+      "sec-websocket-version":
+        (headers["sec-websocket-version"] as string) || "13",
+      "sec-websocket-key": wsKey,
+    };
+    if (headers["sec-websocket-protocol"]) {
+      backendHeaders["sec-websocket-protocol"] =
+        headers["sec-websocket-protocol"] as string;
+    }
+    if (headers["sec-websocket-extensions"]) {
+      backendHeaders["sec-websocket-extensions"] =
+        headers["sec-websocket-extensions"] as string;
+    }
+    if (headers["origin"]) {
+      backendHeaders["origin"] = headers["origin"] as string;
+    }
+    if (headers["user-agent"]) {
+      backendHeaders["user-agent"] = headers["user-agent"] as string;
+    }
+    if (headers["cookie"]) {
+      backendHeaders["cookie"] = headers["cookie"] as string;
+    }
+    for (const [key, value] of Object.entries(forwardedHeaders)) {
+      backendHeaders[key] = value;
+    }
+    backendHeaders[PORTLESS_HOPS_HEADER] = String(hops + 1);
+
+    // Open a raw TCP socket to the backend and write the WebSocket upgrade
+    // request ourselves. We avoid http.request here because Node 24's
+    // ClientRequest closes the socket prematurely when used in this CONNECT-
+    // bridging context (it detects "no body / GET" and tears down before the
+    // server's 101 response arrives). Manual framing gives us tight control
+    // over the upgrade lifecycle.
+    const backendSocket = net.connect(route.port, "127.0.0.1");
+    backendSocket.on("error", () => {
+      backendSocket.destroy();
+      if (!stream.destroyed) stream.destroy();
+    });
+
+    let upgradeHandshakeBuffer = Buffer.alloc(0);
+    let upgraded = false;
+
+    const onBackendData = (chunk: Buffer) => {
+      if (upgraded) return; // shouldn't fire — pipes take over
+      upgradeHandshakeBuffer = Buffer.concat([upgradeHandshakeBuffer, chunk]);
+      const headerEnd = upgradeHandshakeBuffer.indexOf("\r\n\r\n");
+      if (headerEnd === -1) return; // wait for more
+      const headerBlock = upgradeHandshakeBuffer.slice(0, headerEnd).toString("utf8");
+      const remaining = upgradeHandshakeBuffer.slice(headerEnd + 4);
+      const lines = headerBlock.split("\r\n");
+      const statusLine = lines[0];
+      // Status line: "HTTP/1.1 101 Switching Protocols"
+      const statusMatch = statusLine.match(/^HTTP\/1\.[01]\s+(\d{3})/);
+      const status = statusMatch ? parseInt(statusMatch[1], 10) : 0;
+      if (status !== 101) {
+        // Backend rejected; we already told the client :status 200, so the
+        // only graceful out is to drop the stream. Client retries.
+        backendSocket.destroy();
+        if (!stream.destroyed) stream.destroy();
+        return;
+      }
+
+      // Validate Sec-WebSocket-Accept matches what we sent.
+      const acceptHeader = lines
+        .slice(1)
+        .map((l) => l.split(":"))
+        .find(([k]) => k && k.trim().toLowerCase() === "sec-websocket-accept");
+      const acceptValue = acceptHeader ? acceptHeader.slice(1).join(":").trim() : "";
+      const expectedAccept = crypto
+        .createHash("sha1")
+        .update(wsKey + WS_GUID)
+        .digest("base64");
+      if (acceptValue !== expectedAccept) {
+        backendSocket.destroy();
+        if (!stream.destroyed) stream.destroy();
+        return;
+      }
+
+      upgraded = true;
+      backendSocket.removeListener("data", onBackendData);
+
+      // Flush any WS frame bytes that arrived in the same TCP packet as the
+      // 101 response (rare but possible) before piping.
+      if (remaining.length > 0 && !stream.destroyed) {
+        stream.write(remaining);
+      }
+
+      // Pipe raw WS frames both directions. HTTP/2 DATA frames carry the
+      // bytes transparently — same byte stream as HTTP/1.1 after upgrade.
+      backendSocket.pipe(stream);
+      stream.pipe(backendSocket);
+
+      const cleanup = () => {
+        backendSocket.destroy();
+        if (!stream.destroyed) stream.close();
+      };
+      backendSocket.on("error", cleanup);
+      backendSocket.on("close", cleanup);
+      backendSocket.on("end", cleanup);
+      stream.on("close", cleanup);
+      stream.on("aborted", cleanup);
+    };
+
+    backendSocket.once("connect", () => {
+      backendSocket.on("data", onBackendData);
+
+      // Build the HTTP/1.1 WebSocket upgrade request manually.
+      let req = `GET ${path} HTTP/1.1\r\n`;
+      for (const [name, value] of Object.entries(backendHeaders)) {
+        if (value === undefined) continue;
+        req += `${name}: ${value}\r\n`;
+      }
+      req += "\r\n";
+      backendSocket.write(req);
+    });
+
+    stream.on("close", () => {
+      if (!backendSocket.destroyed) backendSocket.destroy();
+    });
+  };
+
   if (tls) {
     const h2Server = http2.createSecureServer({
       cert: tls.ca ? Buffer.concat([tls.cert, tls.ca]) : tls.cert,
       key: tls.key,
       allowHTTP1: true,
+      // Advertise RFC 8441 Extended CONNECT support to clients. Required so
+      // browsers send `:method=CONNECT, :protocol=websocket` for WebSockets
+      // over an existing HTTP/2 connection (instead of opening a separate
+      // HTTP/1.1 connection, which they don't anymore on Chrome/Firefox).
+      // Without this setting, the h2 server RST_STREAMs Extended CONNECT
+      // requests, the browser reports the WebSocket as failed, and Next.js
+      // Turbopack / Vite HMR breaks (manifests as random page reloads when
+      // the HMR client gives up reconnecting).
+      settings: { enableConnectProtocol: true },
       // Tolerate high rates of RST_STREAM from browsers during HMR and
       // page navigations. Without this, Node sends GOAWAY INTERNAL_ERROR
       // after ~1000 cumulative stream resets and kills the session,
@@ -386,9 +601,67 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
       // Absorb RST_STREAM errors from cancelled requests (browser navigation,
       // HMR) so they don't propagate to the HTTP/2 session.
       req.stream?.on("error", () => {});
+      // RFC 8441 Extended CONNECT (WebSocket-over-HTTP/2) fires both 'stream'
+      // and 'request' events; the 'stream' listener handles bridging. Here
+      // we neutralize the compat-layer Http2ServerResponse so it doesn't
+      // end the underlying stream — without this, the compat layer's
+      // implicit response lifecycle closes the stream's writable side
+      // immediately after the listener returns, killing the WS tunnel.
+      if (req.method === "CONNECT") {
+        const noop = () => res;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (res as any).end = noop;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (res as any).writeHead = noop;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (res as any).write = noop;
+        return;
+      }
       handleRequest(req as unknown as http.IncomingMessage, res as unknown as http.ServerResponse);
     });
-    // WebSocket upgrades arrive over HTTP/1.1 connections (allowHTTP1)
+
+    // RFC 8441 Extended CONNECT: WebSocket-over-HTTP/2 from modern browsers.
+    // Bridges to the HTTP/1.1 backend (Next.js/Vite/etc. dev servers) by
+    // synthesizing a classic WebSocket Upgrade request and piping bytes
+    // both directions once the backend confirms the upgrade.
+    //
+    // prependListener is critical: Node http2's compatibility layer also
+    // listens for 'stream' and auto-responds 405 to CONNECT requests when a
+    // 'request' listener is registered (because compat layer can't route
+    // CONNECT to a normal request handler). Without prepending, the compat
+    // layer wins the race, sets headers, and our stream.respond throws
+    // "Response has already been initiated".
+    h2Server.prependListener(
+      "stream",
+      (stream: http2.ServerHttp2Stream, headers: http2.IncomingHttpHeaders) => {
+        if (
+          headers[":method"] !== "CONNECT" ||
+          headers[":protocol"] !== "websocket"
+        ) {
+          // Regular request — handled by the 'request' event listener above.
+          return;
+        }
+        // Node's HTTP/2 compatibility layer (internal/http2/compat.js)
+        // unconditionally calls `response.end()` on CONNECT streams when a
+        // 'request' listener is registered, because the compat API's
+        // request/response abstraction doesn't model CONNECT. That call
+        // sends END_STREAM on our writable side and breaks WebSocket
+        // tunneling. Override `stream.end` to a no-op so the compat layer's
+        // shutdown attempt is harmless; the WebSocket bridge below pipes
+        // raw bytes via stream.write directly. The stream is destroyed
+        // (RST_STREAM) at the end of the WS lifecycle on disconnect, so we
+        // never need stream.end() for graceful shutdown.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (stream as any).end = function (this: http2.ServerHttp2Stream) {
+          return this;
+        };
+        handleH2WebSocket(stream, headers);
+      }
+    );
+
+    // HTTP/1.1 fallback: legacy clients (curl, older browsers) that never
+    // upgrade to HTTP/2 use the classic Upgrade: websocket flow. Still
+    // possible because allowHTTP1 is true.
     h2Server.on("upgrade", (req: http.IncomingMessage, socket: net.Socket, head: Buffer) => {
       handleUpgrade(req, socket, head);
     });

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -376,11 +376,15 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
    *
    * Flow:
    *   browser → portless (h2 stream, :method=CONNECT, :protocol=websocket)
-   *   portless → backend (http.request with Upgrade: websocket)
+   *   portless → backend (raw net.Socket + manual HTTP/1.1 Upgrade request)
    *   backend → portless (101 Switching Protocols + Sec-WebSocket-Accept)
    *   portless → browser (HTTP/2 :status=200, no Sec-WebSocket-Accept needed
    *                       per RFC 8441 §4)
    *   ↔ pipe raw WebSocket frames in both directions
+   *
+   * Raw net.Socket (not http.request) because Node 24's ClientRequest tears
+   * down the socket prematurely when used in this CONNECT-bridging context;
+   * see comment on backendSocket below for details.
    */
   const handleH2WebSocket = (
     stream: http2.ServerHttp2Stream,
@@ -413,8 +417,7 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
       return;
     }
 
-    const hops =
-      parseInt(headers[PORTLESS_HOPS_HEADER] as string, 10) || 0;
+    const hops = parseInt(headers[PORTLESS_HOPS_HEADER] as string, 10) || 0;
     if (hops >= MAX_PROXY_HOPS) {
       onError(
         `WebSocket loop detected for ${host}: request has passed through portless ${hops} times.`
@@ -435,8 +438,7 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
     // under RFC 8441, but pass it through if present for diagnostic clarity;
     // otherwise generate one.
     const wsKey =
-      (headers["sec-websocket-key"] as string) ||
-      crypto.randomBytes(16).toString("base64");
+      (headers["sec-websocket-key"] as string) || crypto.randomBytes(16).toString("base64");
 
     const fakeReq = {
       socket: stream.session?.socket,
@@ -448,17 +450,14 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
       host: authority,
       connection: "Upgrade",
       upgrade: "websocket",
-      "sec-websocket-version":
-        (headers["sec-websocket-version"] as string) || "13",
+      "sec-websocket-version": (headers["sec-websocket-version"] as string) || "13",
       "sec-websocket-key": wsKey,
     };
     if (headers["sec-websocket-protocol"]) {
-      backendHeaders["sec-websocket-protocol"] =
-        headers["sec-websocket-protocol"] as string;
+      backendHeaders["sec-websocket-protocol"] = headers["sec-websocket-protocol"] as string;
     }
     if (headers["sec-websocket-extensions"]) {
-      backendHeaders["sec-websocket-extensions"] =
-        headers["sec-websocket-extensions"] as string;
+      backendHeaders["sec-websocket-extensions"] = headers["sec-websocket-extensions"] as string;
     }
     if (headers["origin"]) {
       backendHeaders["origin"] = headers["origin"] as string;
@@ -634,10 +633,7 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
     h2Server.prependListener(
       "stream",
       (stream: http2.ServerHttp2Stream, headers: http2.IncomingHttpHeaders) => {
-        if (
-          headers[":method"] !== "CONNECT" ||
-          headers[":protocol"] !== "websocket"
-        ) {
+        if (headers[":method"] !== "CONNECT" || headers[":protocol"] !== "websocket") {
           // Regular request — handled by the 'request' event listener above.
           return;
         }


### PR DESCRIPTION
## Summary

- Modern browsers running an HTTPS page behind portless negotiate HTTP/2 to the proxy and then use RFC 8441 Extended CONNECT for WebSockets on that existing HTTP/2 session — they no longer fall back to a separate HTTP/1.1 connection just for WS, even with `allowHTTP1: true`.
- portless's HTTPS/2 server doesn't advertise `SETTINGS_ENABLE_CONNECT_PROTOCOL` and has no stream-level CONNECT handler, so all such WebSocket attempts are rejected. Symptom: Next.js Turbopack and Vite HMR sockets fail silently in the browser, the HMR client retries until it gives up, and the page reloads at random intervals while you work.
- This PR adds the Extended CONNECT bridge: advertise the setting, accept the CONNECT stream, synthesize a classic HTTP/1.1 WebSocket Upgrade to the backend, validate `Sec-WebSocket-Accept`, and pipe frames both directions.
- Includes 5 new unit tests. Likely fixes #64. Distinct from #246 (which is the HTTP/1.1 upgrade crash on Node 22.21).

## Details

### Why this happens

Chrome, Firefox, and Safari all use HTTP/2 to talk to portless when TLS is on. Once the HTTP/2 session is established, dev-server WebSockets (Next.js Turbopack `/_next/webpack-hmr`, Vite HMR) use **RFC 8441 Extended CONNECT** on that same session instead of opening a fresh HTTP/1.1 connection. RFC 8441 requires the server to advertise `SETTINGS_ENABLE_CONNECT_PROTOCOL=1` and accept `:method=CONNECT, :protocol=websocket` streams. Without this, the server RST_STREAMs the request, the browser logs a WebSocket connection failure, and HMR breaks.

`allowHTTP1: true` doesn't help — browsers don't downgrade to HTTP/1.1 for individual streams once they've negotiated HTTP/2 for the connection.

### What was tricky

Node's HTTP/2 server has a compatibility layer (`internal/http2/compat.js`) that bridges `'request'` events to `http.IncomingMessage` / `http.ServerResponse` shapes. CONNECT doesn't fit that abstraction, so the compat layer auto-responds 405 to any CONNECT stream the moment a `'request'` listener is registered. portless registers one for normal HTTPS handling, so a naive `h2Server.on('stream', ...)` handler loses the race.

Workarounds in this PR:

1. **`prependListener('stream', ...)`** so our handler runs before the compat layer's.
2. **Synchronous `stream.respond({ ':status': 200 })`** before any async backend wiring — RFC 8441 §4 specifies status 200 for accepted WS-over-H2, and we have to claim the stream before the compat layer does.
3. **Per-stream `stream.end = noop`** because the compat layer also unconditionally calls `response.end()` for CONNECT requests, sending END_STREAM on the writable side and breaking the tunnel. The WS lifecycle ends via stream destruction (RST_STREAM) on disconnect, not via `end()`.
4. **Raw `net.Socket` to the backend, with a manually-built upgrade request,** instead of `http.request`. On Node 24, `http.request` with `Upgrade` headers in a CONNECT-bridging context closes the socket prematurely before the backend's 101 arrives. Manual framing gives tight control over the upgrade lifecycle.

### Backwards compatibility

The HTTP/1.1 upgrade handler (`h2Server.on('upgrade', ...)`) is untouched, so legacy clients (curl, older browsers, anything that opens a fresh HTTP/1.1 connection for WS) keep working. Non-CONNECT HTTP/2 traffic is unaffected — the new code only fires on `:method=CONNECT && :protocol=websocket`.

### Tests

Adds 5 unit tests inside the existing `createProxyServer with TLS (HTTP/2)` describe block:

1. Server advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL=1` to clients.
2. Extended CONNECT WebSocket bridges to an HTTP/1.1 backend; raw frames round-trip.
3. Stream destroyed cleanly when backend rejects the upgrade with non-101.
4. Stream destroyed when backend returns 101 with mismatched `Sec-WebSocket-Accept` (security check; no payload data leaks).
5. Stream destroyed for Extended CONNECT to a non-existent route.

All 49 tests in `proxy.test.ts` pass; lint and type-check clean.

### Verified end-to-end

Running this fork against a Next.js 16 Turbopack dev server in two concurrent worktrees, HMR connects (`[HMR] connected` in browser console) and edits hot-reload without page refresh. Before the fix, the same setup produced full-page reloads every 30–60 seconds as the HMR client gave up reconnecting.