### PR TITLE
Add OS startup service support

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ portless service status
 portless service uninstall
 ```
 
-The service uses portless defaults: HTTPS on port 443 with `.localhost` names. macOS and Linux install a root-owned service so port 443 can bind at boot. Windows installs a Task Scheduler startup task that runs as SYSTEM. Installation and removal may require administrator privileges.
+The service uses portless defaults: HTTPS on port 443 with `.localhost` names. macOS and Linux install a root-owned service so port 443 can bind at boot. Windows installs a Task Scheduler startup task that runs as SYSTEM. Installation and removal may require administrator privileges. `portless clean` automatically removes the service.
 
 ## LAN mode
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,18 @@ portless trust
 
 On Linux, `portless trust` supports Debian/Ubuntu, Arch, Fedora/RHEL/CentOS, and openSUSE (via `update-ca-certificates` or `update-ca-trust`). On Windows, it uses `certutil` to add the CA to the system trust store.
 
+## Start at OS startup
+
+Install the proxy as an OS startup service so clean HTTPS URLs are available after reboot without starting the proxy from a terminal:
+
+```bash
+portless service install
+portless service status
+portless service uninstall
+```
+
+The service uses portless defaults: HTTPS on port 443 with `.localhost` names. macOS and Linux install a root-owned service so port 443 can bind at boot. Windows installs a Task Scheduler startup task that runs as SYSTEM. Installation and removal may require administrator privileges.
+
 ## LAN mode
 
 ```bash
@@ -334,6 +346,11 @@ portless proxy start -p 1355     # Start on a custom port (no sudo)
 portless proxy start --foreground  # Start in foreground (for debugging)
 portless proxy start --wildcard  # Allow unregistered subdomains to fall back to parent
 portless proxy stop              # Stop the proxy
+
+# OS startup service
+portless service install         # Start HTTPS proxy when the OS starts
+portless service status          # Show service and proxy status
+portless service uninstall       # Remove the startup service
 ```
 
 ### Options
@@ -380,7 +397,7 @@ PORTLESS_TAILSCALE_URL           Tailscale URL of the app (when --tailscale is a
 NODE_EXTRA_CA_CERTS              Path to the portless CA (when HTTPS is active)
 ```
 
-> **Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `trust`, `clean`, `prune`, and `proxy` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name from your project, or `portless --name <name> <cmd>` to force any name including reserved ones.
+> **Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `trust`, `clean`, `prune`, `proxy`, and `service` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name from your project, or `portless --name <name> <cmd>` to force any name including reserved ones.
 
 ## Uninstall / reset
 

--- a/apps/docs/src/app/commands/page.mdx
+++ b/apps/docs/src/app/commands/page.mdx
@@ -187,6 +187,16 @@ portless proxy start
 portless proxy stop
 ```
 
+## OS startup service
+
+```bash
+portless service install
+portless service status
+portless service uninstall
+```
+
+Installs the proxy as an OS startup service using the default clean URL behavior: HTTPS on port 443 with `.localhost` names. macOS and Linux use a root-owned service so port 443 can bind at boot. Windows uses a Task Scheduler startup task that runs as SYSTEM. Installation and removal may require administrator privileges.
+
 ### LAN mode
 
 Access services from phones and other devices on the same WiFi via mDNS (`.local` domains):

--- a/apps/docs/src/app/commands/page.mdx
+++ b/apps/docs/src/app/commands/page.mdx
@@ -195,7 +195,7 @@ portless service status
 portless service uninstall
 ```
 
-Installs the proxy as an OS startup service using the default clean URL behavior: HTTPS on port 443 with `.localhost` names. macOS and Linux use a root-owned service so port 443 can bind at boot. Windows uses a Task Scheduler startup task that runs as SYSTEM. Installation and removal may require administrator privileges.
+Installs the proxy as an OS startup service using the default clean URL behavior: HTTPS on port 443 with `.localhost` names. macOS and Linux use a root-owned service so port 443 can bind at boot. Windows uses a Task Scheduler startup task that runs as SYSTEM. Installation and removal may require administrator privileges. `portless clean` automatically removes the service.
 
 ### LAN mode
 

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -99,6 +99,7 @@ describe("CLI", () => {
       expect(stdout).toContain("Usage:");
       expect(stdout).toContain("Examples:");
       expect(stdout).toContain("proxy start");
+      expect(stdout).toContain("service install");
       expect(stdout).toContain("portless run");
       expect(stdout).toContain("portless get");
       expect(stdout).toContain("run [--name <name>]");
@@ -166,6 +167,26 @@ describe("CLI", () => {
       const { status, stdout } = run(["proxy", "unknown"]);
       expect(status).toBe(1);
       expect(stdout).toContain("proxy start");
+    });
+  });
+
+  describe("service", () => {
+    it("prints service help", () => {
+      const { status, stdout } = run(["service", "--help"]);
+      expect(status).toBe(0);
+      expect(stdout).toContain("portless service");
+      expect(stdout).toContain("service install");
+      expect(stdout).toContain("service uninstall");
+      expect(stdout).toContain("service status");
+    });
+
+    it("still dispatches service help when PORTLESS=0", () => {
+      const { status, stdout } = run(["service", "--help"], {
+        env: { PORTLESS: "0" },
+      });
+      expect(status).toBe(0);
+      expect(stdout).toContain("portless service");
+      expect(stdout).toContain("service install");
     });
   });
 

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -95,7 +95,7 @@ import {
   hasTurboConfig,
 } from "./turbo.js";
 import type { ManifestEntry } from "./turbo.js";
-import { handleService, tryUninstallService } from "./service.js";
+import { buildServiceUninstallSudoArgs, handleService, tryUninstallService } from "./service.js";
 
 const chalk = colors;
 
