### PR TITLE
feat: support .config/portless.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Bare `portless` works out of the box. It runs the `"dev"` script from `package.j
 portless        # -> runs "dev" script, https://<project>.localhost
 ```
 
-Use an optional `portless.json` to override defaults:
+Use an optional `portless.json` or `.config/portless.json` to override defaults:
 
 ```json
 { "name": "myapp" }
@@ -60,7 +60,7 @@ The script defaults to `"dev"`. The name is inferred from `package.json` if not 
 
 ### Monorepo
 
-One `portless.json` at the repo root covers all workspace packages. Portless discovers packages from `pnpm-workspace.yaml`, or the `"workspaces"` field in `package.json` (npm, yarn, bun):
+One portless config file at the repo root covers all workspace packages. Portless discovers packages from `pnpm-workspace.yaml`, or the `"workspaces"` field in `package.json` (npm, yarn, bun):
 
 ```json
 {
@@ -76,7 +76,7 @@ portless        # from repo root: starts all workspace packages with a "dev" scr
 cd apps/web && portless   # start just one package
 ```
 
-The `apps` map is optional and only needed for name overrides. Packages not listed still auto-discover with names inferred from their `package.json`.
+The `apps` map is optional and only needed for name overrides. Packages not listed still auto-discover with names inferred from their `package.json`. Paths in `apps` are always relative to the repo root, even if the config file lives in `.config/`.
 
 Without an `apps` map, hostnames follow the `<package>.<project>.localhost` convention. The project name comes from the most common npm scope across workspace packages (e.g. `@myorg/web` and `@myorg/api` produce `myorg`), falling back to the workspace root directory name. If a package's short name matches the project name, it gets the bare `<project>.localhost` without duplication.
 
@@ -93,7 +93,7 @@ Without an `apps` map, hostnames follow the `<package>.<project>.localhost` conv
 
 ### package.json "portless" key
 
-Instead of a separate `portless.json`, you can add a `"portless"` key to your `package.json`. A string value is shorthand for setting the name:
+Instead of a separate config file, you can add a `"portless"` key to your `package.json`. A string value is shorthand for setting the name:
 
 ```json
 {
@@ -111,7 +111,13 @@ An object supports all per-app fields (`name`, `script`, `appPort`, `proxy`):
 }
 ```
 
-The `package.json` `"portless"` key takes precedence over `portless.json` app entries but is overridden by CLI flags.
+Lookup order is:
+
+1. `portless.json`
+2. `.config/portless.json`
+3. `package.json` `"portless"` key
+
+For workspace package overrides, the package's own `package.json` `"portless"` key takes precedence over the root config's `apps` entry but is overridden by CLI flags.
 
 ### --script flag
 
@@ -152,7 +158,7 @@ You can still use portless in `package.json` scripts:
 }
 ```
 
-With a `portless.json`, you can simplify to:
+With a portless config file, you can simplify to:
 
 ```json
 {

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -1175,7 +1175,7 @@ describe("CLI", () => {
     );
   });
 
-  describe("portless.json config", () => {
+  describe("portless config", () => {
     let tmpDir: string;
 
     beforeEach(() => {
@@ -1210,6 +1210,23 @@ describe("CLI", () => {
         env: { PORTLESS: "0" },
       });
       expect(stdout).toContain("config-dev");
+    });
+
+    it("portless run (no command) with .config/portless.json resolves dev script", () => {
+      fs.writeFileSync(
+        path.join(tmpDir, "package.json"),
+        JSON.stringify({ name: "test-app", scripts: { dev: "echo config-dir-dev" } })
+      );
+      fs.mkdirSync(path.join(tmpDir, ".config"), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, ".config", "portless.json"),
+        JSON.stringify({ name: "myapp" })
+      );
+      const { stdout } = run(["run"], {
+        cwd: tmpDir,
+        env: { PORTLESS: "0" },
+      });
+      expect(stdout).toContain("config-dir-dev");
     });
 
     it("portless run (no command) without portless.json resolves dev script", () => {
@@ -1258,6 +1275,28 @@ describe("CLI", () => {
         env: { PORTLESS: "0" },
       });
       expect(stdout).toContain("from-start");
+    });
+
+    it("portless run prefers root portless.json over .config/portless.json", () => {
+      fs.writeFileSync(
+        path.join(tmpDir, "package.json"),
+        JSON.stringify({
+          name: "test-app",
+          scripts: { dev: "echo from-dev", start: "echo from-start" },
+        })
+      );
+      fs.writeFileSync(path.join(tmpDir, "portless.json"), JSON.stringify({ script: "start" }));
+      fs.mkdirSync(path.join(tmpDir, ".config"), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, ".config", "portless.json"),
+        JSON.stringify({ script: "dev" })
+      );
+      const { stdout } = run(["run"], {
+        cwd: tmpDir,
+        env: { PORTLESS: "0" },
+      });
+      expect(stdout).toContain("from-start");
+      expect(stdout).not.toContain("from-dev");
     });
 
     it("--script flag overrides config script field", () => {
@@ -1316,6 +1355,21 @@ describe("CLI", () => {
       );
       fs.writeFileSync(
         path.join(tmpDir, "portless.json"),
+        JSON.stringify({ appPort: "not-a-number" })
+      );
+      const { status, stderr } = run(["run"], { cwd: tmpDir });
+      expect(status).toBe(1);
+      expect(stderr).toContain("appPort");
+    });
+
+    it(".config/portless.json validation rejects invalid appPort", () => {
+      fs.writeFileSync(
+        path.join(tmpDir, "package.json"),
+        JSON.stringify({ name: "test-app", scripts: { dev: "echo hello" } })
+      );
+      fs.mkdirSync(path.join(tmpDir, ".config"), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, ".config", "portless.json"),
         JSON.stringify({ appPort: "not-a-number" })
       );
       const { status, stderr } = run(["run"], { cwd: tmpDir });

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1284,7 +1284,7 @@ ${colors.bold("Options:")}
   --help, -h             Show this help
 
 ${colors.bold("Name inference (in order):")}
-  1. portless.json "name" field
+  1. portless config "name" field
   2. package.json "name" field (walks up directories)
   3. Git repo root directory name
   4. Current directory basename
@@ -1436,9 +1436,9 @@ ${colors.bold("Examples:")}
   portless myapp --tailscale next dev # -> also https://<node>.ts.net (tailnet)
   portless myapp --funnel next dev    # -> also https://<node>.ts.net (public)
 
-${colors.bold("Configuration (portless.json):")}
+${colors.bold("Configuration (portless.json or .config/portless.json):")}
   Optional. Portless works out of the box by running the "dev" script
-  from package.json. Use portless.json to override defaults.
+  from package.json. Use a portless config file to override defaults.
 
   Override name:   { "name": "myapp" }
   Override script: { "name": "myapp", "script": "start" }
@@ -2545,14 +2545,14 @@ ${colors.bold("LAN mode (--lan):")}
 }
 
 /**
- * Load the effective AppConfig for the current directory from portless.json.
+ * Load the effective AppConfig for the current directory from the portless config.
  * Handles both single-app (top-level fields) and monorepo (apps map) configs.
  */
 function loadAppConfig(cwd: string = process.cwd()): AppConfig | null {
   try {
     const loaded = loadConfig(cwd);
     if (!loaded) return null;
-    return resolveAppConfig(loaded.config, loaded.configDir, cwd);
+    return resolveAppConfig(loaded.config, loaded.configBaseDir, cwd);
   } catch (err) {
     if (err instanceof ConfigValidationError) {
       console.error(colors.red(`Error: ${err.message}`));
@@ -2569,8 +2569,8 @@ function loadAppConfig(cwd: string = process.cwd()): AppConfig | null {
  * Activates when:
  * - At a workspace root (pnpm, npm, yarn, or bun) -> multi-app mode
  * - In any directory with a package.json that has the target script -> single-app mode
- * Config (portless.json / package.json "portless" key) is loaded for overrides
- * but is not required.
+ * Config (portless.json / .config/portless.json / package.json "portless" key)
+ * is loaded for overrides but is not required.
  */
 async function handleDefaultMode(
   globalScript?: string,
@@ -2633,7 +2633,7 @@ async function handleDefaultSingle(
       .split(".")
       .map((label) => truncateLabel(label))
       .join(".");
-    nameSource = "portless.json";
+    nameSource = "portless config";
   } else {
     const inferred = inferProjectName(cwd);
     baseName = inferred.name;
@@ -2877,7 +2877,9 @@ async function handleDefaultMulti(
 
   for (const pkg of packages) {
     const rel = path.relative(wsRoot, pkg.dir).replace(/\\/g, "/");
-    const rootOverride = loaded ? resolveAppConfig(loaded.config, loaded.configDir, pkg.dir) : null;
+    const rootOverride = loaded
+      ? resolveAppConfig(loaded.config, loaded.configBaseDir, pkg.dir)
+      : null;
     let pkgConfig: AppConfig | null;
     try {
       pkgConfig = loadPackagePortlessConfig(pkg.dir);
@@ -2889,7 +2891,7 @@ async function handleDefaultMulti(
       throw err;
     }
 
-    // Merge (closest wins): package.json "portless" > portless.json app entry > defaults
+    // Merge (closest wins): package.json "portless" > portless config app entry > defaults
     const appOverride: AppConfig = {
       ...Object.fromEntries(Object.entries(rootOverride ?? {}).filter(([, v]) => v !== undefined)),
       ...Object.fromEntries(Object.entries(pkgConfig ?? {}).filter(([, v]) => v !== undefined)),
@@ -3230,7 +3232,7 @@ async function handleRunMode(args: string[], globalScript?: string): Promise<voi
       .split(".")
       .map((label) => truncateLabel(label))
       .join(".");
-    nameSource = "portless.json";
+    nameSource = "portless config";
   } else {
     const inferred = inferProjectName();
     baseName = inferred.name;

--- a/packages/portless/src/config.test.ts
+++ b/packages/portless/src/config.test.ts
@@ -99,7 +99,7 @@ describe("loadConfig", () => {
     cleanupDir(tmpDir);
   });
 
-  it("returns null when no portless.json exists", () => {
+  it("returns null when no config source exists", () => {
     expect(loadConfig(tmpDir)).toBeNull();
   });
 
@@ -108,7 +108,21 @@ describe("loadConfig", () => {
     const result = loadConfig(tmpDir);
     expect(result).not.toBeNull();
     expect(result!.config.name).toBe("myapp");
-    expect(result!.configDir).toBe(tmpDir);
+    expect(result!.configBaseDir).toBe(tmpDir);
+    expect(result!.sourcePath).toBe(path.join(tmpDir, "portless.json"));
+  });
+
+  it("loads .config/portless.json when root portless.json is absent", () => {
+    fs.mkdirSync(path.join(tmpDir, ".config"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, ".config", "portless.json"),
+      JSON.stringify({ name: "myapp" })
+    );
+    const result = loadConfig(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result!.config.name).toBe("myapp");
+    expect(result!.configBaseDir).toBe(tmpDir);
+    expect(result!.sourcePath).toBe(path.join(tmpDir, ".config", "portless.json"));
   });
 
   it("does not walk up from a subdirectory", () => {
@@ -163,7 +177,8 @@ describe("loadConfig", () => {
     expect(result).not.toBeNull();
     expect(result!.config.name).toBe("myapp");
     expect(result!.config.script).toBe("dev");
-    expect(result!.configDir).toBe(tmpDir);
+    expect(result!.configBaseDir).toBe(tmpDir);
+    expect(result!.sourcePath).toBe(path.join(tmpDir, "package.json"));
   });
 
   it("loads string shorthand from package.json portless key", () => {
@@ -192,6 +207,33 @@ describe("loadConfig", () => {
     );
     const result = loadConfig(tmpDir);
     expect(result!.config.name).toBe("from-file");
+  });
+
+  it("prefers root portless.json over .config/portless.json", () => {
+    fs.mkdirSync(path.join(tmpDir, ".config"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "portless.json"), JSON.stringify({ name: "from-root" }));
+    fs.writeFileSync(
+      path.join(tmpDir, ".config", "portless.json"),
+      JSON.stringify({ name: "from-config-dir" })
+    );
+    const result = loadConfig(tmpDir);
+    expect(result!.config.name).toBe("from-root");
+    expect(result!.sourcePath).toBe(path.join(tmpDir, "portless.json"));
+  });
+
+  it("prefers .config/portless.json over package.json portless key", () => {
+    fs.mkdirSync(path.join(tmpDir, ".config"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, ".config", "portless.json"),
+      JSON.stringify({ name: "from-config-dir" })
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "test", portless: { name: "from-pkg" } })
+    );
+    const result = loadConfig(tmpDir);
+    expect(result!.config.name).toBe("from-config-dir");
+    expect(result!.sourcePath).toBe(path.join(tmpDir, ".config", "portless.json"));
   });
 
   it("ignores package.json without portless key", () => {
@@ -226,6 +268,12 @@ describe("loadConfig validation", () => {
 
   it("throws on invalid JSON", () => {
     fs.writeFileSync(path.join(tmpDir, "portless.json"), "not json");
+    expect(() => loadConfig(tmpDir)).toThrow(ConfigValidationError);
+  });
+
+  it("throws on invalid JSON in .config/portless.json", () => {
+    fs.mkdirSync(path.join(tmpDir, ".config"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, ".config", "portless.json"), "not json");
     expect(() => loadConfig(tmpDir)).toThrow(ConfigValidationError);
   });
 
@@ -377,6 +425,16 @@ describe("resolveAppConfig", () => {
     };
     // path.relative on Windows returns backslashes
     const result = resolveAppConfig(config, "/repo", "/repo/apps/web");
+    expect(result).toEqual({ name: "web" });
+  });
+
+  it("matches apps relative to the project root even when config lives in .config", () => {
+    const config = {
+      apps: {
+        "packages/web": { name: "web" },
+      },
+    };
+    const result = resolveAppConfig(config, "/repo", "/repo/packages/web");
     expect(result).toEqual({ name: "web" });
   });
 });

--- a/packages/portless/src/config.ts
+++ b/packages/portless/src/config.ts
@@ -22,32 +22,42 @@ export interface PortlessConfig extends AppConfig {
 
 export interface LoadedConfig {
   config: PortlessConfig;
-  configDir: string;
+  configBaseDir: string;
+  sourcePath: string;
 }
 
 const CONFIG_FILENAME = "portless.json";
+const ALT_CONFIG_PATH = path.join(".config", CONFIG_FILENAME);
 
-/**
- * Load portless config from `cwd`. Checks `portless.json` first, then
- * falls back to a `"portless"` key in `package.json`. Does not walk up
- * to parent directories.
- */
-export function loadConfig(cwd: string = process.cwd()): LoadedConfig | null {
-  const configPath = path.join(cwd, CONFIG_FILENAME);
+function loadConfigFromFile(configPath: string, configBaseDir: string): LoadedConfig | null {
   try {
     const raw = fs.readFileSync(configPath, "utf-8");
     const parsed = JSON.parse(raw);
     validateConfig(parsed, configPath);
-    return { config: parsed, configDir: cwd };
+    return { config: parsed, configBaseDir, sourcePath: configPath };
   } catch (err) {
     if (isErrnoException(err) && err.code === "ENOENT") {
-      return loadConfigFromPackageJson(cwd);
+      return null;
     }
     if (err instanceof SyntaxError) {
       throw new ConfigValidationError(`Invalid JSON in ${configPath}`);
     }
     throw err;
   }
+}
+
+/**
+ * Load portless config from `cwd`. Checks `portless.json`, then
+ * `.config/portless.json`, then falls back to a `"portless"` key in
+ * `package.json`. Does not walk up to parent directories.
+ */
+export function loadConfig(cwd: string = process.cwd()): LoadedConfig | null {
+  for (const configPath of [path.join(cwd, CONFIG_FILENAME), path.join(cwd, ALT_CONFIG_PATH)]) {
+    const loaded = loadConfigFromFile(configPath, cwd);
+    if (loaded) return loaded;
+  }
+
+  return loadConfigFromPackageJson(cwd);
 }
 
 /** Normalize the raw `"portless"` value: a string is shorthand for `{ name }`. */
@@ -67,7 +77,7 @@ function loadConfigFromPackageJson(dir: string): LoadedConfig | null {
       const config = normalizePortlessValue(pkg.portless);
       if (config === null) return null;
       validateConfig(config, `${pkgPath} "portless"`);
-      return { config: config as PortlessConfig, configDir: dir };
+      return { config: config as PortlessConfig, configBaseDir: dir, sourcePath: pkgPath };
     }
   } catch (err) {
     if (isErrnoException(err) && err.code === "ENOENT") return null;
@@ -107,11 +117,11 @@ export function loadPackagePortlessConfig(dir: string): AppConfig | null {
  */
 export function resolveAppConfig(
   config: PortlessConfig,
-  configDir: string,
+  configBaseDir: string,
   packageDir: string
 ): AppConfig {
   if (config.apps) {
-    const rel = normalizePath(path.relative(configDir, packageDir));
+    const rel = normalizePath(path.relative(configBaseDir, packageDir));
     if (rel && !rel.startsWith("..")) {
       let candidate = rel;
       while (candidate) {

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -63,7 +63,7 @@ portless        # -> runs "dev" script, https://<project>.localhost
 pnpm dev        # -> works without portless, plain "next dev"
 ```
 
-Use an optional `portless.json` to override defaults (name, script, port):
+Use an optional `portless.json` or `.config/portless.json` to override defaults (name, script, port):
 
 ```json
 { "name": "myapp" }
@@ -75,7 +75,7 @@ portless        # -> runs "dev" script, https://myapp.localhost
 
 ### Monorepo
 
-One `portless.json` at the repo root. Portless discovers packages from `pnpm-workspace.yaml`, or the `"workspaces"` field in `package.json` (npm, yarn, bun):
+One portless config file at the repo root. Portless discovers packages from `pnpm-workspace.yaml`, or the `"workspaces"` field in `package.json` (npm, yarn, bun):
 
 ```json
 {
@@ -92,7 +92,7 @@ cd apps/web && portless   # start just one package
 portless --script start   # run "start" instead of "dev"
 ```
 
-The `apps` map is optional and only provides name overrides. Unlisted packages auto-discover with inferred names.
+The `apps` map is optional and only provides name overrides. Unlisted packages auto-discover with inferred names. Paths in `apps` are always relative to the repo root, even if the config file lives in `.config/`.
 
 Without an `apps` map, hostnames follow `<package>.<project>.localhost`. The project name comes from the most common npm scope (e.g. `@myorg/web` and `@myorg/api` produce `myorg`), falling back to the workspace root directory name. If a package's short name matches the project name, it uses the bare `<project>.localhost`.
 
@@ -280,9 +280,9 @@ Each `--tailscale` app is root-mounted on its own Tailscale HTTPS port (443, the
 
 **Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `trust`, `clean`, `prune`, and `proxy` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name, or `portless --name <name> <cmd>` to force any name including reserved ones.
 
-## portless.json
+## portless config
 
-Optional config file. Portless looks for it in the current directory.
+Optional config file. Portless looks for `portless.json` in the current directory, then `.config/portless.json`.
 
 | Field     | Type    | Default                    | Description                                              |
 | --------- | ------- | -------------------------- | -------------------------------------------------------- |
@@ -297,7 +297,7 @@ Each `apps` entry has the same shape (`name`, `script`, `appPort`, `proxy`). Whe
 
 ### package.json "portless" key
 
-Instead of a separate `portless.json`, you can add a `"portless"` key to your `package.json`. A string value is shorthand for setting the name:
+Instead of a separate config file, you can add a `"portless"` key to your `package.json`. A string value is shorthand for setting the name:
 
 ```json
 { "portless": "myapp" }
@@ -309,7 +309,13 @@ An object supports all per-app fields (`name`, `script`, `appPort`, `proxy`):
 { "portless": { "name": "myapp", "script": "dev:app" } }
 ```
 
-Precedence (closest wins): CLI flags > package.json `"portless"` key > portless.json app entry > defaults.
+Lookup order:
+
+1. `portless.json`
+2. `.config/portless.json`
+3. `package.json` `"portless"` key
+
+For workspace package overrides, precedence is: CLI flags > package `package.json` `"portless"` key > root config `apps` entry > defaults.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Add support for loading project config from `.config/portless.json` as an alternative to the existing root `portless.json`.

Closes #268.

## What changed

- added `.config/portless.json` as a fallback config location
- preserved existing precedence:
  1. `portless.json`
  2. `.config/portless.json`
  3. `package.json#portless`
- kept `apps` path matching relative to the project root, including when config is loaded from `.config/`
- added tests for precedence, validation, and workspace app matching
- updated README, `skills/portless/SKILL.md`, and CLI help text

## Why

This supports the growing `.config/` convention without changing existing behavior for projects that already use `portless.json`.

## Notes

Issue #268 suggests making `package.json#portless` highest precedence, but the current implementation and tests already define `portless.json` as higher precedence. This PR keeps the existing behavior and adds `.config/portless.json` as a non-breaking fallback.
