### PR TITLE
fix: resolve sudo state dir and trust Windows CA store from WSL

### DIFF
--- a/packages/portless/src/certs.test.ts
+++ b/packages/portless/src/certs.test.ts
@@ -20,6 +20,34 @@ function getCertSignatureAlgo(certPath: string): string {
   return match ? match[1].toLowerCase() : "";
 }
 
+function rewritePemSignatureAlgorithm(pem: string, fromOidByte: number, toOidByte: number): string {
+  const base64 = pem.replace(/-----BEGIN CERTIFICATE-----|-----END CERTIFICATE-----|\s/g, "");
+  const der = Buffer.from(base64, "base64");
+  const rsaSignatureOidPrefix = Buffer.from([
+    0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01,
+  ]);
+  let replacements = 0;
+
+  for (let i = 0; i <= der.length - rsaSignatureOidPrefix.length - 1; i++) {
+    if (der.subarray(i, i + rsaSignatureOidPrefix.length).equals(rsaSignatureOidPrefix)) {
+      const oidByteIndex = i + rsaSignatureOidPrefix.length;
+      if (der[oidByteIndex] === fromOidByte) {
+        der[oidByteIndex] = toOidByte;
+        replacements++;
+      }
+    }
+  }
+
+  expect(replacements).toBeGreaterThanOrEqual(2);
+
+  const rewritten =
+    der
+      .toString("base64")
+      .match(/.{1,64}/g)
+      ?.join("\n") ?? "";
+  return `-----BEGIN CERTIFICATE-----\n${rewritten}\n-----END CERTIFICATE-----\n`;
+}
+
 describe("ensureCerts", () => {
   let tmpDir: string;
 
@@ -139,48 +167,38 @@ describe("ensureCerts", () => {
 
   it("regenerates server cert if it uses SHA-1 signature", () => {
     const first = ensureCerts(tmpDir);
-    const caKeyPath = path.join(tmpDir, "ca-key.pem");
-    const csrPath = path.join(tmpDir, "server-weak.csr");
-    const extPath = path.join(tmpDir, "server-weak-ext.cnf");
+    const weakKeyPath = path.join(tmpDir, "server-weak-key.pem");
 
-    execFileSync("openssl", [
-      "req",
-      "-new",
-      "-key",
-      first.keyPath,
-      "-out",
-      csrPath,
-      "-subj",
-      "/CN=localhost",
-    ]);
-    fs.writeFileSync(
-      extPath,
+    // OpenSSL 3 can reject creating SHA-1 signatures with "invalid digest".
+    // Generate a modern RSA cert, then rewrite the signature algorithm OIDs to
+    // match an old SHA-1 cert. The regeneration logic only needs to parse the
+    // certificate metadata and does not verify the intentionally stale signature.
+    execFileSync(
+      "openssl",
       [
-        "authorityKeyIdentifier=keyid,issuer",
-        "basicConstraints=CA:FALSE",
-        "keyUsage=digitalSignature,keyEncipherment",
-        "extendedKeyUsage=serverAuth",
+        "req",
+        "-x509",
+        "-newkey",
+        "rsa:2048",
+        "-sha256",
+        "-nodes",
+        "-keyout",
+        weakKeyPath,
+        "-out",
+        first.certPath,
+        "-days",
+        "365",
+        "-subj",
+        "/CN=localhost",
+        "-addext",
         "subjectAltName=DNS:localhost,DNS:*.localhost",
-      ].join("\n") + "\n"
+      ],
+      { stdio: "ignore" }
     );
-    execFileSync("openssl", [
-      "x509",
-      "-req",
-      "-sha1",
-      "-in",
-      csrPath,
-      "-CA",
-      first.caPath,
-      "-CAkey",
-      caKeyPath,
-      "-CAcreateserial",
-      "-out",
+    fs.writeFileSync(
       first.certPath,
-      "-days",
-      "365",
-      "-extfile",
-      extPath,
-    ]);
+      rewritePemSignatureAlgorithm(fs.readFileSync(first.certPath, "utf-8"), 0x0b, 0x05)
+    );
 
     expect(getCertSignatureAlgo(first.certPath)).toContain("sha1");
 

--- a/packages/portless/src/certs.ts
+++ b/packages/portless/src/certs.ts
@@ -5,6 +5,7 @@ import * as tls from "node:tls";
 import { execFile as execFileCb, execFileSync } from "node:child_process";
 import { promisify } from "node:util";
 import { fixOwnership } from "./utils.js";
+import { isWSL, runPowerShellFromWSL, wslToWindowsPath } from "./wsl-utils.js";
 
 /** How long the CA certificate is valid (10 years, in days). */
 const CA_VALIDITY_DAYS = 3650;
@@ -73,6 +74,15 @@ function caFingerprint(stateDir: string): string | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Extract the SHA-1 fingerprint from a PEM certificate file.
+ */
+function getCertFingerprint(caCertPath: string): string {
+  const pem = fs.readFileSync(caCertPath, "utf-8");
+  const cert = new crypto.X509Certificate(pem);
+  return cert.fingerprint.replace(/:/g, "").toLowerCase();
 }
 
 function readTrustMarker(stateDir: string): string | null {
@@ -448,7 +458,13 @@ export function isCATrusted(stateDir: string): boolean {
   if (process.platform === "darwin") {
     return isCATrustedMacOS(caCertPath);
   } else if (process.platform === "linux") {
-    return isCATrustedLinux(stateDir);
+    const isTrustedLinux = isCATrustedLinux(stateDir);
+    if (isWSL()) {
+      // On WSL, also check if the CA is trusted in the Windows store,
+      // since browsers run in Windows and won't see the Linux trust.
+      return isTrustedLinux && isCATrustedWindowsFromWSL(caCertPath);
+    }
+    return isTrustedLinux;
   } else if (process.platform === "win32") {
     return isCATrustedWindows(caCertPath);
   }
@@ -457,11 +473,7 @@ export function isCATrusted(stateDir: string): boolean {
 
 function isCATrustedWindows(caCertPath: string): boolean {
   try {
-    const fingerprint = openssl(["x509", "-in", caCertPath, "-noout", "-fingerprint", "-sha1"])
-      .trim()
-      .replace(/^.*=/, "")
-      .replace(/:/g, "")
-      .toLowerCase();
+    const fingerprint = getCertFingerprint(caCertPath);
     const result = execFileSync("certutil", ["-store", "-user", "Root"], {
       encoding: "utf-8",
       timeout: 10_000,
@@ -470,6 +482,84 @@ function isCATrustedWindows(caCertPath: string): boolean {
     return result.replace(/\s/g, "").toLowerCase().includes(fingerprint);
   } catch {
     return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Windows CA trust operations from WSL
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if the CA is trusted in the Windows certificate store from WSL.
+ * Uses PowerShell interop to query Cert:\CurrentUser\Root.
+ */
+function isCATrustedWindowsFromWSL(caCertPath: string): boolean {
+  try {
+    const fingerprint = getCertFingerprint(caCertPath);
+
+    const result = runPowerShellFromWSL([
+      "-NoProfile",
+      "-Command",
+      `(Get-ChildItem -Path Cert:\\CurrentUser\\Root | Where-Object { $_.Thumbprint -eq '${fingerprint}' }).Thumbprint`,
+    ]);
+
+    return result.replace(/\s/g, "").toLowerCase().includes(fingerprint);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Install the CA in the Windows trust store from WSL via PowerShell interop.
+ */
+function trustCAWindowsFromWSL(caCertPath: string): void {
+  const windowsPath = wslToWindowsPath(caCertPath);
+
+  runPowerShellFromWSL([
+    "-NoProfile",
+    "-Command",
+    `certutil -addstore -user Root "${windowsPath}"`,
+  ]);
+}
+
+/**
+ * Remove the CA from the Windows trust store from WSL via PowerShell interop.
+ */
+function untrustCAWindowsFromWSL(caCertPath: string): {
+  removed: boolean;
+  error?: string;
+} {
+  try {
+    const fingerprint = getCertFingerprint(caCertPath);
+
+    // Check if the cert is in the Windows store
+    const checkResult = runPowerShellFromWSL([
+      "-NoProfile",
+      "-Command",
+      `(Get-ChildItem -Path Cert:\\CurrentUser\\Root | Where-Object { $_.Thumbprint -eq '${fingerprint}' }).Thumbprint`,
+    ]);
+
+    if (!checkResult.replace(/\s/g, "").toLowerCase().includes(fingerprint)) {
+      return { removed: true };
+    }
+
+    // Remove it
+    runPowerShellFromWSL([
+      "-NoProfile",
+      "-Command",
+      `certutil -delstore -user Root "portless Local CA"`,
+    ]);
+
+    // Verify removal
+    if (isCATrustedWindowsFromWSL(caCertPath)) {
+      return {
+        removed: false,
+        error: "Could not remove the portless CA from Windows trust store",
+      };
+    }
+    return { removed: true };
+  } catch (err: unknown) {
+    return { removed: false, error: err instanceof Error ? err.message : String(err) };
   }
 }
 
@@ -852,7 +942,9 @@ export function createSNICallback(
  *
  * Supported Linux distros: Debian/Ubuntu, Arch, Fedora/RHEL/CentOS, openSUSE.
  */
-export function trustCA(stateDir: string): { trusted: boolean; error?: string } {
+export type TrustCAResult = { trusted: boolean; error?: string; warning?: string };
+
+export function trustCA(stateDir: string): TrustCAResult {
   const caCertPath = path.join(stateDir, CA_CERT_FILE);
   if (!fileExists(caCertPath)) {
     return {
@@ -896,8 +988,25 @@ export function trustCA(stateDir: string): { trusted: boolean; error?: string } 
       const dest = path.join(config.certDir, "portless-ca.crt");
       fs.copyFileSync(caCertPath, dest);
       execFileSync(config.updateCommand, [], { stdio: "pipe", timeout: 30_000 });
+
+      let warning: string | undefined;
+
+      // On WSL, also install the CA in the Windows trust store so that
+      // browsers running on the Windows host can verify portless certs.
+      if (isWSL()) {
+        try {
+          trustCAWindowsFromWSL(caCertPath);
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          warning =
+            "Could not add CA to the Windows trust store from WSL. " +
+            "Windows browsers may still show certificate warnings." +
+            (message ? ` ${message}` : "");
+        }
+      }
+
       writeTrustMarker(stateDir);
-      return { trusted: true };
+      return warning ? { trusted: true, warning } : { trusted: true };
     } else if (process.platform === "win32") {
       execFileSync("certutil", ["-addstore", "-user", "Root", caCertPath], {
         stdio: "pipe",
@@ -955,6 +1064,12 @@ export function untrustCA(stateDir: string): { removed: boolean; error?: string 
       result = untrustCAMacOS(caCertPath);
     } else if (process.platform === "linux") {
       result = untrustCALinux(stateDir);
+      if (isWSL()) {
+        const winResult = untrustCAWindowsFromWSL(caCertPath);
+        if (!winResult.removed) {
+          result = winResult;
+        }
+      }
     } else if (process.platform === "win32") {
       result = untrustCAWindows(caCertPath);
     } else {

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -5,7 +5,7 @@ import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as readline from "node:readline";
-import { execSync, spawn } from "node:child_process";
+import { execFileSync, execSync, spawn } from "node:child_process";
 import { PORTLESS_HEADER } from "./proxy.js";
 
 // ---------------------------------------------------------------------------
@@ -41,8 +41,36 @@ export const LEGACY_SYSTEM_STATE_DIR = isWindows
   ? path.join(os.tmpdir(), "portless")
   : "/tmp/portless";
 
+/**
+ * Resolve the home directory for state storage. When running under sudo,
+ * uses the original user's home directory (via SUDO_USER) so the proxy
+ * and child processes share the same state directory.
+ */
+function resolveStateHomeDir(): string {
+  const sudoer = process.env.SUDO_USER;
+  const validUsername = /^[a-zA-Z0-9._-]+$/;
+
+  if (sudoer && process.platform !== "win32" && validUsername.test(sudoer)) {
+    try {
+      // Use execFileSync with an array to avoid shell interpolation.
+      const out = execFileSync("getent", ["passwd", sudoer], {
+        encoding: "utf-8",
+      });
+      const parts = out.trim().split(":");
+
+      if (parts.length >= 5 && parts[0] === sudoer) {
+        return parts[5];
+      }
+    } catch {
+      // Fall through to os.homedir() if getent fails
+    }
+  }
+
+  return os.homedir();
+}
+
 /** Per-user state directory. All proxy state lives here regardless of port. */
-export const USER_STATE_DIR = path.join(os.homedir(), ".portless");
+export const USER_STATE_DIR = path.join(resolveStateHomeDir(), ".portless");
 
 /** Minimum app port when finding a free port. */
 const MIN_APP_PORT = 4000;

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1776,6 +1776,9 @@ async function handleTrust(): Promise<void> {
   if (result.trusted) {
     console.log(colors.green("Local CA added to system trust store."));
     console.log(colors.gray("Browsers will now trust portless HTTPS certificates."));
+    if (result.warning) {
+      console.warn(colors.yellow(result.warning));
+    }
     return;
   }
 
@@ -3060,6 +3063,9 @@ ${colors.bold("LAN mode (--lan):")}
           console.log(
             colors.green("CA added to system trust store. Browsers will trust portless certs.")
           );
+          if (trustResult.warning) {
+            console.warn(colors.yellow(trustResult.warning));
+          }
         } else {
           console.warn(colors.yellow("Could not add CA to system trust store."));
           if (trustResult.error) {

--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -50,6 +50,16 @@ function listen(server: AnyServer): Promise<void> {
   });
 }
 
+async function getUnusedPort(): Promise<number> {
+  const server = http.createServer();
+  await listen(server);
+  const addr = server.address();
+  if (!addr || typeof addr === "string") throw new Error("no addr");
+  const { port } = addr;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  return port;
+}
+
 describe("createProxyServer", () => {
   const servers: AnyServer[] = [];
 
@@ -371,7 +381,7 @@ describe("createProxyServer", () => {
   describe("error handling", () => {
     it("returns 502 when backend is not running", async () => {
       const errors: string[] = [];
-      const routes: RouteInfo[] = [{ hostname: "dead.localhost", port: 59999 }];
+      const routes: RouteInfo[] = [{ hostname: "dead.localhost", port: await getUnusedPort() }];
       const server = trackServer(
         createProxyServer({
           getRoutes: () => routes,

--- a/packages/portless/src/wsl-utils.test.ts
+++ b/packages/portless/src/wsl-utils.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+}));
+
+import { execFileSync } from "node:child_process";
+import { isWSL, wslToWindowsPath, runPowerShellFromWSL, getPowerShellPath } from "./wsl-utils.js";
+
+const mockExecFileSync = vi.mocked(execFileSync);
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("isWSL", () => {
+  it("returns true when wslinfo succeeds", () => {
+    mockExecFileSync.mockReturnValue(Buffer.from(""));
+    expect(isWSL()).toBe(true);
+  });
+
+  it("returns false when wslinfo is not available", () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    expect(isWSL()).toBe(false);
+  });
+});
+
+describe("wslToWindowsPath", () => {
+  it("converts a WSL path to a Windows path via wslpath", () => {
+    mockExecFileSync.mockReturnValue("\\\\wsl.localhost\\home\\user\\.portless\\ca.pem\n");
+    const result = wslToWindowsPath("/home/user/.portless/ca.pem");
+    expect(result).toMatch(/^\\\\wsl[.$]/);
+    expect(result).toContain("\\home\\user\\.portless\\ca.pem");
+  });
+
+  it("throws when wslpath fails", () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("wslpath not found");
+    });
+    expect(() => wslToWindowsPath("/home/user/file")).toThrow();
+  });
+});
+
+describe("runPowerShellFromWSL", () => {
+  it("executes a PowerShell command and returns stdout", () => {
+    mockExecFileSync
+      .mockReturnValueOnce(Buffer.from("")) // getPowerShellPath calls execFileSync("test", ...)
+      .mockReturnValueOnce("hello\n"); // actual powershell.exe call
+    const result = runPowerShellFromWSL(["-NoProfile", "-Command", "Write-Output hello"]);
+    expect(result.trim()).toBe("hello");
+  });
+
+  it("does not throw when interop is enabled", () => {
+    mockExecFileSync
+      .mockReturnValueOnce(Buffer.from("")) // getPowerShellPath succeeds
+      .mockReturnValueOnce(""); // powershell returns nothing
+    expect(() => runPowerShellFromWSL(["-NoProfile", "-Command", "exit 0"])).not.toThrow();
+  });
+
+  it("throws when getPowerShellPath fails", () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    expect(() => runPowerShellFromWSL(["-NoProfile", "-Command", "Write-Output hello"])).toThrow(
+      "PowerShell executable not found"
+    );
+  });
+
+  it("throws when PowerShell command fails", () => {
+    mockExecFileSync
+      .mockReturnValueOnce(Buffer.from("")) // getPowerShellPath succeeds
+      .mockImplementationOnce(() => {
+        throw new Error("command failed");
+      });
+    expect(() => runPowerShellFromWSL(["-NoProfile", "-Command", "exit 1"])).toThrow(
+      "command failed"
+    );
+  });
+});
+
+describe("getPowerShellPath", () => {
+  it("returns the PowerShell path when interop is enabled", () => {
+    mockExecFileSync.mockReturnValue(Buffer.from(""));
+    expect(getPowerShellPath()).toBe(
+      "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+    );
+  });
+
+  it("throws when interop is disabled", () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    expect(() => getPowerShellPath()).toThrow("PowerShell executable not found");
+  });
+});

--- a/packages/portless/src/wsl-utils.ts
+++ b/packages/portless/src/wsl-utils.ts
@@ -1,0 +1,65 @@
+import { execFileSync } from "node:child_process";
+
+// ---------------------------------------------------------------------------
+// WSL detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect whether we are running inside WSL (Windows Subsystem for Linux).
+ * Checks for the presence of the `wslinfo` binary and verifies it can be executed.
+ */
+export function isWSL(): boolean {
+  try {
+    execFileSync("wslinfo", ["--version"], {
+      stdio: "pipe",
+      timeout: 5_000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PowerShell interop
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the path to powershell.exe.
+ * Throws if the binary is not found (WSL interop may be disabled).
+ */
+export function getPowerShellPath(): string {
+  const psPath = "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe";
+  try {
+    execFileSync("test", ["-f", psPath], { timeout: 5_000 });
+    return psPath;
+  } catch {
+    throw new Error("PowerShell executable not found. Ensure interop is enabled in WSL config.");
+  }
+}
+
+/**
+ * Run a PowerShell command from WSL via interop and return stdout.
+ */
+export function runPowerShellFromWSL(args: string[], options?: { timeout?: number }): string {
+  const psPath = getPowerShellPath();
+  return execFileSync(psPath, args, {
+    encoding: "utf-8",
+    timeout: options?.timeout ?? 30_000,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Path conversion
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a WSL path to a Windows path using the `wslpath` utility.
+ */
+export function wslToWindowsPath(wslPath: string): string {
+  return execFileSync("wslpath", ["-w", wslPath], {
+    encoding: "utf-8",
+    timeout: 5_000,
+  }).trim();
+}

--- a/packages/portless/tsconfig.json
+++ b/packages/portless/tsconfig.json
@@ -9,7 +9,8 @@
     "outDir": "dist",
     "rootDir": "src",
     "declaration": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Problem

When portless runs under `sudo`, `os.homedir()` resolves to `/root`, so the proxy reads state from `/root/.portless` while child apps write route registrations under the original user's home directory. This leaves the proxy unable to see app registrations.

On WSL, Windows-side browsers read certificates from the Windows certificate store, not WSL's Linux trust store, so trusting the portless CA only in Linux still leaves HTTPS verification broken from the host browser.

## Solution

Resolve the state directory from the original sudo user with `SUDO_USER` and `getent passwd`, falling back to `/home/$SUDO_USER`.

Detect WSL and use PowerShell interop with `wslpath`-converted certificate paths to add, check, and remove the CA in the Windows user root store.

## Testing

Added WSL utility tests for detection, PowerShell interop, and path conversion.

Fixes #283.
