### PR TITLE
fix(cli): report package config source

### DIFF
--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -1281,6 +1281,43 @@ describe("CLI", () => {
       expect(stdout).toContain("from-start");
     });
 
+    it("prints package.json as the name source for package portless config", async () => {
+      const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-cli-config-state-"));
+      const proxyPort = await getFreePort();
+      try {
+        fs.writeFileSync(
+          path.join(tmpDir, "package.json"),
+          JSON.stringify({
+            name: "test-app",
+            scripts: { dev: "node -e \"console.log('from-dev')\"" },
+            portless: { name: "pkg-name" },
+          })
+        );
+
+        const { status, stdout } = run([], {
+          cwd: tmpDir,
+          env: {
+            PORTLESS_HTTPS: "0",
+            PORTLESS_PORT: String(proxyPort),
+            PORTLESS_STATE_DIR: stateDir,
+          },
+        });
+
+        expect(status).toBe(0);
+        expect(stdout).toContain('Name "pkg-name" (from package.json)');
+        expect(stdout).not.toContain('Name "pkg-name" (from portless.json)');
+      } finally {
+        run(["proxy", "stop"], {
+          env: {
+            PORTLESS_HTTPS: "0",
+            PORTLESS_PORT: String(proxyPort),
+            PORTLESS_STATE_DIR: stateDir,
+          },
+        });
+        fs.rmSync(stateDir, { recursive: true, force: true });
+      }
+    });
+
     it("--script flag overrides config script field", () => {
       fs.writeFileSync(
         path.join(tmpDir, "package.json"),

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -99,6 +99,11 @@ import { buildServiceUninstallSudoArgs, handleService, tryUninstallService } fro
 
 const chalk = colors;
 
+type LoadedAppConfig = {
+  config: AppConfig;
+  source: "portless.json" | "package.json";
+};
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -2593,14 +2598,17 @@ ${colors.bold("LAN mode (--lan):")}
 }
 
 /**
- * Load the effective AppConfig for the current directory from portless.json.
+ * Load the effective AppConfig for the current directory from portless config.
  * Handles both single-app (top-level fields) and monorepo (apps map) configs.
  */
-function loadAppConfig(cwd: string = process.cwd()): AppConfig | null {
+function loadAppConfig(cwd: string = process.cwd()): LoadedAppConfig | null {
   try {
     const loaded = loadConfig(cwd);
     if (!loaded) return null;
-    return resolveAppConfig(loaded.config, loaded.configDir, cwd);
+    return {
+      config: resolveAppConfig(loaded.config, loaded.configDir, cwd),
+      source: loaded.source,
+    };
   } catch (err) {
     if (err instanceof ConfigValidationError) {
       console.error(colors.red(`Error: ${err.message}`));
@@ -2650,7 +2658,7 @@ async function handleDefaultMode(
   }
 
   const appConfig = loadAppConfig(cwd);
-  const scriptName = globalScript ?? appConfig?.script ?? "dev";
+  const scriptName = globalScript ?? appConfig?.config.script ?? "dev";
   if (hasScript(scriptName, cwd)) {
     await handleDefaultSingle(cwd, scriptName, appConfig);
     return true;
@@ -2665,7 +2673,7 @@ async function handleDefaultMode(
 async function handleDefaultSingle(
   cwd: string,
   scriptName: string,
-  appConfig: AppConfig | null
+  appConfig: LoadedAppConfig | null
 ): Promise<void> {
   const resolved = resolveScriptCommand(scriptName, cwd);
   if (!resolved) {
@@ -2676,12 +2684,12 @@ async function handleDefaultSingle(
   let baseName: string;
   let nameSource: string;
 
-  if (appConfig?.name) {
-    baseName = appConfig.name
+  if (appConfig?.config.name) {
+    baseName = appConfig.config.name
       .split(".")
       .map((label) => truncateLabel(label))
       .join(".");
-    nameSource = "portless.json";
+    nameSource = appConfig.source;
   } else {
     const inferred = inferProjectName(cwd);
     baseName = inferred.name;
@@ -2705,7 +2713,7 @@ async function handleDefaultSingle(
     tld,
     false,
     { nameSource, prefix: worktree?.prefix, prefixSource: worktree?.source },
-    appConfig?.appPort,
+    appConfig?.config.appPort,
     lanMode,
     lanIp
   );
@@ -3246,7 +3254,7 @@ async function handleRunMode(args: string[], globalScript?: string): Promise<voi
   const appConfig = loadAppConfig();
 
   if (parsed.commandArgs.length === 0) {
-    const scriptName = globalScript ?? appConfig?.script ?? "dev";
+    const scriptName = globalScript ?? appConfig?.config.script ?? "dev";
     const resolved = resolveScriptCommand(scriptName, process.cwd());
     if (resolved) {
       parsed.commandArgs = resolved;
@@ -3273,20 +3281,20 @@ async function handleRunMode(args: string[], globalScript?: string): Promise<voi
       .map((label) => truncateLabel(label))
       .join(".");
     nameSource = "--name flag";
-  } else if (appConfig?.name) {
-    baseName = appConfig.name
+  } else if (appConfig?.config.name) {
+    baseName = appConfig.config.name
       .split(".")
       .map((label) => truncateLabel(label))
       .join(".");
-    nameSource = "portless.json";
+    nameSource = appConfig.source;
   } else {
     const inferred = inferProjectName();
     baseName = inferred.name;
     nameSource = inferred.source;
   }
 
-  if (!parsed.appPort && appConfig?.appPort) {
-    parsed.appPort = appConfig.appPort;
+  if (!parsed.appPort && appConfig?.config.appPort) {
+    parsed.appPort = appConfig.config.appPort;
   }
 
   const worktree = detectWorktreePrefix();
@@ -3326,8 +3334,8 @@ async function handleNamedMode(args: string[]): Promise<void> {
 
   if (!parsed.appPort) {
     const appConfig = loadAppConfig();
-    if (appConfig?.appPort) {
-      parsed.appPort = appConfig.appPort;
+    if (appConfig?.config.appPort) {
+      parsed.appPort = appConfig.config.appPort;
     }
   }
 
@@ -3499,7 +3507,7 @@ async function main() {
     let commandArgs = parsed.commandArgs;
     if (commandArgs.length === 0 && (isRunCommand || args.length === 0)) {
       const appConfig = loadAppConfig();
-      const scriptName = globalScript ?? appConfig?.script ?? "dev";
+      const scriptName = globalScript ?? appConfig?.config.script ?? "dev";
       const resolved = resolveScriptCommand(scriptName, process.cwd());
       if (resolved) commandArgs = resolved;
     }

--- a/packages/portless/src/config.test.ts
+++ b/packages/portless/src/config.test.ts
@@ -164,6 +164,7 @@ describe("loadConfig", () => {
     expect(result!.config.name).toBe("myapp");
     expect(result!.config.script).toBe("dev");
     expect(result!.configDir).toBe(tmpDir);
+    expect(result!.source).toBe("package.json");
   });
 
   it("loads string shorthand from package.json portless key", () => {
@@ -174,6 +175,7 @@ describe("loadConfig", () => {
     const result = loadConfig(tmpDir);
     expect(result).not.toBeNull();
     expect(result!.config.name).toBe("myapp");
+    expect(result!.source).toBe("package.json");
   });
 
   it("ignores empty string portless key", () => {
@@ -192,6 +194,7 @@ describe("loadConfig", () => {
     );
     const result = loadConfig(tmpDir);
     expect(result!.config.name).toBe("from-file");
+    expect(result!.source).toBe("portless.json");
   });
 
   it("ignores package.json without portless key", () => {

--- a/packages/portless/src/config.ts
+++ b/packages/portless/src/config.ts
@@ -23,6 +23,7 @@ export interface PortlessConfig extends AppConfig {
 export interface LoadedConfig {
   config: PortlessConfig;
   configDir: string;
+  source: "portless.json" | "package.json";
 }
 
 const CONFIG_FILENAME = "portless.json";
@@ -38,7 +39,7 @@ export function loadConfig(cwd: string = process.cwd()): LoadedConfig | null {
     const raw = fs.readFileSync(configPath, "utf-8");
     const parsed = JSON.parse(raw);
     validateConfig(parsed, configPath);
-    return { config: parsed, configDir: cwd };
+    return { config: parsed, configDir: cwd, source: "portless.json" };
   } catch (err) {
     if (isErrnoException(err) && err.code === "ENOENT") {
       return loadConfigFromPackageJson(cwd);
@@ -67,7 +68,7 @@ function loadConfigFromPackageJson(dir: string): LoadedConfig | null {
       const config = normalizePortlessValue(pkg.portless);
       if (config === null) return null;
       validateConfig(config, `${pkgPath} "portless"`);
-      return { config: config as PortlessConfig, configDir: dir };
+      return { config: config as PortlessConfig, configDir: dir, source: "package.json" };
     }
   } catch (err) {
     if (isErrnoException(err) && err.code === "ENOENT") return null;


### PR DESCRIPTION
## Summary
- preserve whether `loadConfig()` came from `portless.json` or the `package.json` `portless` key
- use that source when printing the auto-selected app name in default/run modes
- add regression coverage for the package.json source label

Closes #274.

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm --filter portless build`
- `pnpm --filter portless type-check`
- `pnpm --filter portless test -- src/config.test.ts src/cli.test.ts`
- `pnpm exec prettier --check packages/portless/src/config.ts packages/portless/src/config.test.ts packages/portless/src/cli.ts packages/portless/src/cli.test.ts`
- `pnpm --filter portless lint`
- `git diff --check`