### PR TITLE
Add NetBird sharing with auth flags and end-to-end reachability

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,20 @@ Set `PORTLESS_TAILSCALE=1` in your shell profile or `.env` to share every app by
 
 Requires the Tailscale CLI to be installed and connected (`tailscale up`).
 
+## NetBird sharing
+
+Share your dev server via the [NetBird](https://netbird.io) reverse proxy:
+
+```bash
+portless myapp --netbird next dev
+# -> https://myapp.localhost                       (local)
+# -> https://myapp-<random>.proxy.<your-cluster>   (NetBird)
+```
+
+Portless runs `netbird expose` in the background, derives the service name from the app name, and stops the exposure when the app exits. Set `PORTLESS_NETBIRD=1` in your shell profile or `.env` to share every app by default. `portless list` shows the NetBird URL alongside the local URL.
+
+Requires the NetBird CLI to be installed and connected (`netbird up`). See [Expose from CLI](https://docs.netbird.io/manage/reverse-proxy/expose-from-cli) for setup details.
+
 ## Commands
 
 ```bash
@@ -351,6 +365,7 @@ portless proxy stop              # Stop the proxy
 --app-port <number>              Use a fixed port for the app (skip auto-assignment)
 --tailscale                      Share the app on your Tailscale network (tailnet)
 --funnel                         Share the app publicly via Tailscale Funnel
+--netbird                        Share the app via NetBird reverse proxy
 --force                          Kill the existing process and take over its route
 --name <name>                    Use <name> as the app name
 ```
@@ -368,6 +383,7 @@ PORTLESS_WILDCARD=1              Allow unregistered subdomains to fall back to p
 PORTLESS_SYNC_HOSTS=0            Disable auto-sync of /etc/hosts (on by default)
 PORTLESS_TAILSCALE=1             Share apps on your Tailscale network (same as --tailscale)
 PORTLESS_FUNNEL=1                Share apps publicly via Tailscale Funnel (same as --funnel)
+PORTLESS_NETBIRD=1               Share apps via NetBird reverse proxy (same as --netbird)
 PORTLESS_STATE_DIR=<path>        Override the state directory
 
 # Injected into child processes
@@ -375,6 +391,7 @@ PORT                             Ephemeral port the child should listen on
 HOST                             Usually 127.0.0.1 (omitted for Expo in LAN mode)
 PORTLESS_URL                     Public URL (e.g. https://myapp.localhost)
 PORTLESS_TAILSCALE_URL           Tailscale URL of the app (when --tailscale is active)
+PORTLESS_NETBIRD_URL             NetBird URL of the app (when --netbird is active)
 NODE_EXTRA_CA_CERTS              Path to the portless CA (when HTTPS is active)
 ```
 
@@ -456,3 +473,4 @@ pnpm format           # Format all files with Prettier
 - Node.js 20+
 - macOS, Linux, or Windows
 - Tailscale CLI (optional, for `--tailscale` and `--funnel`)
+- NetBird CLI (optional, for `--netbird`)

--- a/README.md
+++ b/README.md
@@ -330,6 +330,14 @@ portless myapp --netbird next dev
 
 Portless runs `netbird expose` in the background, derives the service name from the app name, and stops the exposure when the app exits. Set `PORTLESS_NETBIRD=1` in your shell profile or `.env` to share every app by default. `portless list` shows the NetBird URL alongside the local URL.
 
+Protect the exposed service with a password, PIN, or SSO user groups (pass-through to `netbird expose`):
+
+```bash
+portless myapp --netbird --netbird-password s3cret next dev
+portless myapp --netbird --netbird-pin 123456 next dev
+portless myapp --netbird --netbird-groups devops,Backend next dev
+```
+
 Requires the NetBird CLI to be installed and connected (`netbird up`). See [Expose from CLI](https://docs.netbird.io/manage/reverse-proxy/expose-from-cli) for setup details.
 
 ## Commands
@@ -385,6 +393,9 @@ portless service uninstall       # Remove the startup service
 --tailscale                      Share the app on your Tailscale network (tailnet)
 --funnel                         Share the app publicly via Tailscale Funnel
 --netbird                        Share the app via NetBird reverse proxy
+--netbird-password <string>      Protect the NetBird-exposed service with a password
+--netbird-pin <code>             Protect the NetBird-exposed service with a 6-digit PIN
+--netbird-groups <csv>           Restrict NetBird access to SSO user groups (comma-separated)
 --force                          Kill the existing process and take over its route
 --name <name>                    Use <name> as the app name
 ```
@@ -403,6 +414,9 @@ PORTLESS_SYNC_HOSTS=0            Disable auto-sync of /etc/hosts (on by default)
 PORTLESS_TAILSCALE=1             Share apps on your Tailscale network (same as --tailscale)
 PORTLESS_FUNNEL=1                Share apps publicly via Tailscale Funnel (same as --funnel)
 PORTLESS_NETBIRD=1               Share apps via NetBird reverse proxy (same as --netbird)
+PORTLESS_NETBIRD_PASSWORD        Password for NetBird-exposed services (same as --netbird-password)
+PORTLESS_NETBIRD_PIN             6-digit PIN for NetBird-exposed services (same as --netbird-pin)
+PORTLESS_NETBIRD_GROUPS          CSV of SSO user groups (same as --netbird-groups)
 PORTLESS_STATE_DIR=<path>        Override the state directory
 
 # Injected into child processes

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -434,6 +434,19 @@ describe("injectFrameworkFlags", () => {
     }
   });
 
+  it("injects --host 0.0.0.0 in NetBird mode so the netbird daemon can reach the app", () => {
+    const prev = process.env.PORTLESS_NETBIRD;
+    process.env.PORTLESS_NETBIRD = "1";
+    try {
+      const args = ["vite", "dev"];
+      injectFrameworkFlags(args, 4567);
+      expect(args).toEqual(["vite", "dev", "--port", "4567", "--strictPort", "--host", "0.0.0.0"]);
+    } finally {
+      if (prev === undefined) delete process.env.PORTLESS_NETBIRD;
+      else process.env.PORTLESS_NETBIRD = prev;
+    }
+  });
+
   it("does not inject for frameworks that read PORT", () => {
     const nextArgs = ["next", "dev"];
     injectFrameworkFlags(nextArgs, 4567);

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -332,6 +332,14 @@ export function isLanEnvEnabled(): boolean {
 }
 
 /**
+ * Return whether NetBird sharing is requested via the PORTLESS_NETBIRD env var.
+ */
+export function isNetbirdEnvEnabled(): boolean {
+  const val = process.env.PORTLESS_NETBIRD;
+  return val === "1" || val === "true";
+}
+
+/**
  * Read the last-known proxy configuration from the state directory on disk.
  * Unlike {@link discoverState}, this does not check whether the proxy is
  * actually running. It simply reads whatever state files exist so a
@@ -955,7 +963,8 @@ export function injectFrameworkFlags(commandArgs: string[], port: number): void 
     // HOST=127.0.0.1 causes Metro's HMR WebSocket to break after a few reloads.
     const isExpoLan = basename === "expo" && isLanEnvEnabled();
     if (isExpoLan) return;
-    const hostValue = basename === "expo" ? "localhost" : "127.0.0.1";
+    const netbirdShared = isNetbirdEnvEnabled();
+    const hostValue = basename === "expo" ? "localhost" : netbirdShared ? "0.0.0.0" : "127.0.0.1";
     commandArgs.push("--host", hostValue);
   }
 }

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -21,6 +21,7 @@ import {
   registerServe,
   unregisterTailscale,
 } from "./tailscale.js";
+import { ensureNetbirdReady, startExpose, type ExposeHandle } from "./netbird.js";
 import {
   inferProjectName,
   detectWorktreePrefix,
@@ -784,6 +785,9 @@ function listRoutes(store: RouteStore, proxyPort: number, tls: boolean): void {
       const tsLabel = route.tailscaleFunnel ? "funnel" : "tailscale";
       console.log(`    ${colors.gray(tsLabel + ":")} ${colors.green(route.tailscaleUrl)}`);
     }
+    if (route.netbirdUrl) {
+      console.log(`    ${colors.gray("netbird:")} ${colors.green(route.netbirdUrl)}`);
+    }
   }
   console.log();
 }
@@ -974,6 +978,25 @@ async function runApp(
     }
   }
 
+  const wantsNetbird =
+    process.env.PORTLESS_NETBIRD === "1" || process.env.PORTLESS_NETBIRD === "true";
+
+  if (wantsNetbird) {
+    try {
+      ensureNetbirdReady();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(colors.red(`Error: ${message}`));
+      if (message.includes("not found")) {
+        console.error(colors.blue("Install NetBird: https://netbird.io/download"));
+      } else {
+        console.error(colors.blue("Make sure NetBird is connected:"));
+        console.error(colors.cyan("  netbird up"));
+      }
+      process.exit(1);
+    }
+  }
+
   let desired: ProxyDesiredState;
   try {
     desired = resolveProxyDesiredState(lanMode);
@@ -1118,6 +1141,35 @@ async function runApp(
     }
   }
 
+  // NetBird sharing: spawn `netbird expose` and hold the foreground child
+  // alive for the lifetime of the dev server. Killing the child stops
+  // exposure (NetBird has no separate unregister step).
+  let netbirdHandle: ExposeHandle | undefined;
+  let netbirdUrl: string | undefined;
+
+  if (wantsNetbird) {
+    const namePrefix = name
+      .replace(/[^a-z0-9-]/gi, "-")
+      .toLowerCase()
+      .slice(0, 32);
+    try {
+      netbirdHandle = await startExpose(port, { namePrefix });
+      netbirdUrl = netbirdHandle.info.url;
+      console.log(chalk.green(`  NetBird -> ${netbirdUrl}`));
+      console.log(chalk.gray("  (accessible via NetBird reverse proxy)\n"));
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(colors.red(`Error: ${message}`));
+      process.exit(1);
+    }
+
+    try {
+      store.updateRoute(hostname, { netbirdUrl });
+    } catch {
+      // Non-fatal: route display metadata only
+    }
+  }
+
   // Child servers always bind to localhost; the proxy handles cross-device LAN access.
   // Exception: Expo in LAN mode — Metro defaults to LAN and setting HOST=127.0.0.1
   // conflicts with its internal networking, causing HMR WebSocket degradation.
@@ -1174,6 +1226,7 @@ async function runApp(
       // own LAN discovery natively.
       ...(lanMode ? { PORTLESS_LAN: "1" } : {}),
       ...(tailscaleUrl ? { PORTLESS_TAILSCALE_URL: tailscaleUrl } : {}),
+      ...(netbirdUrl ? { PORTLESS_NETBIRD_URL: netbirdUrl } : {}),
       ...caEnv,
     },
     onCleanup: () => {
@@ -1182,6 +1235,11 @@ async function runApp(
           tailscaleHttpsPort,
           tailscaleFunnel: wantsFunnel || undefined,
         });
+      } catch {
+        // Best-effort cleanup; non-fatal
+      }
+      try {
+        netbirdHandle?.stop();
       } catch {
         // Best-effort cleanup; non-fatal
       }
@@ -1245,6 +1303,14 @@ function applyTailscaleFlag(flag: string): boolean {
   if (flag === "--funnel") {
     process.env.PORTLESS_FUNNEL = "1";
     process.env.PORTLESS_TAILSCALE = "1";
+    return true;
+  }
+  return false;
+}
+
+function applyNetbirdFlag(flag: string): boolean {
+  if (flag === "--netbird") {
+    process.env.PORTLESS_NETBIRD = "1";
     return true;
   }
   return false;
@@ -1314,12 +1380,14 @@ ${colors.bold("Examples:")}
         process.exit(1);
       }
       name = args[i];
-    } else if (applyTailscaleFlag(args[i])) {
+    } else if (applyTailscaleFlag(args[i]) || applyNetbirdFlag(args[i])) {
       // handled
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
       console.error(
-        colors.blue("Known flags: --name, --force, --app-port, --tailscale, --funnel, --help")
+        colors.blue(
+          "Known flags: --name, --force, --app-port, --tailscale, --funnel, --netbird, --help"
+        )
       );
       process.exit(1);
     }
@@ -1353,11 +1421,13 @@ function parseAppArgs(args: string[]): ParsedAppArgs {
     } else if (args[i] === "--app-port") {
       i++;
       appPort = parseAppPort(args[i]);
-    } else if (applyTailscaleFlag(args[i])) {
+    } else if (applyTailscaleFlag(args[i]) || applyNetbirdFlag(args[i])) {
       // handled
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
-      console.error(colors.blue("Known flags: --force, --app-port, --tailscale, --funnel"));
+      console.error(
+        colors.blue("Known flags: --force, --app-port, --tailscale, --funnel, --netbird")
+      );
       process.exit(1);
     }
     i++;
@@ -1377,11 +1447,13 @@ function parseAppArgs(args: string[]): ParsedAppArgs {
     } else if (args[i] === "--app-port") {
       i++;
       appPort = parseAppPort(args[i]);
-    } else if (applyTailscaleFlag(args[i])) {
+    } else if (applyTailscaleFlag(args[i]) || applyNetbirdFlag(args[i])) {
       // handled
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
-      console.error(colors.blue("Known flags: --force, --app-port, --tailscale, --funnel"));
+      console.error(
+        colors.blue("Known flags: --force, --app-port, --tailscale, --funnel, --netbird")
+      );
       process.exit(1);
     }
     i++;
@@ -1435,6 +1507,7 @@ ${colors.bold("Examples:")}
   portless get backend                # -> https://backend.localhost
   portless myapp --tailscale next dev # -> also https://<node>.ts.net (tailnet)
   portless myapp --funnel next dev    # -> also https://<node>.ts.net (public)
+  portless myapp --netbird next dev   # -> also https://<name>.<proxy-cluster> (NetBird)
 
 ${colors.bold("Configuration (portless.json):")}
   Optional. Portless works out of the box by running the "dev" script
@@ -1494,6 +1567,12 @@ ${colors.bold("Tailscale sharing:")}
   ${colors.cyan("portless myapp --tailscale next dev")}
   ${colors.cyan("portless myapp --funnel next dev")}
 
+${colors.bold("NetBird sharing:")}
+  Use --netbird to share your dev server via the NetBird reverse proxy.
+  Portless runs "netbird expose" in the background and stops it on exit.
+  Requires NetBird CLI to be installed and connected ("netbird up").
+  ${colors.cyan("portless myapp --netbird next dev")}
+
 ${colors.bold("Options:")}
   run [--name <name>] <cmd>      Infer project name (or override with --name)
                                 Adds worktree prefix in git worktrees
@@ -1512,6 +1591,7 @@ ${colors.bold("Options:")}
   --app-port <number>           Use a fixed port for the app (skip auto-assignment)
   --tailscale                   Share the app on your Tailscale network (tailnet)
   --funnel                      Share the app publicly via Tailscale Funnel
+  --netbird                     Share the app via NetBird reverse proxy
   --force                       Kill the existing process and take over its route
   --name <name>                 Use <name> as the app name (bypasses subcommand dispatch)
   --                            Stop flag parsing; everything after is passed to the child
@@ -1526,6 +1606,7 @@ ${colors.bold("Environment variables:")}
   PORTLESS_SYNC_HOSTS=0         Disable auto-sync of ${HOSTS_DISPLAY} (on by default)
   PORTLESS_TAILSCALE=1          Share apps on your Tailscale network (same as --tailscale)
   PORTLESS_FUNNEL=1             Share apps publicly via Tailscale Funnel (same as --funnel)
+  PORTLESS_NETBIRD=1            Share apps via NetBird reverse proxy (same as --netbird)
   PORTLESS_STATE_DIR=<path>     Override the state directory
   PORTLESS=0                    Run command directly without proxy
 
@@ -1535,6 +1616,7 @@ ${colors.bold("Child process environment:")}
   PORTLESS_URL                  Public URL of the app (e.g. https://myapp.localhost)
   PORTLESS_LAN                  Set to 1 when proxy is in LAN mode
   PORTLESS_TAILSCALE_URL        Tailscale URL of the app (when --tailscale is active)
+  PORTLESS_NETBIRD_URL          NetBird URL of the app (when --netbird is active)
   NODE_EXTRA_CA_CERTS           Path to the portless CA (set when HTTPS is active)
 
 ${colors.bold("Safari / DNS:")}
@@ -3393,6 +3475,9 @@ async function main() {
   if (stripGlobalFlag("--funnel", false)) {
     process.env.PORTLESS_FUNNEL = "1";
     process.env.PORTLESS_TAILSCALE = "1";
+  }
+  if (stripGlobalFlag("--netbird", false)) {
+    process.env.PORTLESS_NETBIRD = "1";
   }
 
   // --script flag: override the default "dev" script for zero-arg mode.

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1210,7 +1210,11 @@ async function runApp(
   const basename = path.basename(commandArgs[0]);
   const isExpo = basename === "expo";
   const isExpoLan = isExpo && (lanMode || isLanEnvEnabled());
-  const hostBind = isExpoLan ? undefined : "127.0.0.1";
+  // With --netbird, the local end of the tunnel dials the peer's NetBird
+  // WireGuard IP (not 127.0.0.1), so the app must bind to all interfaces
+  // for netbird expose to reach it. Same idea as --lan, applied to the app
+  // bind instead of the proxy bind.
+  const hostBind = isExpoLan ? undefined : wantsNetbird ? "0.0.0.0" : "127.0.0.1";
 
   // Ensure PORTLESS_LAN is propagated to child processes when the proxy
   // was started with --lan separately and discovered from the state marker,
@@ -1650,7 +1654,7 @@ ${colors.bold("Environment variables:")}
 
 ${colors.bold("Child process environment:")}
   PORT                          Ephemeral port the child should listen on
-  HOST                          Usually 127.0.0.1 (omitted for Expo in LAN mode)
+  HOST                          Usually 127.0.0.1 (0.0.0.0 with --netbird, omitted for Expo in LAN mode)
   PORTLESS_URL                  Public URL of the app (e.g. https://myapp.localhost)
   PORTLESS_LAN                  Set to 1 when proxy is in LAN mode
   PORTLESS_TAILSCALE_URL        Tailscale URL of the app (when --tailscale is active)

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1186,8 +1186,20 @@ async function runApp(
       .replace(/[^a-z0-9-]/gi, "-")
       .toLowerCase()
       .slice(0, 32);
+    const groupsEnv = process.env.PORTLESS_NETBIRD_GROUPS;
+    const userGroups = groupsEnv
+      ? groupsEnv
+          .split(",")
+          .map((g) => g.trim())
+          .filter(Boolean)
+      : undefined;
     try {
-      netbirdHandle = await startExpose(port, { namePrefix });
+      netbirdHandle = await startExpose(port, {
+        namePrefix,
+        password: process.env.PORTLESS_NETBIRD_PASSWORD,
+        pin: process.env.PORTLESS_NETBIRD_PIN,
+        userGroups,
+      });
       netbirdUrl = netbirdHandle.info.url;
       console.log(chalk.green(`  NetBird -> ${netbirdUrl}`));
       console.log(chalk.gray("  (accessible via NetBird reverse proxy)\n"));
@@ -1354,6 +1366,26 @@ function applyNetbirdFlag(flag: string): boolean {
   return false;
 }
 
+const NETBIRD_VALUE_FLAGS: Record<string, string> = {
+  "--netbird-password": "PORTLESS_NETBIRD_PASSWORD",
+  "--netbird-pin": "PORTLESS_NETBIRD_PIN",
+  "--netbird-groups": "PORTLESS_NETBIRD_GROUPS",
+};
+
+function isNetbirdValueFlag(flag: string): boolean {
+  return Object.prototype.hasOwnProperty.call(NETBIRD_VALUE_FLAGS, flag);
+}
+
+function consumeNetbirdValueFlag(flag: string, value: string | undefined): void {
+  const envKey = NETBIRD_VALUE_FLAGS[flag];
+  if (!value || value.startsWith("-")) {
+    console.error(colors.red(`Error: ${flag} requires a value.`));
+    process.exit(1);
+  }
+  process.env[envKey] = value;
+  process.env.PORTLESS_NETBIRD = "1";
+}
+
 /**
  * Parse `run` subcommand arguments: `[--name <name>] [--force] [--] <command...>`
  *
@@ -1420,11 +1452,15 @@ ${colors.bold("Examples:")}
       name = args[i];
     } else if (applyTailscaleFlag(args[i]) || applyNetbirdFlag(args[i])) {
       // handled
+    } else if (isNetbirdValueFlag(args[i])) {
+      const flag = args[i];
+      i++;
+      consumeNetbirdValueFlag(flag, args[i]);
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
       console.error(
         colors.blue(
-          "Known flags: --name, --force, --app-port, --tailscale, --funnel, --netbird, --help"
+          "Known flags: --name, --force, --app-port, --tailscale, --funnel, --netbird, --netbird-password, --netbird-pin, --netbird-groups, --help"
         )
       );
       process.exit(1);
@@ -1461,10 +1497,16 @@ function parseAppArgs(args: string[]): ParsedAppArgs {
       appPort = parseAppPort(args[i]);
     } else if (applyTailscaleFlag(args[i]) || applyNetbirdFlag(args[i])) {
       // handled
+    } else if (isNetbirdValueFlag(args[i])) {
+      const flag = args[i];
+      i++;
+      consumeNetbirdValueFlag(flag, args[i]);
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
       console.error(
-        colors.blue("Known flags: --force, --app-port, --tailscale, --funnel, --netbird")
+        colors.blue(
+          "Known flags: --force, --app-port, --tailscale, --funnel, --netbird, --netbird-password, --netbird-pin, --netbird-groups"
+        )
       );
       process.exit(1);
     }
@@ -1487,10 +1529,16 @@ function parseAppArgs(args: string[]): ParsedAppArgs {
       appPort = parseAppPort(args[i]);
     } else if (applyTailscaleFlag(args[i]) || applyNetbirdFlag(args[i])) {
       // handled
+    } else if (isNetbirdValueFlag(args[i])) {
+      const flag = args[i];
+      i++;
+      consumeNetbirdValueFlag(flag, args[i]);
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
       console.error(
-        colors.blue("Known flags: --force, --app-port, --tailscale, --funnel, --netbird")
+        colors.blue(
+          "Known flags: --force, --app-port, --tailscale, --funnel, --netbird, --netbird-password, --netbird-pin, --netbird-groups"
+        )
       );
       process.exit(1);
     }
@@ -1634,6 +1682,9 @@ ${colors.bold("Options:")}
   --tailscale                   Share the app on your Tailscale network (tailnet)
   --funnel                      Share the app publicly via Tailscale Funnel
   --netbird                     Share the app via NetBird reverse proxy
+  --netbird-password <string>   Protect the NetBird-exposed service with a password
+  --netbird-pin <code>          Protect the NetBird-exposed service with a 6-digit PIN
+  --netbird-groups <csv>        Restrict NetBird access to SSO user groups (comma-separated)
   --force                       Kill the existing process and take over its route
   --name <name>                 Use <name> as the app name (bypasses subcommand dispatch)
   --                            Stop flag parsing; everything after is passed to the child
@@ -1649,6 +1700,9 @@ ${colors.bold("Environment variables:")}
   PORTLESS_TAILSCALE=1          Share apps on your Tailscale network (same as --tailscale)
   PORTLESS_FUNNEL=1             Share apps publicly via Tailscale Funnel (same as --funnel)
   PORTLESS_NETBIRD=1            Share apps via NetBird reverse proxy (same as --netbird)
+  PORTLESS_NETBIRD_PASSWORD     Password for NetBird-exposed services (same as --netbird-password)
+  PORTLESS_NETBIRD_PIN          6-digit PIN for NetBird-exposed services (same as --netbird-pin)
+  PORTLESS_NETBIRD_GROUPS       CSV of SSO user groups (same as --netbird-groups)
   PORTLESS_STATE_DIR=<path>     Override the state directory
   PORTLESS=0                    Run command directly without proxy
 
@@ -3530,6 +3584,16 @@ async function main() {
   }
   if (stripGlobalFlag("--netbird", false)) {
     process.env.PORTLESS_NETBIRD = "1";
+  }
+  for (const [flag, envKey] of Object.entries(NETBIRD_VALUE_FLAGS)) {
+    const result = stripGlobalFlag(flag, true);
+    if (result === false) {
+      console.error(colors.red(`Error: ${flag} requires a value.`));
+      process.exit(1);
+    } else if (typeof result === "string") {
+      process.env[envKey] = result;
+      process.env.PORTLESS_NETBIRD = "1";
+    }
   }
 
   // --script flag: override the default "dev" script for zero-arg mode.

--- a/packages/portless/src/netbird.test.ts
+++ b/packages/portless/src/netbird.test.ts
@@ -201,6 +201,14 @@ describe("netbird", () => {
       expect(calls[0]).toEqual(["expose", "--with-name-prefix", "myapp", "8080"]);
     });
 
+    it("resolves when the URL block is printed on stderr (netbird's real behavior)", async () => {
+      const fake = new FakeProcess();
+      const promise = startExpose(8080, { spawner: () => fake });
+      fake.emitStderr(SUCCESS_OUTPUT);
+      const handle = await promise;
+      expect(handle.info.url).toBe("https://myapp-a1b2c3.proxy.example.com");
+    });
+
     it("stop() sends SIGTERM to the child", async () => {
       const fake = new FakeProcess();
       const promise = startExpose(8080, { spawner: () => fake });

--- a/packages/portless/src/netbird.test.ts
+++ b/packages/portless/src/netbird.test.ts
@@ -1,0 +1,237 @@
+import { EventEmitter } from "node:events";
+import { describe, it, expect } from "vitest";
+import {
+  buildExposeArgs,
+  ensureNetbirdReady,
+  parseExposeInfo,
+  startExpose,
+  type ExposeProcessLike,
+  type ExposeSpawner,
+  type NetbirdCommandRunner,
+} from "./netbird.js";
+
+interface MockResult {
+  status?: number | null;
+  stdout?: string;
+  stderr?: string;
+  error?: Error;
+}
+
+function createRunner(
+  results: Record<string, MockResult>,
+  calls: string[][] = []
+): NetbirdCommandRunner {
+  return (args: string[]) => {
+    calls.push(args);
+    const key = args.join(" ");
+    const result = results[key];
+    if (!result) throw new Error(`Unexpected netbird call: ${key}`);
+    return {
+      status: result.status ?? 0,
+      stdout: result.stdout ?? "",
+      stderr: result.stderr ?? "",
+      ...(result.error ? { error: result.error } : {}),
+    };
+  };
+}
+
+class FakeProcess extends EventEmitter implements ExposeProcessLike {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  killed = false;
+  killSignal: NodeJS.Signals | number | undefined;
+
+  kill(signal?: NodeJS.Signals | number): boolean {
+    this.killed = true;
+    this.killSignal = signal;
+    return true;
+  }
+
+  emitStdout(data: string): void {
+    this.stdout.emit("data", Buffer.from(data));
+  }
+
+  emitStderr(data: string): void {
+    this.stderr.emit("data", Buffer.from(data));
+  }
+}
+
+const SUCCESS_OUTPUT = `Service exposed successfully!
+  Name:     myapp-a1b2c3
+  URL:      https://myapp-a1b2c3.proxy.example.com
+  Domain:   myapp-a1b2c3.proxy.example.com
+  Protocol: http
+  Internal: 8080
+
+Press Ctrl+C to stop exposing.
+`;
+
+describe("netbird", () => {
+  // -----------------------------------------------------------------------
+  // ensureNetbirdReady
+  // -----------------------------------------------------------------------
+
+  describe("ensureNetbirdReady", () => {
+    it("returns daemon status and fqdn when connected", () => {
+      const runner = createRunner({
+        "status --json": {
+          status: 0,
+          stdout: JSON.stringify({ daemonStatus: "Connected", fqdn: "devbox.netbird.cloud" }),
+        },
+      });
+      const ready = ensureNetbirdReady(runner);
+      expect(ready.daemonStatus).toBe("Connected");
+      expect(ready.fqdn).toBe("devbox.netbird.cloud");
+    });
+
+    it("throws when daemon is not connected", () => {
+      const runner = createRunner({
+        "status --json": {
+          status: 0,
+          stdout: JSON.stringify({ daemonStatus: "NeedsLogin" }),
+        },
+      });
+      expect(() => ensureNetbirdReady(runner)).toThrow(
+        "NetBird is not connected (status: NeedsLogin)"
+      );
+    });
+
+    it("throws when netbird CLI is missing", () => {
+      const enoent = Object.assign(new Error("spawn netbird ENOENT"), { code: "ENOENT" });
+      const runner = createRunner({ "status --json": { status: null, error: enoent } });
+      expect(() => ensureNetbirdReady(runner)).toThrow("NetBird CLI not found");
+    });
+
+    it("throws on invalid status JSON", () => {
+      const runner = createRunner({
+        "status --json": { status: 0, stdout: "not json" },
+      });
+      expect(() => ensureNetbirdReady(runner)).toThrow("Failed to parse");
+    });
+
+    it("surfaces stderr details when status command fails", () => {
+      const runner = createRunner({
+        "status --json": { status: 1, stderr: "daemon not running" },
+      });
+      expect(() => ensureNetbirdReady(runner)).toThrow("daemon not running");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // buildExposeArgs
+  // -----------------------------------------------------------------------
+
+  describe("buildExposeArgs", () => {
+    it("builds bare expose with just the port", () => {
+      expect(buildExposeArgs(8080)).toEqual(["expose", "8080"]);
+    });
+
+    it("appends every supported flag in order, with port last", () => {
+      const args = buildExposeArgs(5432, {
+        protocol: "tcp",
+        password: "s3cret",
+        pin: "123456",
+        namePrefix: "myapp",
+        externalPort: 5433,
+        customDomain: "tls.example.com",
+        userGroups: ["devops", "Backend"],
+      });
+      expect(args).toEqual([
+        "expose",
+        "--protocol",
+        "tcp",
+        "--with-password",
+        "s3cret",
+        "--with-pin",
+        "123456",
+        "--with-name-prefix",
+        "myapp",
+        "--with-external-port",
+        "5433",
+        "--with-custom-domain",
+        "tls.example.com",
+        "--with-user-groups",
+        "devops,Backend",
+        "5432",
+      ]);
+    });
+
+    it("omits --with-user-groups when the array is empty", () => {
+      expect(buildExposeArgs(80, { userGroups: [] })).toEqual(["expose", "80"]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // parseExposeInfo
+  // -----------------------------------------------------------------------
+
+  describe("parseExposeInfo", () => {
+    it("extracts the four fields from the success block", () => {
+      const info = parseExposeInfo(SUCCESS_OUTPUT);
+      expect(info).toEqual({
+        name: "myapp-a1b2c3",
+        url: "https://myapp-a1b2c3.proxy.example.com",
+        domain: "myapp-a1b2c3.proxy.example.com",
+        protocol: "http",
+      });
+    });
+
+    it("returns null when any required field is missing", () => {
+      const partial = "Name: myapp-a1b2c3\nURL: https://example.com\n";
+      expect(parseExposeInfo(partial)).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // startExpose
+  // -----------------------------------------------------------------------
+
+  describe("startExpose", () => {
+    it("resolves with parsed info when the URL block is printed", async () => {
+      const fake = new FakeProcess();
+      const calls: string[][] = [];
+      const spawner: ExposeSpawner = (args) => {
+        calls.push(args);
+        return fake;
+      };
+      const promise = startExpose(8080, { spawner, namePrefix: "myapp" });
+      fake.emitStdout(SUCCESS_OUTPUT);
+      const handle = await promise;
+      expect(handle.info.url).toBe("https://myapp-a1b2c3.proxy.example.com");
+      expect(calls[0]).toEqual(["expose", "--with-name-prefix", "myapp", "8080"]);
+    });
+
+    it("stop() sends SIGTERM to the child", async () => {
+      const fake = new FakeProcess();
+      const promise = startExpose(8080, { spawner: () => fake });
+      fake.emitStdout(SUCCESS_OUTPUT);
+      const handle = await promise;
+      handle.stop();
+      expect(fake.killed).toBe(true);
+      expect(fake.killSignal).toBe("SIGTERM");
+    });
+
+    it("rejects and kills the child if the URL never arrives before the timeout", async () => {
+      const fake = new FakeProcess();
+      const promise = startExpose(8080, { spawner: () => fake, timeoutMs: 10 });
+      await expect(promise).rejects.toThrow("Timed out waiting for netbird expose");
+      expect(fake.killed).toBe(true);
+    });
+
+    it("rejects with stderr details when the child exits early", async () => {
+      const fake = new FakeProcess();
+      const promise = startExpose(8080, { spawner: () => fake });
+      fake.emitStderr("client is not running, run 'netbird up' first\n");
+      fake.emit("exit", 1);
+      await expect(promise).rejects.toThrow("client is not running");
+    });
+
+    it("rejects with a CLI-not-found error on ENOENT", async () => {
+      const fake = new FakeProcess();
+      const enoent = Object.assign(new Error("spawn netbird ENOENT"), { code: "ENOENT" });
+      const promise = startExpose(8080, { spawner: () => fake });
+      fake.emit("error", enoent);
+      await expect(promise).rejects.toThrow("NetBird CLI not found");
+    });
+  });
+});

--- a/packages/portless/src/netbird.ts
+++ b/packages/portless/src/netbird.ts
@@ -213,24 +213,28 @@ export function startExpose(
       fn();
     };
 
+    const tryResolve = () => {
+      const info = parseExposeInfo(stdoutBuf + "\n" + stderrBuf);
+      if (!info) return;
+      settle(() =>
+        resolve({
+          info,
+          process: child,
+          stop: () => {
+            child.kill("SIGTERM");
+          },
+        })
+      );
+    };
+
     child.stdout?.on("data", (chunk) => {
       stdoutBuf += chunk.toString();
-      const info = parseExposeInfo(stdoutBuf);
-      if (info) {
-        settle(() =>
-          resolve({
-            info,
-            process: child,
-            stop: () => {
-              child.kill("SIGTERM");
-            },
-          })
-        );
-      }
+      tryResolve();
     });
 
     child.stderr?.on("data", (chunk) => {
       stderrBuf += chunk.toString();
+      tryResolve();
     });
 
     child.on("error", (err) => {

--- a/packages/portless/src/netbird.ts
+++ b/packages/portless/src/netbird.ts
@@ -1,0 +1,254 @@
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+
+const NETBIRD_BINARY = "netbird";
+
+const DEFAULT_EXPOSE_TIMEOUT_MS = 30_000;
+
+interface NetbirdCommandResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  error?: Error;
+}
+
+export type NetbirdCommandRunner = (args: string[]) => NetbirdCommandResult;
+
+interface NetbirdStatusJson {
+  daemonStatus?: string;
+  fqdn?: string;
+}
+
+export interface NetbirdReadyResult {
+  daemonStatus: string;
+  fqdn: string;
+}
+
+function defaultRunner(args: string[]): NetbirdCommandResult {
+  const result = spawnSync(NETBIRD_BINARY, args, { encoding: "utf-8" });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    ...(result.error ? { error: result.error } : {}),
+  };
+}
+
+function normalizeSpace(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+function cliNotFoundError(): Error {
+  return new Error(
+    "NetBird CLI not found. Install NetBird (https://netbird.io/download) and ensure `netbird` is on PATH."
+  );
+}
+
+function runOrThrow(
+  args: string[],
+  action: string,
+  runner: NetbirdCommandRunner
+): NetbirdCommandResult {
+  const result = runner(args);
+  if (result.error) {
+    const errno = result.error as NodeJS.ErrnoException;
+    if (errno.code === "ENOENT") throw cliNotFoundError();
+    throw new Error(`Failed to ${action}: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const details = normalizeSpace(result.stderr || result.stdout);
+    throw new Error(`Failed to ${action}: ${details || "unknown netbird error"}`);
+  }
+  return result;
+}
+
+/**
+ * Verify the NetBird daemon is connected. Throws if the CLI is missing or the
+ * daemon is in any state other than "Connected".
+ */
+export function ensureNetbirdReady(
+  runner: NetbirdCommandRunner = defaultRunner
+): NetbirdReadyResult {
+  const result = runOrThrow(["status", "--json"], "read netbird status", runner);
+  let status: NetbirdStatusJson;
+  try {
+    status = JSON.parse(result.stdout) as NetbirdStatusJson;
+  } catch {
+    throw new Error("Failed to parse `netbird status --json` output.");
+  }
+  const daemonStatus = status.daemonStatus ?? "Unknown";
+  if (daemonStatus !== "Connected") {
+    throw new Error(
+      `NetBird is not connected (status: ${daemonStatus}). Run \`netbird up\` first.`
+    );
+  }
+  return { daemonStatus, fqdn: status.fqdn ?? "" };
+}
+
+// ---------------------------------------------------------------------------
+// expose
+// ---------------------------------------------------------------------------
+
+export type ExposeProtocol = "http" | "https" | "tcp" | "udp" | "tls";
+
+export interface ExposeOptions {
+  protocol?: ExposeProtocol;
+  password?: string;
+  pin?: string;
+  namePrefix?: string;
+  externalPort?: number;
+  customDomain?: string;
+  userGroups?: string[];
+}
+
+export interface ExposeInfo {
+  name: string;
+  url: string;
+  domain: string;
+  protocol: string;
+}
+
+/**
+ * Build the argument vector for `netbird expose`. The local port is always
+ * the final positional argument, matching the CLI's required order.
+ */
+export function buildExposeArgs(localPort: number, options: ExposeOptions = {}): string[] {
+  const args = ["expose"];
+  if (options.protocol) args.push("--protocol", options.protocol);
+  if (options.password) args.push("--with-password", options.password);
+  if (options.pin) args.push("--with-pin", options.pin);
+  if (options.namePrefix) args.push("--with-name-prefix", options.namePrefix);
+  if (options.externalPort !== undefined) {
+    args.push("--with-external-port", options.externalPort.toString());
+  }
+  if (options.customDomain) args.push("--with-custom-domain", options.customDomain);
+  if (options.userGroups && options.userGroups.length > 0) {
+    args.push("--with-user-groups", options.userGroups.join(","));
+  }
+  args.push(localPort.toString());
+  return args;
+}
+
+/**
+ * Parse the labelled block printed by `netbird expose` once the service is
+ * registered. Returns null until all four fields (Name, URL, Domain, Protocol)
+ * have been seen.
+ */
+export function parseExposeInfo(output: string): ExposeInfo | null {
+  const fields: Record<string, string> = {};
+  for (const line of output.split(/\r?\n/)) {
+    const match = line.match(/^\s*(Name|URL|Domain|Protocol):\s+(.+?)\s*$/);
+    if (match) fields[match[1].toLowerCase()] = match[2];
+  }
+  if (!fields.name || !fields.url || !fields.domain || !fields.protocol) return null;
+  return {
+    name: fields.name,
+    url: fields.url,
+    domain: fields.domain,
+    protocol: fields.protocol,
+  };
+}
+
+interface ExposeStream {
+  on(event: "data", listener: (chunk: Buffer | string) => void): unknown;
+}
+
+export interface ExposeProcessLike {
+  stdout: ExposeStream | null;
+  stderr: ExposeStream | null;
+  kill(signal?: NodeJS.Signals | number): boolean;
+  on(event: "exit", listener: (code: number | null) => void): unknown;
+  on(event: "error", listener: (err: Error) => void): unknown;
+}
+
+export type ExposeSpawner = (args: string[]) => ExposeProcessLike;
+
+export interface StartExposeOptions extends ExposeOptions {
+  spawner?: ExposeSpawner;
+  timeoutMs?: number;
+}
+
+export interface ExposeHandle {
+  info: ExposeInfo;
+  process: ExposeProcessLike;
+  stop(): void;
+}
+
+function defaultSpawner(args: string[]): ChildProcess {
+  return spawn(NETBIRD_BINARY, args, { stdio: ["ignore", "pipe", "pipe"] });
+}
+
+/**
+ * Spawn `netbird expose` and resolve once the public URL has been printed.
+ * The returned handle owns the child process; call `stop()` to terminate
+ * exposure. Rejects on CLI missing, early exit, or timeout.
+ */
+export function startExpose(
+  localPort: number,
+  options: StartExposeOptions = {}
+): Promise<ExposeHandle> {
+  const {
+    spawner = defaultSpawner,
+    timeoutMs = DEFAULT_EXPOSE_TIMEOUT_MS,
+    ...exposeOptions
+  } = options;
+  const args = buildExposeArgs(localPort, exposeOptions);
+  const child = spawner(args);
+
+  return new Promise<ExposeHandle>((resolve, reject) => {
+    let stdoutBuf = "";
+    let stderrBuf = "";
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGTERM");
+      reject(new Error(`Timed out waiting for netbird expose to publish URL after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      fn();
+    };
+
+    child.stdout?.on("data", (chunk) => {
+      stdoutBuf += chunk.toString();
+      const info = parseExposeInfo(stdoutBuf);
+      if (info) {
+        settle(() =>
+          resolve({
+            info,
+            process: child,
+            stop: () => {
+              child.kill("SIGTERM");
+            },
+          })
+        );
+      }
+    });
+
+    child.stderr?.on("data", (chunk) => {
+      stderrBuf += chunk.toString();
+    });
+
+    child.on("error", (err) => {
+      const errno = err as NodeJS.ErrnoException;
+      settle(() => {
+        if (errno.code === "ENOENT") {
+          reject(cliNotFoundError());
+          return;
+        }
+        reject(new Error(`Failed to start netbird expose: ${err.message}`));
+      });
+    });
+
+    child.on("exit", (code) => {
+      settle(() => {
+        const details = normalizeSpace(stderrBuf || stdoutBuf);
+        reject(new Error(`netbird expose exited with code ${code}: ${details || "unknown error"}`));
+      });
+    });
+  });
+}

--- a/packages/portless/src/routes.ts
+++ b/packages/portless/src/routes.ts
@@ -26,6 +26,7 @@ export interface RouteMapping extends RouteInfo {
   tailscaleUrl?: string;
   tailscaleHttpsPort?: number;
   tailscaleFunnel?: boolean;
+  netbirdUrl?: string;
 }
 
 /** Runtime check that a parsed JSON value is a valid RouteMapping. */
@@ -301,7 +302,9 @@ export class RouteStore {
    */
   updateRoute(
     hostname: string,
-    fields: Partial<Pick<RouteMapping, "tailscaleUrl" | "tailscaleHttpsPort" | "tailscaleFunnel">>
+    fields: Partial<
+      Pick<RouteMapping, "tailscaleUrl" | "tailscaleHttpsPort" | "tailscaleFunnel" | "netbirdUrl">
+    >
   ): void {
     this.ensureDir();
     if (!this.acquireLock()) {
@@ -315,6 +318,7 @@ export class RouteStore {
       if (fields.tailscaleHttpsPort !== undefined)
         route.tailscaleHttpsPort = fields.tailscaleHttpsPort;
       if (fields.tailscaleFunnel !== undefined) route.tailscaleFunnel = fields.tailscaleFunnel;
+      if (fields.netbirdUrl !== undefined) route.netbirdUrl = fields.netbirdUrl;
       this.saveRoutes(routes);
     } finally {
       this.releaseLock();


### PR DESCRIPTION
## Summary

- Adds `--netbird` and three pass-through auth flags that let any portless app be shared over [NetBird's reverse proxy](https://docs.netbird.io/manage/reverse-proxy/expose-from-cli) with zero framework config
- Spawns `netbird expose` in the background, parses the public URL, and kills the child on exit — NetBird has no separate unregister step
- Includes readiness checks, stderr-aware URL parsing, an interface-aware bind fix, and 17 new tests

## Details

**New `netbird.ts` module** encapsulates all `netbird` CLI interactions with an injectable `NetbirdCommandRunner` (sync, for `netbird status --json`) and `ExposeSpawner` (async, for the long-running `netbird expose` child).  
Handles readiness checks, CLI-arg building for every documented `--with-*` flag, success-block parsing, and the foreground-child lifecycle (resolve on URL, reject on early exit / ENOENT / 30 s timeout, SIGTERM on `stop()`).

**CLI integration** supports three placement styles, matching the Tailscale pattern:

```bash                                                                                                                                                                                                                          
portless --netbird myapp next dev               # global flag                                                                                                                                                                  
portless myapp --netbird next dev               # per-app flag
PORTLESS_NETBIRD=1 portless myapp next dev      # env var                                                                                                                                                                        
```
Authentication pass-throughs map 1:1 to netbird expose:                                                                                                                                                                          
```bash                                                    
portless myapp --netbird --netbird-password s3cret next dev                                                                                                                                                                      
portless myapp --netbird --netbird-pin 123456 next dev                                                                                                                                                                           
portless myapp --netbird --netbird-groups devops,Backend next dev
```                                                                                                                                                                                                                               
Each is also available globally and as an env var (PORTLESS_NETBIRD_{PASSWORD,PIN,GROUPS}). Setting any of them implies --netbird. Groups are CSV, matching NetBird's own format.                                                
                                                                                                                                                                                                                               
Stderr parsing is required because netbird expose writes its "Service exposed successfully!" block — including the URL — to stderr, not stdout. The parser consumes both streams; ignoring this caused early iterations to time  
out after 30 s while the URL sat unread.                  
                                                                                                                                                                                                                               
App binds to 0.0.0.0 under --netbird because NetBird's local-side connector dials the peer's NetBird WireGuard IP, not loopback, and the default 127.0.0.1 bind made the NetBird URL hit ECONNREFUSED. The portless local proxy  
still targets 127.0.0.1, so binding only to the netbird IP would break the local URL — 0.0.0.0 satisfies both. Same shape as the existing --lan plumbing, applied to both the HOST env var and the --host flag injected for
Vite/Astro/etc. Expo's --host (a connection mode, not a bind) is left alone.                                                                                                                                                     
                                                        
Route metadata extended with an optional netbirdUrl field. portless list displays the NetBird URL alongside the local URL.                                                                                                       

Lifecycle management: the netbird expose child is tied to the dev server's lifetime — onCleanup sends SIGTERM, so killing the portless CLI ends exposure. No persistent state, so no prune/clean integration needed. PORTLESS_NETBIRD_URL is injected into the child process environment so apps can discover their public URL.