### PR TITLE
fix(cli): forward Vite flags through bun scripts

### DIFF
--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -1220,6 +1220,96 @@ describe("CLI", () => {
       expect(stdout).toContain("hello");
     });
 
+    it("portless (no args) forwards Vite port flags through bun run dev", async () => {
+      const server = http.createServer((_req, res) => {
+        res.setHeader("X-Portless", "1");
+        res.end("ok");
+      });
+      const shimDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-bun-shim-"));
+      const capturePath = path.join(shimDir, "capture.json");
+
+      try {
+        const proxyPort = await new Promise<number>((resolve) => {
+          server.listen(0, "127.0.0.1", () => {
+            const addr = server.address();
+            if (addr && typeof addr !== "string") {
+              resolve(addr.port);
+            }
+          });
+        });
+
+        fs.writeFileSync(path.join(tmpDir, "proxy.port"), proxyPort.toString());
+        fs.writeFileSync(
+          path.join(tmpDir, "package.json"),
+          JSON.stringify({
+            name: "test-app",
+            packageManager: "bun@1.3.4",
+            portless: { appPort: 4567 },
+            scripts: { dev: "vite dev --host 127.0.0.1" },
+          })
+        );
+
+        const captureScriptPath = path.join(shimDir, "capture-bun.js");
+        fs.writeFileSync(
+          captureScriptPath,
+          [
+            'const fs = require("node:fs");',
+            "const capturePath = process.env.PORTLESS_TEST_CAPTURE_FILE;",
+            "const payload = {",
+            "  args: process.argv.slice(2),",
+            "  env: {",
+            "    PORT: process.env.PORT,",
+            "    HOST: process.env.HOST,",
+            "    PORTLESS_URL: process.env.PORTLESS_URL,",
+            "  },",
+            "};",
+            "fs.writeFileSync(capturePath, JSON.stringify(payload));",
+          ].join("\n") + "\n"
+        );
+
+        if (process.platform === "win32") {
+          fs.writeFileSync(
+            path.join(shimDir, "bun.cmd"),
+            `@echo off\r\n"${process.execPath}" "${captureScriptPath}" %*\r\n`
+          );
+        } else {
+          const shimPath = path.join(shimDir, "bun");
+          fs.writeFileSync(
+            shimPath,
+            `#!/bin/sh\n"${process.execPath}" "${captureScriptPath}" "$@"\n`
+          );
+          fs.chmodSync(shimPath, 0o755);
+        }
+
+        const { status } = run([], {
+          cwd: tmpDir,
+          env: {
+            PATH: `${shimDir}${path.delimiter}${process.env.PATH ?? ""}`,
+            PORTLESS_STATE_DIR: tmpDir,
+            PORTLESS_TEST_CAPTURE_FILE: capturePath,
+            PORTLESS_HTTPS: "0",
+          },
+        });
+
+        expect(status).toBe(0);
+
+        const capture = JSON.parse(fs.readFileSync(capturePath, "utf-8")) as {
+          args: string[];
+          env: Record<string, string>;
+        };
+
+        expect(capture.args).toEqual(["run", "dev", "--port", "4567", "--strictPort"]);
+        expect(capture.env).toMatchObject({
+          PORT: "4567",
+          HOST: "127.0.0.1",
+          PORTLESS_URL: `http://test-app.localhost:${proxyPort}`,
+        });
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+        fs.rmSync(shimDir, { recursive: true, force: true });
+      }
+    });
+
     it("portless run (no command) with portless.json resolves dev script", () => {
       fs.writeFileSync(
         path.join(tmpDir, "package.json"),

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -76,6 +76,7 @@ import {
 import {
   loadConfig,
   resolveAppConfig,
+  resolveScript,
   resolveScriptCommand,
   hasScript,
   isServerCommand,
@@ -974,7 +975,8 @@ async function runApp(
   autoInfo?: { nameSource: string; prefix?: string; prefixSource?: string },
   desiredPort?: number,
   lanMode = false,
-  lanIp?: string | null
+  lanIp?: string | null,
+  scriptContext?: { scriptName: string; packageDir: string }
 ) {
   let store = initialStore;
   console.log(chalk.blue.bold(`\nportless\n`));
@@ -1168,6 +1170,7 @@ async function runApp(
   }
 
   // Inject --port for frameworks that ignore the PORT env var (e.g. Vite)
+  injectPackageScriptFrameworkFlags(commandArgs, port, scriptContext);
   injectFrameworkFlags(commandArgs, port);
 
   // Point Node.js at the portless CA so server-side fetches (e.g. Next.js
@@ -1226,6 +1229,32 @@ async function runApp(
       }
     },
   });
+}
+
+function injectPackageScriptFrameworkFlags(
+  commandArgs: string[],
+  port: number,
+  scriptContext?: { scriptName: string; packageDir: string }
+): void {
+  if (!scriptContext) return;
+
+  const [runner, runSubcommand, scriptName] = commandArgs;
+  if (runSubcommand !== "run" || scriptName !== scriptContext.scriptName) return;
+
+  const rawScript = resolveScript(scriptContext.scriptName, scriptContext.packageDir);
+  if (!rawScript) return;
+
+  const scriptWithInjectedFlags = [...rawScript];
+  injectFrameworkFlags(scriptWithInjectedFlags, port);
+  const forwardedFlags = scriptWithInjectedFlags.slice(rawScript.length);
+  if (forwardedFlags.length === 0) return;
+
+  // npm requires `--` before arguments meant for the package script.
+  // bun, pnpm, and yarn forward trailing arguments directly.
+  if (runner === "npm" && !commandArgs.includes("--")) {
+    commandArgs.push("--");
+  }
+  commandArgs.push(...forwardedFlags);
 }
 
 // ---------------------------------------------------------------------------
@@ -2707,7 +2736,8 @@ async function handleDefaultSingle(
     { nameSource, prefix: worktree?.prefix, prefixSource: worktree?.source },
     appConfig?.appPort,
     lanMode,
-    lanIp
+    lanIp,
+    { scriptName, packageDir: cwd }
   );
 }
 
@@ -3244,12 +3274,14 @@ async function handleRunMode(args: string[], globalScript?: string): Promise<voi
   const parsed = parseRunArgs(args);
 
   const appConfig = loadAppConfig();
+  let scriptContext: { scriptName: string; packageDir: string } | undefined;
 
   if (parsed.commandArgs.length === 0) {
     const scriptName = globalScript ?? appConfig?.script ?? "dev";
     const resolved = resolveScriptCommand(scriptName, process.cwd());
     if (resolved) {
       parsed.commandArgs = resolved;
+      scriptContext = { scriptName, packageDir: process.cwd() };
     }
   }
 
@@ -3308,7 +3340,8 @@ async function handleRunMode(args: string[], globalScript?: string): Promise<voi
     { nameSource, prefix: worktree?.prefix, prefixSource: worktree?.source },
     parsed.appPort,
     lanMode,
-    lanIp
+    lanIp,
+    scriptContext
   );
 }
 


### PR DESCRIPTION
## Summary

- forwards framework port flags through package-script delegation when zero-arg mode resolves to `bun run dev`
- keeps the existing package-manager execution model, but inspects the underlying script to detect Vite-style flag injection needs
- adds a regression test using a fake `bun` binary so CI does not require Bun to be installed

Fixes #285.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter portless build`
- `pnpm --filter portless type-check`
- `pnpm --filter portless lint`
- `pnpm --filter portless exec prettier --check src/cli.ts src/cli.test.ts`
- `pnpm --filter portless exec vitest run src/cli.test.ts -t "forwards Vite port flags through bun run dev"`
- `pnpm --filter portless exec vitest run src/cli.test.ts src/cli-utils.test.ts src/config.test.ts` hit one unrelated existing failure in `HTTPS proxy with broken security binary (#228)`; the new regression and `cli-utils`/`config` tests passed.
