### PR TITLE
feat(service): support wildcard installs

### DIFF
--- a/packages/portless/src/service.test.ts
+++ b/packages/portless/src/service.test.ts
@@ -33,10 +33,11 @@ vi.mock("./utils.js", () => ({
   fixOwnership: vi.fn(),
 }));
 
-const { existsSync, rmSync } = await import("node:fs");
+const { existsSync, rmSync, writeFileSync } = await import("node:fs");
 
 const originalPlatform = process.platform;
 const originalGetuid = process.getuid;
+const originalPortlessWildcard = process.env.PORTLESS_WILDCARD;
 
 function setPlatform(platform: NodeJS.Platform): void {
   Object.defineProperty(process, "platform", {
@@ -61,8 +62,14 @@ afterEach(() => {
     configurable: true,
     value: originalGetuid,
   });
+  if (originalPortlessWildcard === undefined) {
+    delete process.env.PORTLESS_WILDCARD;
+  } else {
+    process.env.PORTLESS_WILDCARD = originalPortlessWildcard;
+  }
   vi.mocked(existsSync).mockRestore();
   vi.mocked(rmSync).mockRestore();
+  vi.mocked(writeFileSync).mockClear();
 });
 
 describe("buildServiceSpec", () => {
@@ -198,6 +205,42 @@ describe("buildServiceSpec", () => {
     if (spec.platform !== "darwin") throw new Error("Expected macOS service spec");
     expect(spec.plist).toContain("<key>KeepAlive</key>\n  <true/>");
     expect(spec.plist).not.toContain("SuccessfulExit");
+  });
+
+  it("builds wildcard service specs for macOS, Linux, and Windows", () => {
+    const mac = buildServiceSpec({
+      platform: "darwin",
+      nodePath: "/usr/local/bin/node",
+      entryScript: "/usr/local/lib/portless/cli.js",
+      userHome: "/Users/alice",
+      useWildcard: true,
+    });
+    const linux = buildServiceSpec({
+      platform: "linux",
+      nodePath: "/usr/bin/node",
+      entryScript: "/usr/lib/portless/cli.js",
+      userHome: "/home/alice",
+      useWildcard: true,
+    });
+    const windows = buildServiceSpec({
+      platform: "win32",
+      nodePath: "C:\\nodejs\\node.exe",
+      entryScript: "C:\\cli.js",
+      userHome: "C:\\Users\\Alice",
+      useWildcard: true,
+    });
+
+    if (mac.platform !== "darwin") throw new Error("Expected macOS service spec");
+    if (linux.platform !== "linux") throw new Error("Expected Linux service spec");
+    if (windows.platform !== "win32") throw new Error("Expected Windows service spec");
+
+    expect(mac.programArguments).toContain("--wildcard");
+    expect(mac.plist).toContain("<key>PORTLESS_WILDCARD</key>");
+    expect(mac.plist).toContain("<string>1</string>");
+    expect(linux.execStart).toContain("--wildcard");
+    expect(linux.unit).toContain('Environment=PORTLESS_WILDCARD="1"');
+    expect(windows.script).toContain("--wildcard");
+    expect(windows.script).toContain('set "PORTLESS_WILDCARD=1"');
   });
 });
 
@@ -343,5 +386,60 @@ describe("handleService", () => {
 
     expect(stopIndex).toBeGreaterThanOrEqual(0);
     expect(restartIndex).toBeGreaterThan(stopIndex);
+  });
+
+  it("installs the service in wildcard mode from the --wildcard flag", async () => {
+    setPlatform("linux");
+    setGetuid(0);
+    const runner = vi.fn(() => ({ status: 0, stdout: "", stderr: "" }));
+
+    await handleService(["service", "install", "--wildcard"], {
+      entryScript: "/fake/cli.js",
+      runner,
+    });
+
+    const writtenUnit = vi
+      .mocked(writeFileSync)
+      .mock.calls.find(([file]) => file === "/etc/systemd/system/portless.service")?.[1];
+    expect(writtenUnit).toContain('"--wildcard"');
+    expect(writtenUnit).toContain('Environment=PORTLESS_WILDCARD="1"');
+  });
+
+  it("installs the service in wildcard mode from PORTLESS_WILDCARD", async () => {
+    setPlatform("linux");
+    setGetuid(0);
+    process.env.PORTLESS_WILDCARD = "1";
+    const runner = vi.fn(() => ({ status: 0, stdout: "", stderr: "" }));
+
+    await handleService(["service", "install"], {
+      entryScript: "/fake/cli.js",
+      runner,
+    });
+
+    const writtenUnit = vi
+      .mocked(writeFileSync)
+      .mock.calls.find(([file]) => file === "/etc/systemd/system/portless.service")?.[1];
+    expect(writtenUnit).toContain('"--wildcard"');
+    expect(writtenUnit).toContain('Environment=PORTLESS_WILDCARD="1"');
+  });
+
+  it("preserves --wildcard when escalating service install with sudo", async () => {
+    setPlatform("linux");
+    setGetuid(1000);
+    const runner = vi.fn((_: string, _args: string[]) => ({
+      status: 0,
+      stdout: "",
+      stderr: "",
+    }));
+
+    await expect(
+      handleService(["service", "install", "--wildcard"], {
+        entryScript: "/fake/cli.js",
+        runner,
+      })
+    ).rejects.toThrow("process.exit");
+
+    const sudoCall = runner.mock.calls.find(([command]) => command === "sudo");
+    expect(sudoCall?.[1]).toContain("--wildcard");
   });
 });

