### PR TITLE
Prefix workspace app URLs in git worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ The `apps` map is optional and only needed for name overrides. Packages not list
 
 Without an `apps` map, hostnames follow the `<package>.<project>.localhost` convention. The project name comes from the most common npm scope across workspace packages (e.g. `@myorg/web` and `@myorg/api` produce `myorg`), falling back to the workspace root directory name. If a package's short name matches the project name, it gets the bare `<project>.localhost` without duplication.
 
+In linked git worktrees, monorepo URLs also get the branch prefix. A package that normally uses `web.example.localhost` uses `fix-ui.web.example.localhost` from a `fix-ui` worktree.
+
 ### Config fields
 
 | Field     | Type    | Default  | Description                                               |
@@ -188,6 +190,9 @@ portless run next dev   # -> https://myapp.localhost
 
 # Linked worktree on branch "fix-ui"
 portless run next dev   # -> https://fix-ui.myapp.localhost
+
+# From a linked monorepo worktree
+portless                # -> https://fix-ui.web.example.localhost
 ```
 
 Use `--name` to override the inferred base name while keeping the worktree prefix:

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -67,6 +67,11 @@ function writeExpoShim(dir: string): void {
   fs.chmodSync(shimPath, 0o755);
 }
 
+function writeJson(filePath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2) + "\n");
+}
+
 async function getFreePort(): Promise<number> {
   const server = http.createServer();
   try {
@@ -926,6 +931,107 @@ describe("CLI", () => {
       });
       expect(status).toBe(0);
       expect(capture.NODE_EXTRA_CA_CERTS).toBe(userCaPath);
+    });
+  });
+
+  describe("default workspace mode", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-cli-workspace-"));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("adds the worktree prefix to inferred and overridden Turbo workspace app URLs", async () => {
+      const repoDir = path.join(tmpDir, "repo");
+      const worktreeDir = path.join(tmpDir, "issue-502");
+      const stateDir = path.join(tmpDir, "state");
+      const shimDir = path.join(tmpDir, "shim");
+      const pnpmCapturePath = path.join(shimDir, "pnpm-args.txt");
+
+      const git = (args: string[], cwd: string) => {
+        const result = spawnSync("git", args, { cwd, encoding: "utf-8" });
+        expect(result.status, `${args.join(" ")}\n${result.stderr}`).toBe(0);
+      };
+
+      const server = http.createServer((_req, res) => {
+        res.setHeader("X-Portless", "1");
+        res.end("ok");
+      });
+
+      try {
+        fs.mkdirSync(repoDir, { recursive: true });
+        writeJson(path.join(repoDir, "package.json"), {
+          private: true,
+          packageManager: "pnpm@9.15.4",
+          workspaces: ["apps/*"],
+          scripts: { dev: "turbo run dev" },
+        });
+        fs.writeFileSync(path.join(repoDir, "pnpm-workspace.yaml"), "packages:\n  - apps/*\n");
+        writeJson(path.join(repoDir, "turbo.json"), {});
+        writeJson(path.join(repoDir, "apps/web/package.json"), {
+          name: "@example/web",
+          scripts: { dev: "vite" },
+        });
+        writeJson(path.join(repoDir, "apps/admin/package.json"), {
+          name: "@example/admin",
+          scripts: { dev: "vite" },
+          portless: { name: "control" },
+        });
+
+        git(["init", "-b", "main"], repoDir);
+        git(["config", "user.email", "portless@example.test"], repoDir);
+        git(["config", "user.name", "Portless Test"], repoDir);
+        git(["add", "."], repoDir);
+        git(["commit", "-m", "init"], repoDir);
+        git(["worktree", "add", "-b", "issue-502", worktreeDir], repoDir);
+
+        fs.mkdirSync(stateDir, { recursive: true });
+        fs.mkdirSync(shimDir, { recursive: true });
+
+        const proxyPort = await new Promise<number>((resolve) => {
+          server.listen(0, "127.0.0.1", () => {
+            const addr = server.address();
+            if (addr && typeof addr !== "string") {
+              resolve(addr.port);
+            }
+          });
+        });
+        fs.writeFileSync(path.join(stateDir, "proxy.port"), proxyPort.toString());
+
+        if (process.platform === "win32") {
+          fs.writeFileSync(
+            path.join(shimDir, "pnpm.cmd"),
+            `@echo off\r\necho %* > "${pnpmCapturePath}"\r\nexit /b 0\r\n`
+          );
+        } else {
+          const pnpmShim = path.join(shimDir, "pnpm");
+          fs.writeFileSync(
+            pnpmShim,
+            `#!/bin/sh\nprintf "%s\\n" "$*" > "${pnpmCapturePath}"\nexit 0\n`
+          );
+          fs.chmodSync(pnpmShim, 0o755);
+        }
+
+        const { status, stdout } = run([], {
+          cwd: worktreeDir,
+          env: {
+            PATH: `${shimDir}${path.delimiter}${process.env.PATH ?? ""}`,
+            PORTLESS_STATE_DIR: stateDir,
+            PORTLESS_HTTPS: "0",
+          },
+        });
+
+        expect(status).toBe(0);
+        expect(stdout).toContain(`http://issue-502.web.example.localhost:${proxyPort}`);
+        expect(stdout).toContain(`http://issue-502.control.localhost:${proxyPort}`);
+        expect(fs.readFileSync(pnpmCapturePath, "utf-8").trim()).toBe("run dev");
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
     });
   });
 

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1463,6 +1463,7 @@ ${colors.bold("Usage:")}
 ${colors.bold("Examples:")}
   portless                            # Run dev script through proxy
   portless                            # From monorepo root: start all apps
