### PR TITLE
fix(cli): probe free app ports on 127.0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ portless myapp next dev
 
 HTTPS with HTTP/2 is enabled by default. On first run, portless generates a local CA, trusts it, and binds port 443 (auto-elevates with sudo on macOS/Linux). Use `--no-tls` for plain HTTP.
 
-The proxy auto-starts when you run an app. A random port (4000-4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, VitePlus, Astro, React Router, Angular, Expo, React Native), portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag.
+The proxy auto-starts when you run an app. A random port (4000-4999) that is free on `127.0.0.1` is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, VitePlus, Astro, React Router, Angular, Expo, React Native), portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag.
 
 When auto-starting, portless reuses the configuration (port, TLS, TLD) from the most recent proxy run, so a restart or reboot does not silently revert to defaults. Explicit env vars (`PORTLESS_PORT`, `PORTLESS_HTTPS`, etc.) always take priority.
 

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -59,9 +59,27 @@ describe("findFreePort", () => {
   it("throws when no port is available in a tiny occupied range", async () => {
     // Occupy a single-port range
     const server = net.createServer();
-    await new Promise<void>((resolve) => server.listen(9999, () => resolve()));
+    await new Promise<void>((resolve) => server.listen(9999, "127.0.0.1", () => resolve()));
     try {
       await expect(findFreePort(9999, 9999)).rejects.toThrow("No free port found");
+    } finally {
+      server.close();
+    }
+  });
+
+  it("treats ports occupied on 127.0.0.1 as unavailable", async () => {
+    const server = net.createServer();
+    const port = await new Promise<number>((resolve) => {
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address();
+        if (addr && typeof addr !== "string") {
+          resolve(addr.port);
+        }
+      });
+    });
+
+    try {
+      await expect(findFreePort(port, port)).rejects.toThrow("No free port found");
     } finally {
       server.close();
     }

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -543,7 +543,7 @@ export async function findFreePort(
   const tryPort = (port: number): Promise<boolean> => {
     return new Promise((resolve) => {
       const server = net.createServer();
-      server.listen(port, () => {
+      server.listen(port, "127.0.0.1", () => {
         server.close(() => resolve(true));
       });
       server.on("error", () => resolve(false));

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -48,7 +48,7 @@ portless myapp next dev
 # -> https://myapp.localhost
 ```
 
-The proxy auto-starts when you run an app. You can also start it explicitly with `portless proxy start`. Auto-start reuses the configuration (port, TLS, TLD) from the most recent proxy run, so a restart or reboot does not silently revert to defaults. Explicit env vars always take priority.
+The proxy auto-starts when you run an app. App ports are chosen from ports that are free on `127.0.0.1`, matching the proxy upstream. You can also start the proxy explicitly with `portless proxy start`. Auto-start reuses the configuration (port, TLS, TLD) from the most recent proxy run, so a restart or reboot does not silently revert to defaults. Explicit env vars always take priority.
 
 In non-interactive environments (no TTY, or `CI=1`), portless exits with a descriptive error instead of prompting. Task runners like turborepo should pre-start the proxy.
 


### PR DESCRIPTION
## Summary
- probe candidate app ports on 127.0.0.1, matching the proxy upstream host
- add regression coverage for loopback-occupied ports
- document that auto-assigned app ports are free on 127.0.0.1

Fixes #288.

## Verification
- pnpm install
- pnpm --filter portless test -- src/cli-utils.test.ts
- pnpm --filter portless type-check
- pnpm --filter portless lint
- pnpm --filter portless build
- pnpm --filter portless test -- src/cli-utils.test.ts src/routes.test.ts src/cli.test.ts (cli.test.ts has unrelated local timeouts in bypass/NODE_EXTRA_CA_CERTS cases; cli-utils and routes passed)
- pnpm format:check -- README.md skills/portless/SKILL.md packages/portless/src/cli-utils.ts packages/portless/src/cli-utils.test.ts