@@ -377,14 +377,31 @@ function sudoStop(port: number): boolean {
 
 function runCleanWithSudo(reason: string): boolean {
   console.log(colors.yellow(`${reason} Requesting sudo...`));
+  const home = process.env.HOME;
   const result = spawnSync(
     "sudo",
-    ["env", ...collectPortlessEnvArgs(), process.execPath, getEntryScript(), "clean"],
+    [
+      "env",
+      ...collectPortlessEnvArgs(),
+      ...(home ? [`HOME=${home}`] : []),
+      process.execPath,
+      getEntryScript(),
+      "clean",
+    ],
     {
       stdio: "inherit",
       timeout: SUDO_SPAWN_TIMEOUT_MS,
     }
   );
+  return result.status === 0;
+}
+
+function runServiceUninstallWithSudo(reason: string): boolean {
+  console.log(colors.yellow(`${reason} Requesting sudo...`));
+  const result = spawnSync("sudo", buildServiceUninstallSudoArgs(getEntryScript()), {
+    stdio: "inherit",
+    timeout: SUDO_SPAWN_TIMEOUT_MS,
+  });
   return result.status === 0;
 }
 
@@ -1664,11 +1681,12 @@ ${colors.bold("Options:")}
   if (serviceResult.removed) {
     console.log(colors.green("Removed startup service."));
   } else if (serviceResult.needsElevation && !isWindows && (process.getuid?.() ?? -1) !== 0) {
-    if (!runCleanWithSudo("Removing the startup service requires elevated privileges.")) {
+    if (
+      !runServiceUninstallWithSudo("Removing the startup service requires elevated privileges.")
+    ) {
       console.error(colors.red("Failed to remove startup service with sudo."));
       process.exit(1);
     }
-    return;
   } else if (serviceResult.error) {
     const adminHint = isWindows ? " Run as Administrator and try again." : "";
     const message = `Could not remove startup service: ${serviceResult.error}${adminHint}`;

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -375,6 +375,19 @@ function sudoStop(port: number): boolean {
   return result.status === 0;
 }
 
+function runCleanWithSudo(reason: string): boolean {
+  console.log(colors.yellow(`${reason} Requesting sudo...`));
+  const result = spawnSync(
+    "sudo",
+    ["env", ...collectPortlessEnvArgs(), process.execPath, getEntryScript(), "clean"],
+    {
+      stdio: "inherit",
+      timeout: SUDO_SPAWN_TIMEOUT_MS,
+    }
+  );
+  return result.status === 0;
+}
+
 // ---------------------------------------------------------------------------
 // Proxy server lifecycle
 // ---------------------------------------------------------------------------
@@ -1647,19 +1660,31 @@ ${colors.bold("Options:")}
     process.exit(1);
   }
 
+  const serviceResult = tryUninstallService(getEntryScript());
+  if (serviceResult.removed) {
+    console.log(colors.green("Removed startup service."));
+  } else if (serviceResult.needsElevation && !isWindows && (process.getuid?.() ?? -1) !== 0) {
+    if (!runCleanWithSudo("Removing the startup service requires elevated privileges.")) {
+      console.error(colors.red("Failed to remove startup service with sudo."));
+      process.exit(1);
+    }
+    return;
+  } else if (serviceResult.error) {
+    const adminHint = isWindows ? " Run as Administrator and try again." : "";
+    const message = `Could not remove startup service: ${serviceResult.error}${adminHint}`;
+    if (serviceResult.installed) {
+      console.error(colors.red(message));
+      process.exit(1);
+    }
+    console.warn(colors.yellow(message));
+  }
+
   console.log(colors.cyan("Stopping proxy if it is running..."));
   const { dir, port, tls } = await discoverState();
   const store = new RouteStore(dir, {
     onWarning: (msg) => console.warn(colors.yellow(msg)),
   });
   await stopProxy(store, port, tls);
-
-  const serviceResult = tryUninstallService(getEntryScript());
-  if (serviceResult.removed) {
-    console.log(colors.green("Removed startup service."));
-  } else if (serviceResult.error) {
-    console.warn(colors.yellow(`Could not remove startup service: ${serviceResult.error}`));
-  }
 
   // Clean up any tailscale serve/funnel registrations tied to stale routes
   const routesForClean = store.loadRoutesRaw();
@@ -1701,18 +1726,7 @@ ${colors.bold("Options:")}
   if (cleanHostsFile()) {
     console.log(colors.green(`Removed portless entries from ${HOSTS_DISPLAY}.`));
   } else if (!isWindows && process.getuid?.() !== 0) {
-    console.log(
-      colors.yellow(`Updating ${HOSTS_DISPLAY} requires elevated privileges. Requesting sudo...`)
-    );
-    const result = spawnSync(
-      "sudo",
-      ["env", ...collectPortlessEnvArgs(), process.execPath, getEntryScript(), "clean"],
-      {
-        stdio: "inherit",
-        timeout: SUDO_SPAWN_TIMEOUT_MS,
-      }
-    );
-    if (result.status !== 0) {
+    if (!runCleanWithSudo(`Updating ${HOSTS_DISPLAY} requires elevated privileges.`)) {
       console.error(colors.red(`Failed to update ${HOSTS_DISPLAY}. Run: sudo portless clean`));
       process.exit(1);
     }

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -95,6 +95,7 @@ import {
   hasTurboConfig,
 } from "./turbo.js";
 import type { ManifestEntry } from "./turbo.js";
+import { handleService } from "./service.js";
 
 const chalk = colors;
 
@@ -1418,6 +1419,7 @@ ${colors.bold("Usage:")}
   ${colors.cyan("portless <name> <cmd>")}            Run with an explicit app name
   ${colors.cyan("portless proxy start")}             Start the proxy (HTTPS on port 443, daemon)
   ${colors.cyan("portless proxy stop")}              Stop the proxy
+  ${colors.cyan("portless service install")}         Start proxy automatically when the OS starts
   ${colors.cyan("portless get <name>")}              Print URL for a service (for cross-service refs)
   ${colors.cyan("portless alias <name> <port>")}     Register a static route (e.g. for Docker)
   ${colors.cyan("portless alias --remove <name>")}   Remove a static route
@@ -1435,6 +1437,7 @@ ${colors.bold("Examples:")}
   portless myapp next dev             # -> https://myapp.localhost
   portless run next dev               # -> https://<project>.localhost
   portless run next dev               # in worktree -> https://<worktree>.<project>.localhost
+  portless service install            # Start HTTPS proxy on OS startup
   portless get backend                # -> https://backend.localhost
   portless myapp --tailscale next dev # -> also https://<node>.ts.net (tailnet)
   portless myapp --funnel next dev    # -> also https://<node>.ts.net (public)
@@ -1555,7 +1558,7 @@ ${colors.bold("Skip portless:")}
   PORTLESS=0 pnpm dev           # Runs command directly without proxy
 
 ${colors.bold("Reserved names:")}
-  run, get, alias, hosts, list, trust, clean, prune, proxy are subcommands and
+  run, get, alias, hosts, list, trust, clean, prune, proxy, service are subcommands and
   cannot be used as app names directly. Use "portless run" to infer the name,
   or "portless --name <name>" to force any name including reserved ones.
 `);
@@ -3411,7 +3414,7 @@ async function main() {
 
   // --name flag: treat the next arg as an explicit app name, bypassing
   // subcommand dispatch. Useful when the app name collides with a reserved
-  // subcommand (run, alias, hosts, list, trust, clean, prune, proxy).
+  // subcommand (run, alias, hosts, list, trust, clean, prune, proxy, service).
   if (args[0] === "--name") {
     args.shift();
     if (!args[0]) {
@@ -3450,7 +3453,7 @@ async function main() {
     skipPortless &&
     (isRunCommand ||
       args.length === 0 ||
-      (args.length >= 2 && args[0] !== "proxy" && args[0] !== "clean"))
+      (args.length >= 2 && args[0] !== "proxy" && args[0] !== "clean" && args[0] !== "service"))
   ) {
     const parsed = isRunCommand ? parseRunArgs(args) : parseAppArgs(args);
     let commandArgs = parsed.commandArgs;
@@ -3468,7 +3471,7 @@ async function main() {
     return;
   }
 
-  // Global dispatch: help, version, trust, clean, prune, list, alias, hosts, proxy
+  // Global dispatch: help, version, trust, clean, prune, list, alias, hosts, proxy, service
   // When `run` is used, skip these so args like "list" or "--help" are treated
   // as child-command tokens, not portless subcommands.
   if (!isRunCommand) {
@@ -3517,6 +3520,10 @@ async function main() {
     }
     if (args[0] === "proxy") {
       await handleProxy(args);
+      return;
+    }
+    if (args[0] === "service") {
+      await handleService(args, { entryScript: getEntryScript() });
       return;
     }
   }

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -95,7 +95,7 @@ import {
   hasTurboConfig,
 } from "./turbo.js";
 import type { ManifestEntry } from "./turbo.js";
-import { handleService } from "./service.js";
+import { handleService, tryUninstallService } from "./service.js";
 
 const chalk = colors;
 
@@ -1620,10 +1620,11 @@ async function handleClean(args: string[]): Promise<void> {
     console.log(`
 ${colors.bold("portless clean")} - Remove portless artifacts from this machine.
 
-Stops the proxy if it is running, removes the local CA from the OS trust store
-when it was installed by portless, deletes known files under state directories
-(~/.portless, the system state directory, and PORTLESS_STATE_DIR when set),
-and removes the portless block from ${HOSTS_DISPLAY}.
+Stops the proxy if it is running, uninstalls the startup service if installed,
+removes the local CA from the OS trust store when it was installed by portless,
+deletes known files under state directories (~/.portless, the system state
+directory, and PORTLESS_STATE_DIR when set), and removes the portless block
+from ${HOSTS_DISPLAY}.
 
 Only allowlisted filenames under each state directory are deleted. Custom
 certificate paths from --cert and --key are never removed.
@@ -1652,6 +1653,13 @@ ${colors.bold("Options:")}
     onWarning: (msg) => console.warn(colors.yellow(msg)),
   });
   await stopProxy(store, port, tls);
+
+  const serviceResult = tryUninstallService(getEntryScript());
+  if (serviceResult.removed) {
+    console.log(colors.green("Removed startup service."));
+  } else if (serviceResult.error) {
+    console.warn(colors.yellow(`Could not remove startup service: ${serviceResult.error}`));
+  }
 
   // Clean up any tailscale serve/funnel registrations tied to stale routes
   const routesForClean = store.loadRoutesRaw();

--- a/packages/portless/src/service.test.ts
+++ b/packages/portless/src/service.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { buildServiceSpec } from "./service.js";
+
+describe("buildServiceSpec", () => {
+  it("builds a macOS LaunchDaemon for the HTTPS proxy", () => {
+    const spec = buildServiceSpec({
+      platform: "darwin",
+      nodePath: "/usr/local/bin/node",
+      entryScript: "/usr/local/lib/node_modules/portless/dist/cli.js",
+      userHome: "/Users/alice",
+      uid: "501",
+      gid: "20",
+    });
+
+    expect(spec.platform).toBe("darwin");
+    if (spec.platform !== "darwin") throw new Error("Expected macOS service spec");
+    expect(spec.plistPath).toBe("/Library/LaunchDaemons/sh.portless.proxy.plist");
+    expect(spec.programArguments).toEqual([
+      "/usr/local/bin/node",
+      "/usr/local/lib/node_modules/portless/dist/cli.js",
+      "proxy",
+      "start",
+      "--foreground",
+      "--port",
+      "443",
+      "--https",
+      "--skip-trust",
+    ]);
+    expect(spec.plist).toContain("<key>RunAtLoad</key>");
+    expect(spec.plist).toContain("<key>KeepAlive</key>");
+    expect(spec.plist).toContain("<key>PORTLESS_STATE_DIR</key>");
+    expect(spec.plist).toContain("<string>/Users/alice/.portless</string>");
+    expect(spec.plist).toContain("<key>SUDO_UID</key>");
+    expect(spec.plist).toContain("<string>501</string>");
+  });
+
+  it("builds a Linux systemd unit for the HTTPS proxy", () => {
+    const spec = buildServiceSpec({
+      platform: "linux",
+      nodePath: "/usr/bin/node",
+      entryScript: "/usr/lib/node_modules/portless/dist/cli.js",
+      userHome: "/home/alice",
+      uid: "1000",
+      gid: "1000",
+    });
+
+    expect(spec.platform).toBe("linux");
+    if (spec.platform !== "linux") throw new Error("Expected Linux service spec");
+    expect(spec.unitPath).toBe("/etc/systemd/system/portless.service");
+    expect(spec.execStart).toEqual([
+      "/usr/bin/node",
+      "/usr/lib/node_modules/portless/dist/cli.js",
+      "proxy",
+      "start",
+      "--foreground",
+      "--port",
+      "443",
+      "--https",
+      "--skip-trust",
+    ]);
+    expect(spec.unit).toContain("Description=Portless HTTPS proxy");
+    expect(spec.unit).toContain('Environment=PORTLESS_STATE_DIR="/home/alice/.portless"');
+    expect(spec.unit).toContain('Environment=SUDO_UID="1000"');
+    expect(spec.unit).toContain(
+      'ExecStart="/usr/bin/node" "/usr/lib/node_modules/portless/dist/cli.js" "proxy" "start" "--foreground" "--port" "443" "--https" "--skip-trust"'
+    );
+    expect(spec.unit).toContain("WantedBy=multi-user.target");
+  });
+
+  it("builds a Windows startup task for the HTTPS proxy", () => {
+    const spec = buildServiceSpec({
+      platform: "win32",
+      nodePath: "C:\\Program Files\\nodejs\\node.exe",
+      entryScript: "C:\\Users\\Alice\\AppData\\Roaming\\npm\\node_modules\\portless\\dist\\cli.js",
+      userHome: "C:\\Users\\Alice",
+    });
+
+    expect(spec.platform).toBe("win32");
+    if (spec.platform !== "win32") throw new Error("Expected Windows service spec");
+    expect(spec.taskName).toBe("Portless Proxy");
+    expect(spec.createArgs).toContain("/SC");
+    expect(spec.createArgs).toContain("ONSTART");
+    expect(spec.createArgs).toContain("/RU");
+    expect(spec.createArgs).toContain("SYSTEM");
+    expect(spec.scriptPath).toBe("C:\\ProgramData\\portless\\service\\portless-service.cmd");
+    expect(spec.taskRun).toBe('"C:\\ProgramData\\portless\\service\\portless-service.cmd"');
+    expect(spec.script).toContain("PORTLESS_STATE_DIR=C:\\Users\\Alice\\.portless");
+    expect(spec.script).toContain('"C:\\Program Files\\nodejs\\node.exe"');
+    expect(spec.script).toContain("proxy");
+    expect(spec.script).toContain("--port");
+    expect(spec.script).toContain("443");
+    expect(spec.script).toContain("--https");
+    expect(spec.script).toContain("--skip-trust");
+  });
+});

--- a/packages/portless/src/service.test.ts
+++ b/packages/portless/src/service.test.ts
@@ -130,8 +130,8 @@ describe("buildServiceSpec", () => {
 });
 
 describe("tryUninstallService", () => {
-  it("returns removed: false when service is not installed (darwin)", () => {
-    const runner = () => ({ status: 0, stdout: "", stderr: "" });
+  it("returns removed: false when service is not installed", () => {
+    const runner = () => ({ status: 1, stdout: "", stderr: "" });
     const result = tryUninstallService("/fake/cli.js", runner);
     expect(result.removed).toBe(false);
   });

--- a/packages/portless/src/service.test.ts
+++ b/packages/portless/src/service.test.ts
@@ -3,10 +3,62 @@ import { buildServiceSpec, handleService, tryUninstallService } from "./service.
 
 vi.mock("node:fs", async (importOriginal) => {
   const mod = await importOriginal<typeof import("node:fs")>();
-  return { ...mod, existsSync: vi.fn(mod.existsSync) };
+  return {
+    ...mod,
+    chmodSync: vi.fn(),
+    existsSync: vi.fn(mod.existsSync),
+    mkdirSync: vi.fn(),
+    rmSync: vi.fn(),
+    writeFileSync: vi.fn(),
+  };
 });
 
-const { existsSync } = await import("node:fs");
+vi.mock("./certs.js", () => ({
+  ensureCerts: vi.fn(() => ({
+    certPath: "/fake/server.pem",
+    keyPath: "/fake/server-key.pem",
+    caPath: "/fake/ca.pem",
+    caGenerated: false,
+  })),
+  isCATrusted: vi.fn(() => true),
+  trustCA: vi.fn(() => ({ trusted: true })),
+}));
+
+vi.mock("./utils.js", () => ({
+  fixOwnership: vi.fn(),
+}));
+
+const { existsSync, rmSync } = await import("node:fs");
+
+const originalPlatform = process.platform;
+const originalGetuid = process.getuid;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: platform,
+  });
+}
+
+function setGetuid(uid: number): void {
+  Object.defineProperty(process, "getuid", {
+    configurable: true,
+    value: () => uid,
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: originalPlatform,
+  });
+  Object.defineProperty(process, "getuid", {
+    configurable: true,
+    value: originalGetuid,
+  });
+  vi.mocked(existsSync).mockRestore();
+  vi.mocked(rmSync).mockRestore();
+});
 
 describe("buildServiceSpec", () => {
   it("builds a macOS LaunchDaemon for the HTTPS proxy", () => {
@@ -131,9 +183,11 @@ describe("buildServiceSpec", () => {
 
 describe("tryUninstallService", () => {
   it("returns removed: false when service is not installed", () => {
+    vi.mocked(existsSync).mockReturnValue(false);
     const runner = () => ({ status: 1, stdout: "", stderr: "" });
     const result = tryUninstallService("/fake/cli.js", runner);
     expect(result.removed).toBe(false);
+    expect(result.installed).toBe(false);
   });
 
   it("returns removed: false when runner throws", () => {
@@ -144,7 +198,25 @@ describe("tryUninstallService", () => {
     const result = tryUninstallService("/fake/cli.js", runner);
     vi.mocked(existsSync).mockRestore();
     expect(result.removed).toBe(false);
+    expect(result.installed).toBe(true);
     expect(result.error).toContain("spawn failed");
+  });
+
+  it("marks installed services that need elevation", () => {
+    setPlatform("linux");
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(rmSync).mockImplementation(() => {
+      const err = new Error("EACCES: permission denied") as NodeJS.ErrnoException;
+      err.code = "EACCES";
+      throw err;
+    });
+    const runner = vi.fn(() => ({ status: 0, stdout: "", stderr: "" }));
+
+    const result = tryUninstallService("/fake/cli.js", runner);
+
+    expect(result.removed).toBe(false);
+    expect(result.installed).toBe(true);
+    expect(result.needsElevation).toBe(true);
   });
 });
 
@@ -196,5 +268,33 @@ describe("handleService", () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
     const output = errorSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
     expect(output).toContain("bogus");
+  });
+
+  it("stops an existing proxy before restarting the Linux service", async () => {
+    setPlatform("linux");
+    setGetuid(0);
+    const runner = vi.fn((_: string, _args: string[]) => ({
+      status: 0,
+      stdout: "",
+      stderr: "",
+    }));
+
+    await handleService(["service", "install"], {
+      entryScript: "/fake/cli.js",
+      runner,
+    });
+
+    const calls = runner.mock.calls.map(([command, args]) => ({ command, args }));
+    const stopIndex = calls.findIndex(
+      (call) =>
+        call.command === process.execPath &&
+        call.args.join(" ") === "/fake/cli.js proxy stop --port 443"
+    );
+    const restartIndex = calls.findIndex(
+      (call) => call.command === "systemctl" && call.args.join(" ") === "restart portless.service"
+    );
+
+    expect(stopIndex).toBeGreaterThanOrEqual(0);
+    expect(restartIndex).toBeGreaterThan(stopIndex);
   });
 });

--- a/packages/portless/src/service.test.ts
+++ b/packages/portless/src/service.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildServiceSpec } from "./service.js";
+import { buildServiceSpec, tryUninstallService } from "./service.js";
 
 describe("buildServiceSpec", () => {
   it("builds a macOS LaunchDaemon for the HTTPS proxy", () => {
@@ -91,5 +91,50 @@ describe("buildServiceSpec", () => {
     expect(spec.script).toContain("443");
     expect(spec.script).toContain("--https");
     expect(spec.script).toContain("--skip-trust");
+  });
+
+  it("escapes percent signs in Windows batch env values", () => {
+    const spec = buildServiceSpec({
+      platform: "win32",
+      nodePath: "C:\\nodejs\\node.exe",
+      entryScript: "C:\\cli.js",
+      userHome: "C:\\Users\\100%Done",
+    });
+
+    if (spec.platform !== "win32") throw new Error("Expected Windows service spec");
+    expect(spec.script).toContain("PORTLESS_STATE_DIR=C:\\Users\\100%%Done\\.portless");
+    expect(spec.script).not.toMatch(/(?<!%)%(?!%)/);
+  });
+
+  it("uses unconditional KeepAlive in the macOS plist", () => {
+    const spec = buildServiceSpec({
+      platform: "darwin",
+      nodePath: "/usr/local/bin/node",
+      entryScript: "/usr/local/lib/portless/cli.js",
+      userHome: "/Users/bob",
+      uid: "501",
+      gid: "20",
+    });
+
+    if (spec.platform !== "darwin") throw new Error("Expected macOS service spec");
+    expect(spec.plist).toContain("<key>KeepAlive</key>\n  <true/>");
+    expect(spec.plist).not.toContain("SuccessfulExit");
+  });
+});
+
+describe("tryUninstallService", () => {
+  it("returns removed: false when service is not installed (darwin)", () => {
+    const runner = () => ({ status: 0, stdout: "", stderr: "" });
+    const result = tryUninstallService("/fake/cli.js", runner);
+    expect(result.removed).toBe(false);
+  });
+
+  it("returns removed: false when runner throws", () => {
+    const runner = () => {
+      throw new Error("spawn failed");
+    };
+    const result = tryUninstallService("/fake/cli.js", runner);
+    expect(result.removed).toBe(false);
+    expect(result.error).toContain("spawn failed");
   });
 });

--- a/packages/portless/src/service.test.ts
+++ b/packages/portless/src/service.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildServiceSpec, handleService, tryUninstallService } from "./service.js";
 
+vi.mock("node:fs", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("node:fs")>();
+  return { ...mod, existsSync: vi.fn(mod.existsSync) };
+});
+
+const { existsSync } = await import("node:fs");
+
 describe("buildServiceSpec", () => {
   it("builds a macOS LaunchDaemon for the HTTPS proxy", () => {
     const spec = buildServiceSpec({
@@ -130,10 +137,12 @@ describe("tryUninstallService", () => {
   });
 
   it("returns removed: false when runner throws", () => {
+    vi.mocked(existsSync).mockReturnValue(true);
     const runner = () => {
       throw new Error("spawn failed");
     };
     const result = tryUninstallService("/fake/cli.js", runner);
+    vi.mocked(existsSync).mockRestore();
     expect(result.removed).toBe(false);
     expect(result.error).toContain("spawn failed");
   });

--- a/packages/portless/src/service.test.ts
+++ b/packages/portless/src/service.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { buildServiceSpec, handleService, tryUninstallService } from "./service.js";
+import {
+  buildServiceSpec,
+  buildServiceUninstallSudoArgs,
+  handleService,
+  tryUninstallService,
+} from "./service.js";
 
 vi.mock("node:fs", async (importOriginal) => {
   const mod = await importOriginal<typeof import("node:fs")>();
@@ -152,6 +157,21 @@ describe("buildServiceSpec", () => {
     expect(spec.script).toContain("--skip-trust");
   });
 
+  it("preserves PATH in the Windows startup script", () => {
+    const spec = buildServiceSpec({
+      platform: "win32",
+      nodePath: "C:\\nodejs\\node.exe",
+      entryScript: "C:\\cli.js",
+      userHome: "C:\\Users\\Alice",
+      pathEnv: "C:\\Program Files\\Git\\mingw64\\bin;C:\\Tools\\100%Done",
+    });
+
+    if (spec.platform !== "win32") throw new Error("Expected Windows service spec");
+    expect(spec.script).toContain(
+      'set "PATH=C:\\Program Files\\Git\\mingw64\\bin;C:\\Tools\\100%%Done"'
+    );
+  });
+
   it("escapes percent signs in Windows batch env values", () => {
     const spec = buildServiceSpec({
       platform: "win32",
@@ -178,6 +198,32 @@ describe("buildServiceSpec", () => {
     if (spec.platform !== "darwin") throw new Error("Expected macOS service spec");
     expect(spec.plist).toContain("<key>KeepAlive</key>\n  <true/>");
     expect(spec.plist).not.toContain("SuccessfulExit");
+  });
+});
+
+describe("buildServiceUninstallSudoArgs", () => {
+  it("builds a service-scoped sudo command that preserves user state", () => {
+    const args = buildServiceUninstallSudoArgs("/fake/cli.js", {
+      nodePath: "/usr/bin/node",
+      home: "/Users/alice",
+      env: {
+        PORTLESS_STATE_DIR: "/Users/alice/.portless",
+        PORTLESS_DEBUG: "1",
+        OTHER_ENV: "ignored",
+      },
+    });
+
+    expect(args).toEqual([
+      "env",
+      "PORTLESS_DEBUG=1",
+      "HOME=/Users/alice",
+      "PORTLESS_STATE_DIR=/Users/alice/.portless",
+      "/usr/bin/node",
+      "/fake/cli.js",
+      "service",
+      "uninstall",
+    ]);
+    expect(args).not.toContain("clean");
   });
 });
 

--- a/packages/portless/src/service.test.ts
+++ b/packages/portless/src/service.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { buildServiceSpec, tryUninstallService } from "./service.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildServiceSpec, handleService, tryUninstallService } from "./service.js";
 
 describe("buildServiceSpec", () => {
   it("builds a macOS LaunchDaemon for the HTTPS proxy", () => {
@@ -136,5 +136,56 @@ describe("tryUninstallService", () => {
     const result = tryUninstallService("/fake/cli.js", runner);
     expect(result.removed).toBe(false);
     expect(result.error).toContain("spawn failed");
+  });
+});
+
+describe("handleService", () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it("prints help and exits 0 for --help", async () => {
+    const runner = vi.fn(() => ({ status: 0, stdout: "", stderr: "" }));
+    await expect(
+      handleService(["service", "--help"], { entryScript: "/fake/cli.js", runner })
+    ).rejects.toThrow("process.exit");
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    const output = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(output).toContain("portless service");
+    expect(output).toContain("service install");
+    expect(output).toContain("service uninstall");
+    expect(output).toContain("service status");
+  });
+
+  it("prints help and exits 0 when no subcommand is given", async () => {
+    const runner = vi.fn(() => ({ status: 0, stdout: "", stderr: "" }));
+    await expect(
+      handleService(["service"], { entryScript: "/fake/cli.js", runner })
+    ).rejects.toThrow("process.exit");
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it("exits 1 for unknown subcommand", async () => {
+    const runner = vi.fn(() => ({ status: 0, stdout: "", stderr: "" }));
+    await expect(
+      handleService(["service", "bogus"], { entryScript: "/fake/cli.js", runner })
+    ).rejects.toThrow("process.exit");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const output = errorSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(output).toContain("bogus");
   });
 });

--- a/packages/portless/src/service.test.ts
+++ b/packages/portless/src/service.test.ts
@@ -164,7 +164,7 @@ describe("handleService", () => {
       handleService(["service", "--help"], { entryScript: "/fake/cli.js", runner })
     ).rejects.toThrow("process.exit");
     expect(exitSpy).toHaveBeenCalledWith(0);
-    const output = logSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    const output = logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
     expect(output).toContain("portless service");
     expect(output).toContain("service install");
     expect(output).toContain("service uninstall");
@@ -185,7 +185,7 @@ describe("handleService", () => {
       handleService(["service", "bogus"], { entryScript: "/fake/cli.js", runner })
     ).rejects.toThrow("process.exit");
     expect(exitSpy).toHaveBeenCalledWith(1);
-    const output = errorSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    const output = errorSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
     expect(output).toContain("bogus");
   });
 });

--- a/packages/portless/src/service.test.ts
+++ b/packages/portless/src/service.test.ts
@@ -191,6 +191,7 @@ describe("tryUninstallService", () => {
   });
 
   it("returns removed: false when runner throws", () => {
+    setPlatform("linux");
     vi.mocked(existsSync).mockReturnValue(true);
     const runner = () => {
       throw new Error("spawn failed");

--- a/packages/portless/src/service.ts
+++ b/packages/portless/src/service.ts
@@ -1,0 +1,586 @@
+import colors from "./colors.js";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+import { ensureCerts, isCATrusted, trustCA } from "./certs.js";
+import {
+  buildProxyStartConfig,
+  DEFAULT_TLD,
+  getProtocolPort,
+  isProxyRunning,
+} from "./cli-utils.js";
+import { fixOwnership } from "./utils.js";
+
+const SERVICE_PORT = getProtocolPort(true);
+const SERVICE_LABEL = "sh.portless.proxy";
+const SYSTEMD_SERVICE = "portless.service";
+const WINDOWS_TASK_NAME = "Portless Proxy";
+const INTERNAL_ELEVATED_ENV = "PORTLESS_INTERNAL_SERVICE_ELEVATED";
+
+type SupportedPlatform = "darwin" | "linux" | "win32";
+
+type CommandRunner = (
+  command: string,
+  args: string[],
+  options?: { stdio?: "pipe" | "inherit" }
+) => {
+  status: number | null;
+  stdout?: string;
+  stderr?: string;
+  error?: Error;
+};
+
+type UserContext = {
+  home: string;
+  uid?: string;
+  gid?: string;
+  username?: string;
+};
+
+type ServiceContext = {
+  platform: SupportedPlatform;
+  nodePath: string;
+  entryScript: string;
+  stateDir: string;
+  user: UserContext;
+  pathEnv: string;
+  programData: string;
+};
+
+export type ServiceSpec =
+  | {
+      platform: "darwin";
+      label: string;
+      plistPath: string;
+      plist: string;
+      stateDir: string;
+      programArguments: string[];
+    }
+  | {
+      platform: "linux";
+      serviceName: string;
+      unitPath: string;
+      unit: string;
+      stateDir: string;
+      execStart: string[];
+    }
+  | {
+      platform: "win32";
+      taskName: string;
+      stateDir: string;
+      scriptDir: string;
+      scriptPath: string;
+      script: string;
+      taskRun: string;
+      createArgs: string[];
+      runArgs: string[];
+      deleteArgs: string[];
+      queryArgs: string[];
+    };
+
+type ServiceStatus = {
+  installed: boolean;
+  managerState: string;
+  proxyRunning: boolean;
+  details?: string;
+};
+
+function defaultRunner(command: string, args: string[], options?: { stdio?: "pipe" | "inherit" }) {
+  return spawnSync(command, args, {
+    encoding: "utf-8",
+    stdio: options?.stdio ?? "pipe",
+  });
+}
+
+function isSupportedPlatform(platform: NodeJS.Platform): platform is SupportedPlatform {
+  return platform === "darwin" || platform === "linux" || platform === "win32";
+}
+
+function xmlEscape(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function systemdEscape(value: string): string {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function windowsQuote(value: string): string {
+  return `"${value.replace(/"/g, '\\"')}"`;
+}
+
+function readPasswdHome(username: string): string | null {
+  try {
+    const passwd = fs.readFileSync("/etc/passwd", "utf-8");
+    for (const line of passwd.split("\n")) {
+      const fields = line.split(":");
+      if (fields[0] === username && fields[5]) {
+        return fields[5];
+      }
+    }
+  } catch {
+    // Ignore and fall back to platform conventions.
+  }
+  return null;
+}
+
+function resolveUserContext(platform: SupportedPlatform): UserContext {
+  if (platform === "win32") {
+    const home = process.env.USERPROFILE || os.homedir();
+    return { home, username: process.env.USERNAME };
+  }
+
+  const sudoUser = process.env.SUDO_USER;
+  const sudoUid = process.env.SUDO_UID;
+  const sudoGid = process.env.SUDO_GID;
+  if (sudoUser && sudoUser !== "root") {
+    const home =
+      process.env.HOME && process.env.HOME !== "/var/root" && process.env.HOME !== "/root"
+        ? process.env.HOME
+        : readPasswdHome(sudoUser) ||
+          (platform === "darwin" ? path.join("/Users", sudoUser) : path.join("/home", sudoUser));
+    return { home, uid: sudoUid, gid: sudoGid, username: sudoUser };
+  }
+
+  const userInfo = os.userInfo();
+  return {
+    home: os.homedir(),
+    uid: process.getuid?.()?.toString(),
+    gid: process.getgid?.()?.toString(),
+    username: userInfo.username,
+  };
+}
+
+function buildProxyCommand(entryScript: string): string[] {
+  const config = buildProxyStartConfig({
+    useHttps: true,
+    lanMode: false,
+    tld: DEFAULT_TLD,
+    foreground: true,
+    includePort: true,
+    proxyPort: SERVICE_PORT,
+    skipTrust: true,
+  });
+  return [entryScript, "proxy", "start", ...config.args];
+}
+
+function buildServiceEnv(ctx: ServiceContext): Record<string, string> {
+  const env: Record<string, string> = {
+    PORTLESS_STATE_DIR: ctx.stateDir,
+  };
+
+  if (ctx.platform === "win32") {
+    env.USERPROFILE = ctx.user.home;
+  } else {
+    env.HOME = ctx.user.home;
+    if (ctx.user.uid) env.SUDO_UID = ctx.user.uid;
+    if (ctx.user.gid) env.SUDO_GID = ctx.user.gid;
+  }
+
+  return env;
+}
+
+function defaultStateDir(platform: SupportedPlatform, userHome: string): string {
+  return platform === "win32"
+    ? path.win32.join(userHome, ".portless")
+    : path.join(userHome, ".portless");
+}
+
+function buildLaunchdPlist(ctx: ServiceContext, programArguments: string[]): string {
+  const env = buildServiceEnv(ctx);
+  const envEntries = Object.entries(env)
+    .map(
+      ([key, value]) => `    <key>${xmlEscape(key)}</key>
+    <string>${xmlEscape(value)}</string>`
+    )
+    .join("\n");
+  const args = programArguments.map((arg) => `    <string>${xmlEscape(arg)}</string>`).join("\n");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${SERVICE_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+${args}
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+${envEntries}
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>${xmlEscape(path.join(ctx.stateDir, "service.log"))}</string>
+  <key>StandardErrorPath</key>
+  <string>${xmlEscape(path.join(ctx.stateDir, "service.log"))}</string>
+</dict>
+</plist>
+`;
+}
+
+function buildSystemdUnit(ctx: ServiceContext, execStart: string[]): string {
+  const env = buildServiceEnv(ctx);
+  const envLines = Object.entries(env)
+    .map(([key, value]) => `Environment=${key}=${systemdEscape(value)}`)
+    .join("\n");
+
+  return `[Unit]
+Description=Portless HTTPS proxy
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+${envLines}
+Environment=PATH=${systemdEscape(ctx.pathEnv)}
+ExecStart=${execStart.map(systemdEscape).join(" ")}
+Restart=on-failure
+RestartSec=2
+KillSignal=SIGTERM
+TimeoutStopSec=5
+
+[Install]
+WantedBy=multi-user.target
+`;
+}
+
+function buildWindowsScript(ctx: ServiceContext, command: string[]): string {
+  const env = buildServiceEnv(ctx);
+  const setEnv = Object.entries(env)
+    .map(([key, value]) => `set "${key}=${value.replace(/"/g, "")}"`)
+    .join("\r\n");
+  const proxyCommand = [windowsQuote(ctx.nodePath), ...command.map(windowsQuote)].join(" ");
+  return `@echo off\r\n${setEnv}\r\n${proxyCommand}\r\n`;
+}
+
+export function buildServiceSpec(options: {
+  platform: SupportedPlatform;
+  nodePath: string;
+  entryScript: string;
+  userHome: string;
+  uid?: string;
+  gid?: string;
+  username?: string;
+  stateDir?: string;
+  pathEnv?: string;
+  programData?: string;
+}): ServiceSpec {
+  const ctx: ServiceContext = {
+    platform: options.platform,
+    nodePath: options.nodePath,
+    entryScript: options.entryScript,
+    stateDir: options.stateDir || defaultStateDir(options.platform, options.userHome),
+    user: {
+      home: options.userHome,
+      uid: options.uid,
+      gid: options.gid,
+      username: options.username,
+    },
+    pathEnv: options.pathEnv || "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+    programData: options.programData || "C:\\ProgramData",
+  };
+  const proxyCommand = buildProxyCommand(ctx.entryScript);
+
+  if (ctx.platform === "darwin") {
+    const programArguments = [ctx.nodePath, ...proxyCommand];
+    return {
+      platform: "darwin",
+      label: SERVICE_LABEL,
+      plistPath: `/Library/LaunchDaemons/${SERVICE_LABEL}.plist`,
+      plist: buildLaunchdPlist(ctx, programArguments),
+      stateDir: ctx.stateDir,
+      programArguments,
+    };
+  }
+
+  if (ctx.platform === "linux") {
+    const execStart = [ctx.nodePath, ...proxyCommand];
+    return {
+      platform: "linux",
+      serviceName: SYSTEMD_SERVICE,
+      unitPath: `/etc/systemd/system/${SYSTEMD_SERVICE}`,
+      unit: buildSystemdUnit(ctx, execStart),
+      stateDir: ctx.stateDir,
+      execStart,
+    };
+  }
+
+  const scriptDir = path.win32.join(ctx.programData, "portless", "service");
+  const scriptPath = path.win32.join(scriptDir, "portless-service.cmd");
+  const script = buildWindowsScript(ctx, proxyCommand);
+  const taskRun = windowsQuote(scriptPath);
+  return {
+    platform: "win32",
+    taskName: WINDOWS_TASK_NAME,
+    stateDir: ctx.stateDir,
+    scriptDir,
+    scriptPath,
+    script,
+    taskRun,
+    createArgs: [
+      "/Create",
+      "/TN",
+      WINDOWS_TASK_NAME,
+      "/SC",
+      "ONSTART",
+      "/RU",
+      "SYSTEM",
+      "/RL",
+      "HIGHEST",
+      "/TR",
+      taskRun,
+      "/F",
+    ],
+    runArgs: ["/Run", "/TN", WINDOWS_TASK_NAME],
+    deleteArgs: ["/Delete", "/TN", WINDOWS_TASK_NAME, "/F"],
+    queryArgs: ["/Query", "/TN", WINDOWS_TASK_NAME, "/FO", "LIST", "/V"],
+  };
+}
+
+function currentServiceSpec(entryScript: string): ServiceSpec {
+  if (!isSupportedPlatform(process.platform)) {
+    throw new Error(`Unsupported platform: ${process.platform}`);
+  }
+
+  const user = resolveUserContext(process.platform);
+  return buildServiceSpec({
+    platform: process.platform,
+    nodePath: process.execPath,
+    entryScript,
+    userHome: user.home,
+    uid: user.uid,
+    gid: user.gid,
+    username: user.username,
+    stateDir: process.env.PORTLESS_STATE_DIR || defaultStateDir(process.platform, user.home),
+    pathEnv: process.env.PATH,
+    programData: process.env.ProgramData,
+  });
+}
+
+function requireUnixElevation(args: string[], runner: CommandRunner): boolean {
+  if (process.platform !== "darwin" && process.platform !== "linux") return false;
+  if ((process.getuid?.() ?? -1) === 0) return false;
+  if (process.env[INTERNAL_ELEVATED_ENV] === "1") return false;
+
+  const stateDir = process.env.PORTLESS_STATE_DIR || path.join(os.homedir(), ".portless");
+  const result = runner(
+    "sudo",
+    [
+      "env",
+      `${INTERNAL_ELEVATED_ENV}=1`,
+      `HOME=${os.homedir()}`,
+      `PORTLESS_STATE_DIR=${stateDir}`,
+      process.execPath,
+      args[0],
+      ...args.slice(1),
+    ],
+    { stdio: "inherit" }
+  );
+
+  process.exit(result.status ?? 1);
+}
+
+function runRequired(runner: CommandRunner, command: string, args: string[]): void {
+  const result = runner(command, args);
+  if (result.status !== 0) {
+    const detail = result.stderr || result.stdout || result.error?.message || `${command} failed`;
+    throw new Error(detail.trim());
+  }
+}
+
+function runOptional(runner: CommandRunner, command: string, args: string[]): void {
+  runner(command, args);
+}
+
+function prepareTrust(stateDir: string): void {
+  fs.mkdirSync(stateDir, { recursive: true });
+  fixOwnership(stateDir);
+  ensureCerts(stateDir);
+  if (isCATrusted(stateDir)) return;
+
+  console.log(colors.gray("Trusting portless CA for service startup..."));
+  const trustResult = trustCA(stateDir);
+  if (trustResult.trusted) {
+    console.log(colors.green("CA added to the system trust store."));
+    return;
+  }
+
+  console.warn(colors.yellow("Could not add the CA to the system trust store."));
+  if (trustResult.error) {
+    console.warn(colors.gray(trustResult.error));
+  }
+  console.warn(colors.yellow("Run `portless trust` if browsers show certificate warnings."));
+}
+
+async function installService(entryScript: string, runner: CommandRunner): Promise<void> {
+  requireUnixElevation([entryScript, "service", "install"], runner);
+  const spec = currentServiceSpec(entryScript);
+  prepareTrust(spec.stateDir);
+
+  if (spec.platform === "darwin") {
+    fs.writeFileSync(spec.plistPath, spec.plist);
+    fs.chmodSync(spec.plistPath, 0o644);
+    runRequired(runner, "chown", ["root:wheel", spec.plistPath]);
+    runOptional(runner, "launchctl", ["bootout", "system", spec.plistPath]);
+    runRequired(runner, "launchctl", ["bootstrap", "system", spec.plistPath]);
+    runRequired(runner, "launchctl", ["enable", `system/${spec.label}`]);
+    runRequired(runner, "launchctl", ["kickstart", "-k", `system/${spec.label}`]);
+  } else if (spec.platform === "linux") {
+    fs.writeFileSync(spec.unitPath, spec.unit);
+    fs.chmodSync(spec.unitPath, 0o644);
+    runRequired(runner, "systemctl", ["daemon-reload"]);
+    runRequired(runner, "systemctl", ["enable", "--now", spec.serviceName]);
+  } else {
+    fs.mkdirSync(spec.scriptDir, { recursive: true });
+    fs.writeFileSync(spec.scriptPath, spec.script);
+    runRequired(runner, "schtasks", spec.createArgs);
+    runOptional(runner, "schtasks", spec.runArgs);
+  }
+
+  console.log(colors.green("Portless service installed."));
+  console.log(colors.gray(`State directory: ${spec.stateDir}`));
+}
+
+async function uninstallService(entryScript: string, runner: CommandRunner): Promise<void> {
+  requireUnixElevation([entryScript, "service", "uninstall"], runner);
+  const spec = currentServiceSpec(entryScript);
+
+  if (spec.platform === "darwin") {
+    runOptional(runner, "launchctl", ["bootout", "system", spec.plistPath]);
+    fs.rmSync(spec.plistPath, { force: true });
+  } else if (spec.platform === "linux") {
+    runOptional(runner, "systemctl", ["disable", "--now", spec.serviceName]);
+    fs.rmSync(spec.unitPath, { force: true });
+    runOptional(runner, "systemctl", ["daemon-reload"]);
+  } else {
+    runOptional(runner, "schtasks", ["/End", "/TN", spec.taskName]);
+    runOptional(runner, "schtasks", spec.deleteArgs);
+    fs.rmSync(spec.scriptDir, { recursive: true, force: true });
+  }
+
+  console.log(colors.green("Portless service uninstalled."));
+}
+
+async function getServiceStatus(
+  entryScript: string,
+  runner: CommandRunner
+): Promise<ServiceStatus> {
+  const spec = currentServiceSpec(entryScript);
+  const proxyRunning = await isProxyRunning(SERVICE_PORT);
+
+  if (spec.platform === "darwin") {
+    const installed = fs.existsSync(spec.plistPath);
+    const result = runner("launchctl", ["print", `system/${spec.label}`]);
+    const output = `${result.stdout || ""}${result.stderr || ""}`;
+    const managerState =
+      result.status === 0 && /state = running|pid = \d+/.test(output)
+        ? "running"
+        : installed
+          ? "installed"
+          : "not installed";
+    return { installed, managerState, proxyRunning, details: spec.plistPath };
+  }
+
+  if (spec.platform === "linux") {
+    const enabled = runner("systemctl", ["is-enabled", spec.serviceName]);
+    const active = runner("systemctl", ["is-active", spec.serviceName]);
+    const installed = enabled.status === 0 || active.status === 0 || fs.existsSync(spec.unitPath);
+    const activeText = (active.stdout || "").trim();
+    return {
+      installed,
+      managerState:
+        active.status === 0 ? activeText || "active" : installed ? "installed" : "not installed",
+      proxyRunning,
+      details: spec.unitPath,
+    };
+  }
+
+  const query = runner("schtasks", spec.queryArgs);
+  const output = `${query.stdout || ""}${query.stderr || ""}`;
+  const installed = query.status === 0;
+  const stateMatch = output.match(/^\s*Status:\s*(.+)$/im);
+  return {
+    installed,
+    managerState: installed ? stateMatch?.[1]?.trim() || "installed" : "not installed",
+    proxyRunning,
+    details: spec.taskName,
+  };
+}
+
+async function printServiceStatus(entryScript: string, runner: CommandRunner): Promise<void> {
+  const spec = currentServiceSpec(entryScript);
+  const status = await getServiceStatus(entryScript, runner);
+  console.log(colors.bold("portless service"));
+  console.log(`  Manager state: ${status.managerState}`);
+  console.log(`  Installed: ${status.installed ? "yes" : "no"}`);
+  console.log(`  Proxy on 443: ${status.proxyRunning ? "responding" : "not responding"}`);
+  console.log(`  State directory: ${spec.stateDir}`);
+  if (status.details) {
+    console.log(`  Service entry: ${status.details}`);
+  }
+}
+
+export function printServiceHelp(): void {
+  console.log(`
+${colors.bold("portless service")} - Start portless automatically when the OS starts.
+
+${colors.bold("Usage:")}
+  ${colors.cyan("portless service install")}      Install and start the HTTPS service on port 443
+  ${colors.cyan("portless service uninstall")}    Stop and remove the startup service
+  ${colors.cyan("portless service status")}       Show service and proxy status
+
+${colors.bold("Notes:")}
+  The service uses the default clean URL mode: HTTPS on port 443.
+  macOS and Linux install a root-owned service so port 443 can bind at boot.
+  Windows installs a Task Scheduler startup task that runs as SYSTEM.
+`);
+}
+
+export async function handleService(
+  args: string[],
+  options: { entryScript: string; runner?: CommandRunner }
+): Promise<void> {
+  const action = args[1];
+  const runner = options.runner || defaultRunner;
+
+  if (!action || action === "--help" || action === "-h") {
+    printServiceHelp();
+    process.exit(0);
+  }
+
+  try {
+    if (action === "install") {
+      await installService(options.entryScript, runner);
+      return;
+    }
+    if (action === "uninstall") {
+      await uninstallService(options.entryScript, runner);
+      return;
+    }
+    if (action === "status") {
+      await printServiceStatus(options.entryScript, runner);
+      return;
+    }
+
+    console.error(colors.red(`Error: Unknown service command "${action}".`));
+    printServiceHelp();
+    process.exit(1);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(colors.red("Error:"), message);
+    process.exit(1);
+  }
+}

--- a/packages/portless/src/service.ts
+++ b/packages/portless/src/service.ts
@@ -218,10 +218,7 @@ ${envEntries}
   <key>RunAtLoad</key>
   <true/>
   <key>KeepAlive</key>
-  <dict>
-    <key>SuccessfulExit</key>
-    <false/>
-  </dict>
+  <true/>
   <key>StandardOutPath</key>
   <string>${xmlEscape(path.join(ctx.stateDir, "service.log"))}</string>
   <key>StandardErrorPath</key>
@@ -260,7 +257,7 @@ WantedBy=multi-user.target
 function buildWindowsScript(ctx: ServiceContext, command: string[]): string {
   const env = buildServiceEnv(ctx);
   const setEnv = Object.entries(env)
-    .map(([key, value]) => `set "${key}=${value.replace(/"/g, "")}"`)
+    .map(([key, value]) => `set "${key}=${value.replace(/"/g, "").replace(/%/g, "%%")}"`)
     .join("\r\n");
   const proxyCommand = [windowsQuote(ctx.nodePath), ...command.map(windowsQuote)].join(" ");
   return `@echo off\r\n${setEnv}\r\n${proxyCommand}\r\n`;
@@ -370,10 +367,10 @@ function currentServiceSpec(entryScript: string): ServiceSpec {
   });
 }
 
-function requireUnixElevation(args: string[], runner: CommandRunner): boolean {
-  if (process.platform !== "darwin" && process.platform !== "linux") return false;
-  if ((process.getuid?.() ?? -1) === 0) return false;
-  if (process.env[INTERNAL_ELEVATED_ENV] === "1") return false;
+function requireUnixElevation(args: string[], runner: CommandRunner): void {
+  if (process.platform !== "darwin" && process.platform !== "linux") return;
+  if ((process.getuid?.() ?? -1) === 0) return;
+  if (process.env[INTERNAL_ELEVATED_ENV] === "1") return;
 
   const stateDir = process.env.PORTLESS_STATE_DIR || path.join(os.homedir(), ".portless");
   const result = runner(
@@ -408,7 +405,14 @@ function runOptional(runner: CommandRunner, command: string, args: string[]): vo
 function prepareTrust(stateDir: string): void {
   fs.mkdirSync(stateDir, { recursive: true });
   fixOwnership(stateDir);
-  ensureCerts(stateDir);
+  try {
+    ensureCerts(stateDir);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Failed to generate certificates in ${stateDir}. Ensure OpenSSL is installed.\n${detail}`
+    );
+  }
   if (isCATrusted(stateDir)) return;
 
   console.log(colors.gray("Trusting portless CA for service startup..."));
@@ -472,6 +476,41 @@ async function uninstallService(entryScript: string, runner: CommandRunner): Pro
   }
 
   console.log(colors.green("Portless service uninstalled."));
+}
+
+/**
+ * Best-effort service removal for use by `portless clean`. Skips elevation
+ * (caller is expected to already be elevated) and returns a result instead of
+ * calling process.exit.
+ */
+export function tryUninstallService(
+  entryScript: string,
+  runner: CommandRunner = defaultRunner
+): { removed: boolean; error?: string } {
+  try {
+    const spec = currentServiceSpec(entryScript);
+
+    if (spec.platform === "darwin") {
+      if (!fs.existsSync(spec.plistPath)) return { removed: false };
+      runOptional(runner, "launchctl", ["bootout", "system", spec.plistPath]);
+      fs.rmSync(spec.plistPath, { force: true });
+    } else if (spec.platform === "linux") {
+      if (!fs.existsSync(spec.unitPath)) return { removed: false };
+      runOptional(runner, "systemctl", ["disable", "--now", spec.serviceName]);
+      fs.rmSync(spec.unitPath, { force: true });
+      runOptional(runner, "systemctl", ["daemon-reload"]);
+    } else {
+      const query = runner("schtasks", ["/Query", "/TN", "Portless Proxy", "/FO", "LIST"]);
+      if (query.status !== 0) return { removed: false };
+      runOptional(runner, "schtasks", ["/End", "/TN", spec.taskName]);
+      runOptional(runner, "schtasks", spec.deleteArgs);
+      fs.rmSync(spec.scriptDir, { recursive: true, force: true });
+    }
+
+    return { removed: true };
+  } catch (err) {
+    return { removed: false, error: err instanceof Error ? err.message : String(err) };
+  }
 }
 
 async function getServiceStatus(

--- a/packages/portless/src/service.ts
+++ b/packages/portless/src/service.ts
@@ -86,6 +86,13 @@ type ServiceStatus = {
   details?: string;
 };
 
+export type ServiceUninstallResult = {
+  removed: boolean;
+  installed: boolean;
+  error?: string;
+  needsElevation?: boolean;
+};
+
 function defaultRunner(command: string, args: string[], options?: { stdio?: "pipe" | "inherit" }) {
   return spawnSync(command, args, {
     encoding: "utf-8",
@@ -404,6 +411,27 @@ function runOptional(runner: CommandRunner, command: string, args: string[]): vo
   runner(command, args);
 }
 
+function isPermissionError(err: unknown): boolean {
+  const code =
+    err && typeof err === "object" && "code" in err ? String((err as { code?: unknown }).code) : "";
+  const message = err instanceof Error ? err.message : String(err);
+  return (
+    code === "EACCES" ||
+    code === "EPERM" ||
+    /permission denied|operation not permitted|access is denied/i.test(message)
+  );
+}
+
+function stopExistingProxy(entryScript: string, runner: CommandRunner): void {
+  runRequired(runner, process.execPath, [
+    entryScript,
+    "proxy",
+    "stop",
+    "--port",
+    SERVICE_PORT.toString(),
+  ]);
+}
+
 function prepareTrust(stateDir: string): void {
   fs.mkdirSync(stateDir, { recursive: true });
   fixOwnership(stateDir);
@@ -437,19 +465,25 @@ async function installService(entryScript: string, runner: CommandRunner): Promi
   prepareTrust(spec.stateDir);
 
   if (spec.platform === "darwin") {
+    runOptional(runner, "launchctl", ["bootout", "system", spec.plistPath]);
+    stopExistingProxy(entryScript, runner);
     fs.writeFileSync(spec.plistPath, spec.plist);
     fs.chmodSync(spec.plistPath, 0o644);
     runRequired(runner, "chown", ["root:wheel", spec.plistPath]);
-    runOptional(runner, "launchctl", ["bootout", "system", spec.plistPath]);
     runRequired(runner, "launchctl", ["bootstrap", "system", spec.plistPath]);
     runRequired(runner, "launchctl", ["enable", `system/${spec.label}`]);
     runRequired(runner, "launchctl", ["kickstart", "-k", `system/${spec.label}`]);
   } else if (spec.platform === "linux") {
+    runOptional(runner, "systemctl", ["disable", "--now", spec.serviceName]);
+    stopExistingProxy(entryScript, runner);
     fs.writeFileSync(spec.unitPath, spec.unit);
     fs.chmodSync(spec.unitPath, 0o644);
     runRequired(runner, "systemctl", ["daemon-reload"]);
-    runRequired(runner, "systemctl", ["enable", "--now", spec.serviceName]);
+    runRequired(runner, "systemctl", ["enable", spec.serviceName]);
+    runRequired(runner, "systemctl", ["restart", spec.serviceName]);
   } else {
+    runOptional(runner, "schtasks", ["/End", "/TN", spec.taskName]);
+    stopExistingProxy(entryScript, runner);
     fs.mkdirSync(spec.scriptDir, { recursive: true });
     fs.writeFileSync(spec.scriptPath, spec.script);
     runRequired(runner, "schtasks", spec.createArgs);
@@ -488,30 +522,39 @@ async function uninstallService(entryScript: string, runner: CommandRunner): Pro
 export function tryUninstallService(
   entryScript: string,
   runner: CommandRunner = defaultRunner
-): { removed: boolean; error?: string } {
+): ServiceUninstallResult {
+  let installed = false;
   try {
     const spec = currentServiceSpec(entryScript);
 
     if (spec.platform === "darwin") {
-      if (!fs.existsSync(spec.plistPath)) return { removed: false };
+      installed = fs.existsSync(spec.plistPath);
+      if (!installed) return { removed: false, installed: false };
       runOptional(runner, "launchctl", ["bootout", "system", spec.plistPath]);
       fs.rmSync(spec.plistPath, { force: true });
     } else if (spec.platform === "linux") {
-      if (!fs.existsSync(spec.unitPath)) return { removed: false };
+      installed = fs.existsSync(spec.unitPath);
+      if (!installed) return { removed: false, installed: false };
       runOptional(runner, "systemctl", ["disable", "--now", spec.serviceName]);
       fs.rmSync(spec.unitPath, { force: true });
       runOptional(runner, "systemctl", ["daemon-reload"]);
     } else {
       const query = runner("schtasks", ["/Query", "/TN", spec.taskName, "/FO", "LIST"]);
-      if (query.status !== 0) return { removed: false };
+      installed = query.status === 0;
+      if (!installed) return { removed: false, installed: false };
       runOptional(runner, "schtasks", ["/End", "/TN", spec.taskName]);
-      runOptional(runner, "schtasks", spec.deleteArgs);
+      runRequired(runner, "schtasks", spec.deleteArgs);
       fs.rmSync(spec.scriptDir, { recursive: true, force: true });
     }
 
-    return { removed: true };
+    return { removed: true, installed: true };
   } catch (err) {
-    return { removed: false, error: err instanceof Error ? err.message : String(err) };
+    return {
+      removed: false,
+      installed,
+      error: err instanceof Error ? err.message : String(err),
+      needsElevation: installed && isPermissionError(err),
+    };
   }
 }
 

--- a/packages/portless/src/service.ts
+++ b/packages/portless/src/service.ts
@@ -143,7 +143,9 @@ function resolveUserContext(platform: SupportedPlatform): UserContext {
       process.env.HOME && process.env.HOME !== "/var/root" && process.env.HOME !== "/root"
         ? process.env.HOME
         : readPasswdHome(sudoUser) ||
-          (platform === "darwin" ? path.join("/Users", sudoUser) : path.join("/home", sudoUser));
+          (platform === "darwin"
+            ? path.posix.join("/Users", sudoUser)
+            : path.posix.join("/home", sudoUser));
     return { home, uid: sudoUid, gid: sudoGid, username: sudoUser };
   }
 
@@ -188,7 +190,7 @@ function buildServiceEnv(ctx: ServiceContext): Record<string, string> {
 function defaultStateDir(platform: SupportedPlatform, userHome: string): string {
   return platform === "win32"
     ? path.win32.join(userHome, ".portless")
-    : path.join(userHome, ".portless");
+    : path.posix.join(userHome, ".portless");
 }
 
 function buildLaunchdPlist(ctx: ServiceContext, programArguments: string[]): string {
@@ -220,9 +222,9 @@ ${envEntries}
   <key>KeepAlive</key>
   <true/>
   <key>StandardOutPath</key>
-  <string>${xmlEscape(path.join(ctx.stateDir, "service.log"))}</string>
+  <string>${xmlEscape(path.posix.join(ctx.stateDir, "service.log"))}</string>
   <key>StandardErrorPath</key>
-  <string>${xmlEscape(path.join(ctx.stateDir, "service.log"))}</string>
+  <string>${xmlEscape(path.posix.join(ctx.stateDir, "service.log"))}</string>
 </dict>
 </plist>
 `;

--- a/packages/portless/src/service.ts
+++ b/packages/portless/src/service.ts
@@ -185,6 +185,7 @@ function buildServiceEnv(ctx: ServiceContext): Record<string, string> {
 
   if (ctx.platform === "win32") {
     env.USERPROFILE = ctx.user.home;
+    env.PATH = ctx.pathEnv;
   } else {
     env.HOME = ctx.user.home;
     if (ctx.user.uid) env.SUDO_UID = ctx.user.uid;
@@ -376,19 +377,72 @@ function currentServiceSpec(entryScript: string): ServiceSpec {
   });
 }
 
+function collectPortlessEnvArgs(
+  env: NodeJS.ProcessEnv = process.env,
+  omit: Set<string> = new Set()
+): string[] {
+  const envArgs: string[] = [];
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("PORTLESS_") && env[key] && !omit.has(key)) {
+      envArgs.push(`${key}=${env[key]}`);
+    }
+  }
+  return envArgs;
+}
+
+function buildElevatedEnvArgs(options: {
+  home: string;
+  stateDir: string;
+  env?: NodeJS.ProcessEnv;
+  extraEnv?: Record<string, string>;
+}): string[] {
+  const extraEnv = options.extraEnv ?? {};
+  const overrideKeys = new Set(["PORTLESS_STATE_DIR", ...Object.keys(extraEnv)]);
+  return [
+    "env",
+    ...collectPortlessEnvArgs(options.env, overrideKeys),
+    ...Object.entries(extraEnv).map(([key, value]) => `${key}=${value}`),
+    `HOME=${options.home}`,
+    `PORTLESS_STATE_DIR=${options.stateDir}`,
+  ];
+}
+
+export function buildServiceUninstallSudoArgs(
+  entryScript: string,
+  options: {
+    nodePath?: string;
+    home?: string;
+    stateDir?: string;
+    env?: NodeJS.ProcessEnv;
+  } = {}
+): string[] {
+  const env = options.env ?? process.env;
+  const home = options.home ?? os.homedir();
+  const stateDir = options.stateDir ?? env.PORTLESS_STATE_DIR ?? path.join(home, ".portless");
+  return [
+    ...buildElevatedEnvArgs({ home, stateDir, env }),
+    options.nodePath ?? process.execPath,
+    entryScript,
+    "service",
+    "uninstall",
+  ];
+}
+
 function requireUnixElevation(args: string[], runner: CommandRunner): void {
   if (process.platform !== "darwin" && process.platform !== "linux") return;
   if ((process.getuid?.() ?? -1) === 0) return;
   if (process.env[INTERNAL_ELEVATED_ENV] === "1") return;
 
-  const stateDir = process.env.PORTLESS_STATE_DIR || path.join(os.homedir(), ".portless");
+  const home = os.homedir();
+  const stateDir = process.env.PORTLESS_STATE_DIR || path.join(home, ".portless");
   const result = runner(
     "sudo",
     [
-      "env",
-      `${INTERNAL_ELEVATED_ENV}=1`,
-      `HOME=${os.homedir()}`,
-      `PORTLESS_STATE_DIR=${stateDir}`,
+      ...buildElevatedEnvArgs({
+        home,
+        stateDir,
+        extraEnv: { [INTERNAL_ELEVATED_ENV]: "1" },
+      }),
       process.execPath,
       args[0],
       ...args.slice(1),

--- a/packages/portless/src/service.ts
+++ b/packages/portless/src/service.ts
@@ -500,7 +500,7 @@ export function tryUninstallService(
       fs.rmSync(spec.unitPath, { force: true });
       runOptional(runner, "systemctl", ["daemon-reload"]);
     } else {
-      const query = runner("schtasks", ["/Query", "/TN", "Portless Proxy", "/FO", "LIST"]);
+      const query = runner("schtasks", ["/Query", "/TN", spec.taskName, "/FO", "LIST"]);
       if (query.status !== 0) return { removed: false };
       runOptional(runner, "schtasks", ["/End", "/TN", spec.taskName]);
       runOptional(runner, "schtasks", spec.deleteArgs);

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -240,6 +240,18 @@ Tailscale HTTPS certificates must be enabled before `--tailscale` or `--funnel` 
 
 Each `--tailscale` app is root-mounted on its own Tailscale HTTPS port (443, then 8443, 8444, etc.) so no framework `basePath` configuration is needed. Set `PORTLESS_TAILSCALE=1` to share every app by default. `portless list` shows both local and tailnet URLs. Tailscale serve registrations are cleaned up when the app exits. Requires `tailscale` CLI installed and connected, with Tailscale HTTPS certificates enabled.
 
+## OS startup service
+
+Use the service command when users want the proxy to start automatically after reboot:
+
+```bash
+portless service install
+portless service status
+portless service uninstall
+```
+
+The service uses the default clean URL behavior: HTTPS on port 443 with `.localhost` names. macOS and Linux install a root-owned service so port 443 can bind at boot. Windows installs a Task Scheduler startup task that runs as SYSTEM. Installation and removal may require administrator privileges.
+
 ## CLI Reference
 
 | Command                                | Description                                                    |
@@ -265,6 +277,9 @@ Each `--tailscale` app is root-mounted on its own Tailscale HTTPS port (443, the
 | `portless proxy start --foreground`    | Start the proxy in foreground (for debugging)                  |
 | `portless proxy start --wildcard`      | Allow unregistered subdomains to fall back to parent route     |
 | `portless proxy stop`                  | Stop the proxy                                                 |
+| `portless service install`             | Start the HTTPS proxy when the OS starts                       |
+| `portless service status`              | Show service and proxy status                                  |
+| `portless service uninstall`           | Remove the startup service                                     |
 | `portless alias <name> <port>`         | Register a static route (e.g. for Docker containers)           |
 | `portless alias <name> <port> --force` | Overwrite an existing route                                    |
 | `portless alias --remove <name>`       | Remove a static route                                          |
@@ -280,7 +295,7 @@ Each `--tailscale` app is root-mounted on its own Tailscale HTTPS port (443, the
 | `portless run --help`                  | Show help for a subcommand (also: alias, hosts, clean)         |
 | `portless --version` / `-v`            | Show version                                                   |
 
-**Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `trust`, `clean`, `prune`, and `proxy` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name, or `portless --name <name> <cmd>` to force any name including reserved ones.
+**Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `trust`, `clean`, `prune`, `proxy`, and `service` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name, or `portless --name <name> <cmd>` to force any name including reserved ones.
 
 ## portless.json
 

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -250,7 +250,7 @@ portless service status
 portless service uninstall
 ```
 
-The service uses the default clean URL behavior: HTTPS on port 443 with `.localhost` names. macOS and Linux install a root-owned service so port 443 can bind at boot. Windows installs a Task Scheduler startup task that runs as SYSTEM. Installation and removal may require administrator privileges.
+The service uses the default clean URL behavior: HTTPS on port 443 with `.localhost` names. macOS and Linux install a root-owned service so port 443 can bind at boot. Windows installs a Task Scheduler startup task that runs as SYSTEM. Installation and removal may require administrator privileges. `portless clean` automatically removes the service.
 
 ## CLI Reference
 


### PR DESCRIPTION
## Summary
- Add `portless service install|uninstall|status` to manage OS startup for the HTTPS proxy.
- Install native startup entries for macOS launchd, Linux systemd, and Windows Task Scheduler while pinning proxy state to the installing user.
- Document service startup usage across README, docs, skill, and CLI help.