+  portless                            # in worktree -> https://<worktree>.<app>.<project>.localhost
   portless --script start             # Run "start" script instead of "dev"
   portless myapp next dev             # -> https://myapp.localhost
   portless run next dev               # -> https://<project>.localhost
@@ -2921,6 +2922,7 @@ async function handleDefaultMulti(
     }
   }
 
+  const worktree = detectWorktreePrefix(wsRoot);
   const apps: MultiAppEntry[] = [];
 
   for (const pkg of packages) {
@@ -2973,6 +2975,10 @@ async function handleDefaultMulti(
       }
       name = pkgLabel === projectName ? projectName : `${pkgLabel}.${projectName}`;
       label = pkg.scope ? `@${pkg.scope}/${pkg.name}` : (pkg.name ?? rel);
+    }
+
+    if (worktree) {
+      name = `${worktree.prefix}.${name}`;
     }
 
     apps.push({ pkg, name, label, commandArgs, appPort: appOverride.appPort, proxied });

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -96,6 +96,8 @@ The `apps` map is optional and only provides name overrides. Unlisted packages a
 
 Without an `apps` map, hostnames follow `<package>.<project>.localhost`. The project name comes from the most common npm scope (e.g. `@myorg/web` and `@myorg/api` produce `myorg`), falling back to the workspace root directory name. If a package's short name matches the project name, it uses the bare `<project>.localhost`.
 
+In linked git worktrees, monorepo URLs also get the branch prefix. A package that normally uses `web.example.localhost` uses `fix-ui.web.example.localhost` from a `fix-ui` worktree.
+
 ### Turborepo
 
 For turborepo projects, use portless as the `dev` script with the real command in a separate script:
@@ -143,6 +145,9 @@ portless run next dev   # -> https://myapp.localhost
 
 # Linked worktree on branch "fix-ui"
 portless run next dev   # -> https://fix-ui.myapp.localhost
+
+# From a linked monorepo worktree
+portless                # -> https://fix-ui.web.example.localhost
 ```
 
 No config changes needed. Put `portless run` in `package.json` once and it works in all worktrees.


### PR DESCRIPTION
## Summary
I've realized this looks to be a duplicate of #270. Happy to close this out in favor of that one.

- Prefix default monorepo workspace URLs with the git worktree branch name.
- Keep existing package name inference and `portless.name` overrides intact.
- Update README, CLI help, and the portless agent skill docs for the monorepo worktree URL shape.

I've tested this via automated testing + running it for a few days via `portless` to run the `dev` command in my turborepo inside of different git worktrees at a time (which is how I originally discovered this feature was not implemented yet)

```bash
#before
# main
npx portless # web.myapp.localhost, storybook.myapp.localhost
# worktree fix-ui 
npx portless # errors due to conflict with web*, storybook*

# after
# main (same)
npx portless # web.myapp.localhost, storybook.myapp.localhost
# worktree fix-ui
npx portless # fix-ui.web.myapp.localhost, fix-ui.storybook.myapp.localhost
```

## Test

```bash
pnpm --filter portless build
pnpm --filter portless lint
pnpm --filter portless type-check
pnpm --filter portless test -- src/cli.test.ts
```