### PR TITLE
fix: add preflight check for funnel on tailscale

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,9 +300,11 @@ portless myapp --funnel next dev
 # -> https://devbox.yourteam.ts.net    (public)
 ```
 
+Tailscale HTTPS certificates must be enabled before `--tailscale` or `--funnel` can register HTTPS URLs. Funnel must also be enabled for the tailnet and node before `--funnel` can register the public URL. If either setting is missing, portless exits before starting the child process.
+
 Set `PORTLESS_TAILSCALE=1` in your shell profile or `.env` to share every app by default. `portless list` shows both local and tailnet URLs. Tailscale serve registrations are cleaned up automatically when the app exits.
 
-Requires the Tailscale CLI to be installed and connected (`tailscale up`).
+Requires the Tailscale CLI to be installed and connected (`tailscale up`), with Tailscale HTTPS certificates enabled.
 
 ## Commands
 

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -959,14 +959,17 @@ async function runApp(
 
   if (wantsTailscale) {
     try {
-      const tsReady = ensureTailscaleReady();
+      const tsReady = ensureTailscaleReady({
+        requireFunnel: wantsFunnel,
+        requireHttps: true,
+      });
       tsBaseUrl = tsReady.baseUrl;
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       console.error(colors.red(`Error: ${message}`));
       if (message.includes("not found")) {
         console.error(colors.blue("Install Tailscale: https://tailscale.com/download"));
-      } else {
+      } else if (!message.includes("not enabled on your tailnet")) {
         console.error(colors.blue("Make sure Tailscale is connected:"));
         console.error(colors.cyan("  tailscale up"));
       }
@@ -1490,7 +1493,9 @@ ${colors.bold("Tailscale sharing:")}
   Each app is root-mounted on its own Tailscale HTTPS port (443, then 8443,
   8444, etc.) so no basePath configuration is needed.
   Use --funnel to expose your dev server to the public internet via
-  Tailscale Funnel. Requires Tailscale CLI to be installed and connected.
+  Tailscale Funnel. Requires Tailscale CLI to be installed and connected,
+  with Tailscale HTTPS certificates enabled. Funnel must also be enabled
+  on your tailnet.
   ${colors.cyan("portless myapp --tailscale next dev")}
   ${colors.cyan("portless myapp --funnel next dev")}
 

--- a/packages/portless/src/tailscale.test.ts
+++ b/packages/portless/src/tailscale.test.ts
@@ -55,7 +55,7 @@ describe("tailscale", () => {
           }),
         },
       });
-      const ready = ensureTailscaleReady(runner);
+      const ready = ensureTailscaleReady({ runner });
       expect(ready.dnsName).toBe("devbox.example.ts.net");
       expect(ready.baseUrl).toBe("https://devbox.example.ts.net");
     });
@@ -71,8 +71,96 @@ describe("tailscale", () => {
           }),
         },
       });
-      const ready = ensureTailscaleReady(runner);
+      const ready = ensureTailscaleReady({ runner });
       expect(ready.dnsName).toBe("devbox.example.ts.net");
+    });
+
+    it("throws when Funnel is required but not enabled on the tailnet", () => {
+      const runner = createRunner({
+        version: { status: 0 },
+        "status --json": {
+          status: 0,
+          stdout: JSON.stringify({
+            Self: {
+              ID: "nMNPgMjBts11CNTRL",
+              DNSName: "devbox.example.ts.net.",
+              Capabilities: ["https"],
+            },
+          }),
+        },
+      });
+      expect(() => ensureTailscaleReady({ runner, requireFunnel: true })).toThrow(
+        "https://login.tailscale.com/f/funnel?node=nMNPgMjBts11CNTRL"
+      );
+    });
+
+    it("validates node DNS before checking required capabilities", () => {
+      const runner = createRunner({
+        version: { status: 0 },
+        "status --json": {
+          status: 0,
+          stdout: JSON.stringify({
+            Self: {},
+          }),
+        },
+      });
+      expect(() =>
+        ensureTailscaleReady({ runner, requireFunnel: true, requireHttps: true })
+      ).toThrow("Could not determine Tailscale node DNS name");
+    });
+
+    it("throws when HTTPS is required but not enabled on the tailnet", () => {
+      const runner = createRunner({
+        version: { status: 0 },
+        "status --json": {
+          status: 0,
+          stdout: JSON.stringify({
+            Self: {
+              DNSName: "devbox.example.ts.net.",
+              Capabilities: ["funnel"],
+            },
+          }),
+        },
+      });
+      expect(() => ensureTailscaleReady({ runner, requireHttps: true })).toThrow(
+        "Tailscale HTTPS is not enabled on your tailnet"
+      );
+    });
+
+    it("allows HTTPS when the node has an HTTPS capability", () => {
+      const runner = createRunner({
+        version: { status: 0 },
+        "status --json": {
+          status: 0,
+          stdout: JSON.stringify({
+            Self: {
+              DNSName: "devbox.example.ts.net.",
+              CapMap: {
+                https: null,
+              },
+            },
+          }),
+        },
+      });
+      const ready = ensureTailscaleReady({ runner, requireHttps: true });
+      expect(ready.baseUrl).toBe("https://devbox.example.ts.net");
+    });
+
+    it("allows Funnel when the node has a Funnel capability", () => {
+      const runner = createRunner({
+        version: { status: 0 },
+        "status --json": {
+          status: 0,
+          stdout: JSON.stringify({
+            Self: {
+              DNSName: "devbox.example.ts.net.",
+              Capabilities: ["https", "https://tailscale.com/cap/funnel"],
+            },
+          }),
+        },
+      });
+      const ready = ensureTailscaleReady({ runner, requireFunnel: true });
+      expect(ready.baseUrl).toBe("https://devbox.example.ts.net");
     });
 
     it("throws when tailscale CLI is missing", () => {
@@ -82,7 +170,7 @@ describe("tailscale", () => {
       const runner = createRunner({
         version: { status: null, error: enoent },
       });
-      expect(() => ensureTailscaleReady(runner)).toThrow("Tailscale CLI not found");
+      expect(() => ensureTailscaleReady({ runner })).toThrow("Tailscale CLI not found");
     });
 
     it("throws when tailscale is not connected", () => {
@@ -93,14 +181,14 @@ describe("tailscale", () => {
           stdout: JSON.stringify({ Self: {} }),
         },
       });
-      expect(() => ensureTailscaleReady(runner)).toThrow("Could not determine");
+      expect(() => ensureTailscaleReady({ runner })).toThrow("Could not determine");
     });
 
     it("throws on version check failure", () => {
       const runner = createRunner({
         version: { status: 1, stderr: "not found" },
       });
-      expect(() => ensureTailscaleReady(runner)).toThrow("Failed to check tailscale version");
+      expect(() => ensureTailscaleReady({ runner })).toThrow("Failed to check tailscale version");
     });
 
     it("throws on invalid status JSON", () => {
@@ -111,7 +199,7 @@ describe("tailscale", () => {
           stdout: "not json",
         },
       });
-      expect(() => ensureTailscaleReady(runner)).toThrow("Failed to parse");
+      expect(() => ensureTailscaleReady({ runner })).toThrow("Failed to parse");
     });
   });
 
@@ -344,6 +432,38 @@ describe("tailscale", () => {
       });
       expect(() => registerFunnel(4123, 443, { runner })).toThrow(
         "Tailscale Funnel supports ports 443, 8443, and 10000"
+      );
+    });
+
+    it("throws an actionable error when Funnel is not enabled on the tailnet", () => {
+      const runner = createRunner({
+        "funnel --bg --yes --https=443 http://127.0.0.1:4123": {
+          status: 1,
+          stderr: [
+            "Funnel is not enabled on your tailnet.",
+            "To enable, visit:",
+            "",
+            "https://login.tailscale.com/f/funnel?node=nMNPgMjBts11CNTRL",
+          ].join("\n"),
+        },
+      });
+      expect(() => registerFunnel(4123, 443, { runner })).toThrow(
+        "Tailscale Funnel is not enabled on your tailnet"
+      );
+    });
+
+    it("throws an actionable error when Funnel registration times out", () => {
+      const timeout = Object.assign(new Error("spawnSync tailscale ETIMEDOUT"), {
+        code: "ETIMEDOUT",
+      });
+      const runner = createRunner({
+        "funnel --bg --yes --https=443 http://127.0.0.1:4123": {
+          status: null,
+          error: timeout,
+        },
+      });
+      expect(() => registerFunnel(4123, 443, { runner })).toThrow(
+        "Tailscale Funnel registration timed out"
       );
     });
   });

--- a/packages/portless/src/tailscale.ts
+++ b/packages/portless/src/tailscale.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 
 const TAILSCALE_BINARY = "tailscale";
+const TAILSCALE_COMMAND_TIMEOUT_MS = 30_000;
 
 /**
  * Port allocation sequence for tailscale serve HTTPS ports.
@@ -24,8 +25,11 @@ export type TailscaleCommandRunner = (args: string[]) => TailscaleCommandResult;
 
 interface TailscaleStatusJson {
   Self?: {
+    Capabilities?: string[];
+    CapMap?: Record<string, unknown>;
     DNSName?: string;
     HostName?: string;
+    ID?: string;
   };
   CurrentTailnet?: {
     MagicDNSSuffix?: string;
@@ -37,8 +41,18 @@ export interface TailscaleReadyResult {
   baseUrl: string;
 }
 
+export interface EnsureTailscaleReadyOptions {
+  requireFunnel?: boolean;
+  requireHttps?: boolean;
+  runner?: TailscaleCommandRunner;
+}
+
 function defaultRunner(args: string[]): TailscaleCommandResult {
-  const result = spawnSync(TAILSCALE_BINARY, args, { encoding: "utf-8" });
+  const result = spawnSync(TAILSCALE_BINARY, args, {
+    encoding: "utf-8",
+    killSignal: "SIGKILL",
+    timeout: TAILSCALE_COMMAND_TIMEOUT_MS,
+  });
   return {
     status: result.status,
     stdout: result.stdout ?? "",
@@ -107,17 +121,75 @@ function statusToDnsName(status: TailscaleStatusJson): string {
   );
 }
 
+function isFunnelCapability(value: string): boolean {
+  const normalized = value.toLowerCase();
+  return normalized === "funnel" || normalized.endsWith("/funnel");
+}
+
+function isHttpsCapability(value: string): boolean {
+  const normalized = value.toLowerCase();
+  return normalized === "https" || normalized.endsWith("/https");
+}
+
+function hasCapability(
+  status: TailscaleStatusJson,
+  predicate: (value: string) => boolean
+): boolean {
+  const capabilities = status.Self?.Capabilities;
+  if (Array.isArray(capabilities) && capabilities.some(predicate)) {
+    return true;
+  }
+
+  const capMap = status.Self?.CapMap;
+  return Boolean(capMap && Object.keys(capMap).some(predicate));
+}
+
+function hasHttpsCapability(status: TailscaleStatusJson): boolean {
+  return hasCapability(status, isHttpsCapability);
+}
+
+function hasFunnelCapability(status: TailscaleStatusJson): boolean {
+  return hasCapability(status, isFunnelCapability);
+}
+
+function throwHttpsNotEnabled(): never {
+  throw new Error(
+    "Tailscale HTTPS is not enabled on your tailnet. " +
+      "Enable HTTPS certificates in Tailscale DNS settings, then run portless again."
+  );
+}
+
+function throwFunnelNotEnabled(status: TailscaleStatusJson): never {
+  const nodeId = status.Self?.ID;
+  const enableUrl =
+    typeof nodeId === "string" && nodeId.length > 0
+      ? ` Visit https://login.tailscale.com/f/funnel?node=${nodeId} to enable it.`
+      : "";
+  throw new Error(
+    "Tailscale Funnel is not enabled on your tailnet. " +
+      "Enable Funnel for this node, then run portless again." +
+      enableUrl
+  );
+}
+
 /**
  * Verify that the Tailscale CLI is installed and the node is connected.
  * Returns the node's DNS name and base URL.
  */
 export function ensureTailscaleReady(
-  runner: TailscaleCommandRunner = defaultRunner
+  options: EnsureTailscaleReadyOptions = {}
 ): TailscaleReadyResult {
+  const runner = options.runner ?? defaultRunner;
   runOrThrow(["version"], "check tailscale version", runner);
   const statusResult = runOrThrow(["status", "--json"], "read tailscale status", runner);
   const status = parseStatusJson(statusResult.stdout);
   const dnsName = statusToDnsName(status);
+  if (options.requireHttps && !hasHttpsCapability(status)) {
+    throwHttpsNotEnabled();
+  }
+  if (options.requireFunnel && !hasFunnelCapability(status)) {
+    throwFunnelNotEnabled(status);
+  }
   return {
     dnsName,
     baseUrl: `https://${dnsName}`,
@@ -209,6 +281,20 @@ function isConflictError(stderr: string, stdout: string): boolean {
   );
 }
 
+function isFunnelNotEnabledError(stderr: string, stdout: string): boolean {
+  const text = `${stderr}\n${stdout}`.toLowerCase();
+  return text.includes("funnel is not enabled on your tailnet");
+}
+
+function formatFunnelNotEnabledError(stderr: string, stdout: string): string {
+  const details = normalizeSpace(`${stderr}\n${stdout}`);
+  return (
+    "Tailscale Funnel is not enabled on your tailnet. " +
+    "Enable Funnel for this node, then run portless again." +
+    (details ? ` Tailscale said: ${details}` : "")
+  );
+}
+
 export type TailscaleMode = "serve" | "funnel";
 
 export interface RegisterServeOptions {
@@ -235,9 +321,20 @@ function register(
         "Tailscale CLI not found. Install Tailscale (https://tailscale.com/download) and ensure `tailscale` is on PATH."
       );
     }
+    if (mode === "funnel" && isFunnelNotEnabledError(result.stderr, result.stdout)) {
+      throw new Error(formatFunnelNotEnabledError(result.stderr, result.stdout));
+    }
+    if (mode === "funnel" && errno.code === "ETIMEDOUT") {
+      throw new Error(
+        "Tailscale Funnel registration timed out. Make sure Funnel is enabled on your tailnet, then run portless again."
+      );
+    }
     throw new Error(`Failed to register tailscale ${mode}: ${result.error.message}`);
   }
   if (result.status !== 0) {
+    if (mode === "funnel" && isFunnelNotEnabledError(result.stderr, result.stdout)) {
+      throw new Error(formatFunnelNotEnabledError(result.stderr, result.stdout));
+    }
     if (isConflictError(result.stderr, result.stdout)) {
       throw new Error(
         `Tailscale ${mode === "funnel" ? "Funnel " : ""}HTTPS port ${httpsPort} is already in use. ` +

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -236,7 +236,9 @@ portless myapp --funnel next dev
 # -> https://devbox.yourteam.ts.net    (public internet)
 ```
 
-Each `--tailscale` app is root-mounted on its own Tailscale HTTPS port (443, then 8443, 8444, etc.) so no framework `basePath` configuration is needed. Set `PORTLESS_TAILSCALE=1` to share every app by default. `portless list` shows both local and tailnet URLs. Tailscale serve registrations are cleaned up when the app exits. Requires `tailscale` CLI installed and connected.
+Tailscale HTTPS certificates must be enabled before `--tailscale` or `--funnel` can register HTTPS URLs. Funnel must also be enabled for the tailnet and node before `--funnel` can register the public URL. If either setting is missing, portless exits before starting the child process.
+
+Each `--tailscale` app is root-mounted on its own Tailscale HTTPS port (443, then 8443, 8444, etc.) so no framework `basePath` configuration is needed. Set `PORTLESS_TAILSCALE=1` to share every app by default. `portless list` shows both local and tailnet URLs. Tailscale serve registrations are cleaned up when the app exits. Requires `tailscale` CLI installed and connected, with Tailscale HTTPS certificates enabled.
 
 ## CLI Reference
 


### PR DESCRIPTION
## Summary

Fixes `portless --funnel` hanging before the child process starts when Tailscale prerequisites are missing.

> I was using portless + tailscale combination to test a Slack bot from Next.js app. The --funnel command would always hang at localhost setup and won't even start the Next.js app. After some debugging, I realized my tailnet is not configured to use a funnel, and enabling that solved my issue. So, I've added a preflight check that provides actionable feedback to users who encounter the same issue.

## Repro

1. Disable Funnel for the current tailnet/node.
2. Run:

```bash
portless run --funnel next dev"
```

Before this change, portless printed the local URL, then blocked during `tailscale funnel` registration. The child command never started and no actionable error was shown.

## Fix

- Preflight Tailscale readiness before route registration.
- Require Tailscale HTTPS certificates for `--tailscale` and `--funnel`.
- Require Funnel capability for `--funnel`.
- Surface actionable errors for missing HTTPS/Funnel settings.
- Keep a bounded Tailscale CLI timeout as a fallback.
- Update README, CLI help, and agent skill docs.

## Test

```bash
pnpm --filter portless test -- tailscale.test.ts
pnpm --filter portless type-check
pnpm --filter portless build
```

Manual check:

```bash
portless run --funnel next dev"
```

With Funnel disabled, portless should fail before printing `child-started`.