### PR TITLE
Prepare v0.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,24 @@
 # Changelog
 
-## 0.12.0
+## 0.13.0
 
 <!-- release:start -->
+
+### New Features
+
+- **OS startup service**: New `portless service install`, `portless service status`, and `portless service uninstall` commands manage a native startup service for the HTTPS proxy across macOS launchd, Linux systemd, and Windows Task Scheduler. The service starts clean `.localhost` URLs after reboot, and `portless clean` removes it during cleanup. (#289)
+
+### Bug Fixes
+
+- **Tailscale readiness preflight**: `--tailscale` and `--funnel` now check Tailscale HTTPS and Funnel prerequisites before starting the child process, surfacing actionable errors instead of hanging during registration. (#282)
+
+### Contributors
+
+- @ctate
+- @Anshuman71
+<!-- release:end -->
+
+## 0.12.0
 
 ### New Features
 
@@ -19,7 +35,6 @@
 ### Contributors
 
 - @ctate
-<!-- release:end -->
 
 ## 0.11.1
 

--- a/apps/docs/src/app/changelog/page.mdx
+++ b/apps/docs/src/app/changelog/page.mdx
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.13.0
+
+### New Features
+
+- **OS startup service**: New `portless service install`, `portless service status`, and `portless service uninstall` commands manage a native startup service for the HTTPS proxy across macOS launchd, Linux systemd, and Windows Task Scheduler. The service starts clean `.localhost` URLs after reboot, and `portless clean` removes it during cleanup
+
+### Bug Fixes
+
+- **Tailscale readiness preflight**: `--tailscale` and `--funnel` now check Tailscale HTTPS and Funnel prerequisites before starting the child process, surfacing actionable errors instead of hanging during registration
+
 ## 0.12.0
 
 ### New Features

--- a/packages/portless/package.json
+++ b/packages/portless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portless",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Replace port numbers with stable, named .localhost URLs. For humans and agents.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bump `portless` to v0.13.0.
- Add release notes for OS startup service support and the Tailscale readiness preflight fix.
- Move release markers to the v0.13.0 changelog entry for automated release extraction.