--- a/packages/portless/src/service.ts
+++ b/packages/portless/src/service.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_TLD,
   getProtocolPort,
   isProxyRunning,
+  isWildcardEnvEnabled,
 } from "./cli-utils.js";
 import { fixOwnership } from "./utils.js";
 
@@ -46,6 +47,7 @@ type ServiceContext = {
   user: UserContext;
   pathEnv: string;
   programData: string;
+  useWildcard: boolean;
 };
 
 export type ServiceSpec =
@@ -165,11 +167,12 @@ function resolveUserContext(platform: SupportedPlatform): UserContext {
   };
 }
 
-function buildProxyCommand(entryScript: string): string[] {
+function buildProxyCommand(entryScript: string, useWildcard: boolean): string[] {
   const config = buildProxyStartConfig({
     useHttps: true,
     lanMode: false,
     tld: DEFAULT_TLD,
+    useWildcard,
     foreground: true,
     includePort: true,
     proxyPort: SERVICE_PORT,
@@ -182,6 +185,9 @@ function buildServiceEnv(ctx: ServiceContext): Record<string, string> {
   const env: Record<string, string> = {
     PORTLESS_STATE_DIR: ctx.stateDir,
   };
+  if (ctx.useWildcard) {
+    env.PORTLESS_WILDCARD = "1";
+  }
 
   if (ctx.platform === "win32") {
     env.USERPROFILE = ctx.user.home;
@@ -284,6 +290,7 @@ export function buildServiceSpec(options: {
   stateDir?: string;
   pathEnv?: string;
   programData?: string;
+  useWildcard?: boolean;
 }): ServiceSpec {
   const ctx: ServiceContext = {
     platform: options.platform,
@@ -298,8 +305,9 @@ export function buildServiceSpec(options: {
     },
     pathEnv: options.pathEnv || "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
     programData: options.programData || "C:\\ProgramData",
+    useWildcard: options.useWildcard ?? false,
   };
-  const proxyCommand = buildProxyCommand(ctx.entryScript);
+  const proxyCommand = buildProxyCommand(ctx.entryScript, ctx.useWildcard);
 
   if (ctx.platform === "darwin") {
     const programArguments = [ctx.nodePath, ...proxyCommand];
@@ -357,7 +365,10 @@ export function buildServiceSpec(options: {
   };
 }
 
-function currentServiceSpec(entryScript: string): ServiceSpec {
+function currentServiceSpec(
+  entryScript: string,
+  useWildcard = isWildcardEnvEnabled()
+): ServiceSpec {
   if (!isSupportedPlatform(process.platform)) {
     throw new Error(`Unsupported platform: ${process.platform}`);
   }
@@ -374,6 +385,7 @@ function currentServiceSpec(entryScript: string): ServiceSpec {
     stateDir: process.env.PORTLESS_STATE_DIR || defaultStateDir(process.platform, user.home),
     pathEnv: process.env.PATH,
     programData: process.env.ProgramData,
+    useWildcard,
   });
 }
 
@@ -513,9 +525,16 @@ function prepareTrust(stateDir: string): void {
   console.warn(colors.yellow("Run `portless trust` if browsers show certificate warnings."));
 }
 
-async function installService(entryScript: string, runner: CommandRunner): Promise<void> {
-  requireUnixElevation([entryScript, "service", "install"], runner);
-  const spec = currentServiceSpec(entryScript);
+async function installService(
+  entryScript: string,
+  runner: CommandRunner,
+  useWildcard: boolean
+): Promise<void> {
+  requireUnixElevation(
+    [entryScript, "service", "install", ...(useWildcard ? ["--wildcard"] : [])],
+    runner
+  );
+  const spec = currentServiceSpec(entryScript, useWildcard);
   prepareTrust(spec.stateDir);
 
   if (spec.platform === "darwin") {
@@ -680,8 +699,12 @@ ${colors.bold("Usage:")}
   ${colors.cyan("portless service uninstall")}    Stop and remove the startup service
   ${colors.cyan("portless service status")}       Show service and proxy status
 
+${colors.bold("Options:")}
+  ${colors.cyan("--wildcard")}                     Allow unregistered subdomains to fall back to parent route
+
 ${colors.bold("Notes:")}
   The service uses the default clean URL mode: HTTPS on port 443.
+  Set ${colors.cyan("PORTLESS_WILDCARD=1")} or pass ${colors.cyan("--wildcard")} to install the service in wildcard mode.
   macOS and Linux install a root-owned service so port 443 can bind at boot.
   Windows installs a Task Scheduler startup task that runs as SYSTEM.
 `);
@@ -701,7 +724,8 @@ export async function handleService(
 
   try {
     if (action === "install") {
-      await installService(options.entryScript, runner);
+      const useWildcard = args.includes("--wildcard") || isWildcardEnvEnabled();
+      await installService(options.entryScript, runner, useWildcard);
       return;
     }
     if (action === "uninstall") {


### PR DESCRIPTION
## Summary
- add `--wildcard` support to `portless service install`
- persist wildcard mode in generated launchd, systemd, and Windows service environments
- preserve wildcard install intent across sudo escalation

Fixes #298.

## Verification
- `pnpm --filter portless test -- service.test.ts`
- `pnpm --filter portless type-check`
- `pnpm --filter portless lint`
- `pnpm --filter portless exec prettier --check src/service.ts src/service.test.ts`