### PR TITLE
fix(windows): bypass cmd.exe 8191-char PATH limit in spawnCommand

### DIFF
--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -27,6 +27,7 @@ import {
   readPersistedProxyState,
   readTldFromDir,
   resolveStateDir,
+  resolveWindowsExecutable,
   validateTld,
   writeLanMarker,
   writeTldFile,
@@ -1005,5 +1006,193 @@ describe("readPersistedProxyState", () => {
       tld: "local",
       lanMode: true,
     });
+  });
+});
+
+describe("resolveWindowsExecutable", () => {
+  let tmpDir: string;
+  let prevPathext: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-resolve-test-"));
+    prevPathext = process.env.PATHEXT;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (prevPathext === undefined) {
+      delete process.env.PATHEXT;
+    } else {
+      process.env.PATHEXT = prevPathext;
+    }
+  });
+
+  it("returns the absolute path of an existing absolute path input", () => {
+    const file = path.join(tmpDir, "tool.exe");
+    fs.writeFileSync(file, "");
+    expect(resolveWindowsExecutable(file, "")).toBe(path.resolve(file));
+  });
+
+  it("returns null for an absolute path that does not exist", () => {
+    const missing = path.join(tmpDir, "nope.exe");
+    expect(resolveWindowsExecutable(missing, "")).toBeNull();
+  });
+
+  it("returns a path-as-given that contains a separator and exists", () => {
+    const sub = path.join(tmpDir, "sub");
+    fs.mkdirSync(sub);
+    const file = path.join(sub, "tool.cmd");
+    fs.writeFileSync(file, "");
+    // Path contains a separator but is absolute here too; the function
+    // resolves to the canonical absolute form.
+    expect(resolveWindowsExecutable(file, "")).toBe(path.resolve(file));
+  });
+
+  it("walks PATH and matches with PATHEXT extensions", () => {
+    process.env.PATHEXT = ".COM;.EXE;.BAT;.CMD";
+    const dirA = path.join(tmpDir, "a");
+    const dirB = path.join(tmpDir, "b");
+    fs.mkdirSync(dirA);
+    fs.mkdirSync(dirB);
+    const target = path.join(dirB, "tool.cmd");
+    fs.writeFileSync(target, "");
+
+    const pathStr = [dirA, dirB].join(path.delimiter);
+    expect(resolveWindowsExecutable("tool", pathStr)).toBe(target);
+  });
+
+  it("returns the first match when multiple PATH dirs hold the binary", () => {
+    process.env.PATHEXT = ".COM;.EXE;.BAT;.CMD";
+    const dirA = path.join(tmpDir, "a");
+    const dirB = path.join(tmpDir, "b");
+    fs.mkdirSync(dirA);
+    fs.mkdirSync(dirB);
+    const first = path.join(dirA, "tool.exe");
+    const second = path.join(dirB, "tool.exe");
+    fs.writeFileSync(first, "");
+    fs.writeFileSync(second, "");
+
+    const pathStr = [dirA, dirB].join(path.delimiter);
+    expect(resolveWindowsExecutable("tool", pathStr)).toBe(first);
+  });
+
+  it("respects PATHEXT priority order within a single directory", () => {
+    process.env.PATHEXT = ".COM;.EXE;.BAT;.CMD";
+    const dir = path.join(tmpDir, "a");
+    fs.mkdirSync(dir);
+    const exe = path.join(dir, "tool.exe");
+    const cmd = path.join(dir, "tool.cmd");
+    fs.writeFileSync(exe, "");
+    fs.writeFileSync(cmd, "");
+
+    // .EXE is earlier in PATHEXT than .CMD, so it should win.
+    expect(resolveWindowsExecutable("tool", dir)).toBe(exe);
+  });
+
+  it("returns null when the command is not found in any PATH dir", () => {
+    process.env.PATHEXT = ".COM;.EXE;.BAT;.CMD";
+    const dir = path.join(tmpDir, "a");
+    fs.mkdirSync(dir);
+    fs.writeFileSync(path.join(dir, "other.exe"), "");
+
+    expect(resolveWindowsExecutable("missing", dir)).toBeNull();
+  });
+
+  it("returns null when PATH is empty and the command has no separator", () => {
+    process.env.PATHEXT = ".EXE";
+    expect(resolveWindowsExecutable("anything", "")).toBeNull();
+  });
+
+  it("falls back to a default PATHEXT when the env var is unset", () => {
+    delete process.env.PATHEXT;
+    const dir = path.join(tmpDir, "a");
+    fs.mkdirSync(dir);
+    const target = path.join(dir, "tool.bat");
+    fs.writeFileSync(target, "");
+
+    expect(resolveWindowsExecutable("tool", dir)).toBe(target);
+  });
+
+  it("ignores empty directory entries in PATH", () => {
+    process.env.PATHEXT = ".EXE";
+    const dir = path.join(tmpDir, "a");
+    fs.mkdirSync(dir);
+    const target = path.join(dir, "tool.exe");
+    fs.writeFileSync(target, "");
+
+    const pathStr = ["", dir, ""].join(path.delimiter);
+    expect(resolveWindowsExecutable("tool", pathStr)).toBe(target);
+  });
+
+  it("returns null when binary exists with a non-PATHEXT extension", () => {
+    process.env.PATHEXT = ".COM;.EXE;.BAT;.CMD";
+    const dir = path.join(tmpDir, "a");
+    fs.mkdirSync(dir);
+    // Only a .foo file exists; .foo is not in PATHEXT so the walk must miss.
+    fs.writeFileSync(path.join(dir, "mybin.foo"), "");
+    expect(resolveWindowsExecutable("mybin", dir)).toBeNull();
+  });
+
+  it("treats forward-slash input as path-like and returns null when missing", () => {
+    expect(resolveWindowsExecutable("./bin/missing", "")).toBeNull();
+  });
+
+  it("treats backslash input as path-like and returns null when missing", () => {
+    expect(resolveWindowsExecutable(".\\bin\\missing", "")).toBeNull();
+  });
+
+  it("returns literal path when cmd ends with .exe", () => {
+    process.env.PATHEXT = ".COM;.EXE;.BAT;.CMD";
+    const dir = path.join(tmpDir, "bin");
+    fs.mkdirSync(dir);
+    const target = path.join(dir, "node.exe");
+    fs.writeFileSync(target, "");
+
+    expect(resolveWindowsExecutable("node.exe", dir)).toBe(target);
+  });
+
+  it("returns literal path when cmd ends with .bat", () => {
+    process.env.PATHEXT = ".COM;.EXE;.BAT;.CMD";
+    const dir = path.join(tmpDir, "bin");
+    fs.mkdirSync(dir);
+    const target = path.join(dir, "tool.bat");
+    fs.writeFileSync(target, "");
+
+    expect(resolveWindowsExecutable("tool.bat", dir)).toBe(target);
+  });
+
+  it("returns literal path when cmd ends with .cmd", () => {
+    process.env.PATHEXT = ".COM;.EXE;.BAT;.CMD";
+    const dir = path.join(tmpDir, "bin");
+    fs.mkdirSync(dir);
+    const target = path.join(dir, "script.cmd");
+    fs.writeFileSync(target, "");
+
+    expect(resolveWindowsExecutable("script.cmd", dir)).toBe(target);
+  });
+
+  it("returns literal path for non-PATHEXT extensions", () => {
+    process.env.PATHEXT = ".COM;.EXE;.BAT;.CMD";
+    const dir = path.join(tmpDir, "bin");
+    fs.mkdirSync(dir);
+    const target = path.join(dir, "myscript.py");
+    fs.writeFileSync(target, "");
+
+    // .py is not in PATHEXT, but where.exe finds it when named literally.
+    expect(resolveWindowsExecutable("myscript.py", dir)).toBe(target);
+  });
+
+  it("prefers literal over PATHEXT-appended candidate when both exist", () => {
+    process.env.PATHEXT = ".COM;.EXE;.BAT;.CMD";
+    const dir = path.join(tmpDir, "bin");
+    fs.mkdirSync(dir);
+    const literal = path.join(dir, "mytool");
+    const withExt = path.join(dir, "mytool.exe");
+    fs.writeFileSync(literal, "");
+    fs.writeFileSync(withExt, "");
+
+    // Literal name wins over any PATHEXT extension when both exist in the
+    // same directory.
+    expect(resolveWindowsExecutable("mytool", dir)).toBe(literal);
   });
 });

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -765,10 +765,59 @@ export function augmentedPath(env: NodeJS.ProcessEnv | undefined, cwd?: string):
 }
 
 /**
+ * Resolve a command name to an absolute path by walking the supplied PATH
+ * string with each PATHEXT extension (Windows). Returns null when nothing
+ * matches. Used to bypass cmd.exe PATH lookup, which silently ignores any
+ * inherited PATH longer than 8191 characters (Microsoft Learn:
+ * https://learn.microsoft.com/en-us/troubleshoot/windows-client/shell-experience/command-line-string-limitation).
+ *
+ * Absolute paths (or paths containing a separator) are returned as-is if
+ * they exist on disk, with no PATH walk. Within each PATH directory the
+ * literal command name is tried first (so commands that already include an
+ * extension such as "node.exe" or "tool.bat" resolve correctly), then each
+ * PATHEXT extension is appended in turn.
+ */
+export function resolveWindowsExecutable(
+  cmd: string,
+  pathStr: string
+): string | null {
+  if (path.isAbsolute(cmd) || cmd.includes("\\") || cmd.includes("/")) {
+    return fs.existsSync(cmd) ? path.resolve(cmd) : null;
+  }
+  const pathext = process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD";
+  const exts = pathext
+    .split(";")
+    .map((ext) => ext.toLowerCase())
+    .filter((ext) => ext.length > 0);
+  for (const dir of pathStr.split(path.delimiter)) {
+    if (dir.length === 0) continue;
+    // Try literal name first - required when cmd already has a file
+    // extension (e.g. "node.exe", "tool.bat", "script.py"). Mirrors
+    // where.exe / cmd.exe behavior.
+    const literal = path.join(dir, cmd);
+    if (fs.existsSync(literal)) return literal;
+    for (const ext of exts) {
+      const candidate = path.join(dir, cmd + ext);
+      if (fs.existsSync(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+/**
  * Spawn a command with proper signal forwarding, error handling, and exit
- * code propagation. Uses /bin/sh (Unix) or cmd.exe (Windows) so that shell
- * scripts and version manager shims are resolved. Prepends node_modules/.bin
- * to PATH so local project binaries (e.g. next, vite) are found.
+ * code propagation. Prepends node_modules/.bin to PATH so local project
+ * binaries (e.g. next, vite) are found.
+ *
+ * On Unix, runs the command under /bin/sh so shell scripts and version
+ * manager shims are resolved.
+ *
+ * On Windows, resolves the binary against the augmented PATH using
+ * resolveWindowsExecutable, then spawns it through CreateProcess. This
+ * sidesteps cmd.exe's 8191-character PATH inheritance limit and works
+ * correctly with tool managers (mise, asdf, scoop) that put many install
+ * directories on PATH. Only .cmd and .bat shims require a shell, and even
+ * then we pass the fully resolved path so cmd.exe never walks PATH itself.
  */
 export function spawnCommand(
   commandArgs: string[],
@@ -777,6 +826,11 @@ export function spawnCommand(
     onCleanup?: () => void;
   }
 ): void {
+  if (commandArgs.length === 0) {
+    console.error("spawnCommand called with empty commandArgs");
+    process.exit(1);
+  }
+
   const env: Record<string, string | undefined> = {
     ...(options?.env ?? process.env),
     PATH: augmentedPath(options?.env),
@@ -798,16 +852,50 @@ export function spawnCommand(
   // On Unix, spawn detached so the child gets its own process group. This
   // lets us kill the entire tree (shell + grandchild dev server) with a
   // single process.kill(-pid, signal) instead of only the immediate child.
-  const child = isWindows
-    ? spawn("cmd.exe", ["/d", "/s", "/c", commandArgs.join(" ")], {
+  let child: ReturnType<typeof spawn>;
+  if (isWindows) {
+    // Bypass the cmd.exe wrapper when the user command resolves to a real
+    // executable. cmd.exe ignores PATH inherited from the parent process when
+    // PATH exceeds 8191 characters (Microsoft Learn link above), which breaks
+    // common setups where a tool manager such as mise puts many install
+    // directories on PATH. By resolving the binary ourselves and spawning it
+    // through CreateProcess, we sidestep the cmd.exe limit entirely.
+    //
+    // For .cmd and .bat scripts we still need a shell (Node CVE-2024-27980
+    // forbids direct execution of these without `shell: true`), but we pass
+    // the FULLY RESOLVED path to cmd.exe so cmd does not need to walk PATH
+    // itself and never hits the 8191-character limit.
+    const resolved = resolveWindowsExecutable(commandArgs[0]!, env.PATH ?? "");
+    if (resolved === null) {
+      console.error(`Failed to run command: "${commandArgs[0]}" not found in PATH`);
+      console.error(`Is "${commandArgs[0]}" installed and in your PATH?`);
+      process.exit(1);
+    }
+    const ext = path.extname(resolved).toLowerCase();
+    if (ext === ".cmd" || ext === ".bat") {
+      const tail = commandArgs
+        .slice(1)
+        .map((arg) => (/[\s"&|<>^()]/.test(arg) ? `"${arg.replace(/"/g, '\\"')}"` : arg))
+        .join(" ");
+      const cmdline = tail.length > 0 ? `"${resolved}" ${tail}` : `"${resolved}"`;
+      child = spawn("cmd.exe", ["/d", "/s", "/c", cmdline], {
         stdio: "inherit",
         env,
-      })
-    : spawn("/bin/sh", ["-c", commandArgs.map(shellEscape).join(" ")], {
-        stdio: "inherit",
-        env,
-        detached: true,
+        windowsVerbatimArguments: true,
       });
+    } else {
+      child = spawn(resolved, commandArgs.slice(1), {
+        stdio: "inherit",
+        env,
+      });
+    }
+  } else {
+    child = spawn("/bin/sh", ["-c", commandArgs.map(shellEscape).join(" ")], {
+      stdio: "inherit",
+      env,
+      detached: true,
+    });
+  }
 
   let exiting = false;
 


### PR DESCRIPTION
## Summary

Resolves the Windows failure mode where `portless run <name> <command>` exits with `'<command>' is not recognized as an internal or external command, operable program or batch file.` whenever the inherited `PATH` exceeds 8191 characters. The fault is documented Windows behavior, not a portless or Node bug: cmd.exe silently discards inherited `PATH` longer than its 8191-character parsing limit, so the PATH lookup performed by `cmd.exe /d /s /c "<command>"` fails even when the executable exists on `PATH`.

`augmentedPath` already prepends `node_modules/.bin` entries correctly, but the cmd.exe wrapper around the user command erases that work the moment `PATH` crosses the limit.

Fixes #305.

Reference: [Microsoft Learn — Command prompt line string limitation](https://learn.microsoft.com/en-us/troubleshoot/windows-client/shell-experience/command-line-string-limitation).

## Repro

1. On Windows, get `PATH` past 8191 characters. Tool managers such as mise or asdf with many tools installed trigger this naturally; a single test PowerShell session with `$env:Path` re-assigned to a long string also reproduces.

2. Create any Node project with a local binary in `node_modules/.bin` (e.g. `next`, `vite`, `nest`, `mastra`).

3. Run:

   ```pwsh
   portless run myapp next dev
   ```

4. Observe portless print proxy startup, hostname registration, and the `Running: ... next dev` line, then exit immediately with `'next' is not recognized`.

## Fix

`packages/portless/src/cli-utils.ts` (one source file changed, Unix branch untouched):

- Add a small helper `resolveWindowsExecutable(cmd, pathStr)` that walks the augmented `PATH` and the values in `process.env.PATHEXT` to find an absolute path for the user command. Within each PATH directory the literal command name is tried first (so commands that already include an extension such as `node.exe` or `tool.bat` resolve correctly), then each PATHEXT extension is appended in turn. Mirrors `where.exe` / `cmd.exe` behavior. Falls back to the input when the command is already absolute or contains a separator. Returns `null` when nothing matches.

- Rewrite the Windows branch of `spawnCommand` to:
  1. Resolve the command via `resolveWindowsExecutable`. If unresolved, print the same `not in PATH` error as before and exit with code 1.
  2. For `.exe` and `.com` targets, spawn the resolved path directly through `child_process.spawn(resolved, args, { env })`. No shell, no `cmd.exe`. `CreateProcess` honors `env.PATH` without the 8191 limit.
  3. For `.cmd` and `.bat` targets, which require a shell per [Node CVE-2024-27980](https://nodejs.org/en/blog/vulnerability/april-2024-security-releases), continue to use `cmd.exe /d /s /c`, but pass the FULL resolved path as the first token so cmd never walks `PATH` itself. Argument quoting is preserved through `windowsVerbatimArguments: true`.

The Unix branch (`/bin/sh -c`) is unchanged. Signal forwarding, `child.on('error')`, `child.on('exit')`, and the existing case-sensitivity cleanup of `Path` vs `PATH` keys are unchanged. The change is local to a single function plus one new helper.

## Why not just shorten PATH

Shortening PATH is a workaround that pushes the cost onto every Windows user who relies on a tool manager. The fix above eliminates the dependency on cmd.exe parsing the inherited `PATH` at all, which is the correct boundary: portless already knows the resolved binary path the moment it walks `node_modules/.bin`, so spawning it directly is both safer and faster.

## Why not `shell: true`

`spawn(cmd, args, { shell: true })` on Windows is internally equivalent to `cmd.exe /d /s /c`, so it triggers the same 8191 ceiling. Direct `CreateProcess` is the only way to bypass it.

## Test

```bash
pnpm install
pnpm --filter portless type-check
pnpm --filter portless lint
pnpm --filter portless test -- --run cli-utils
```

Unit tests added (18 new in `packages/portless/src/cli-utils.test.ts`, all platform-agnostic):

- Returns absolute path when input is an existing absolute path
- Returns `null` for non-existent absolute path
- Returns canonical absolute path when input contains a separator and exists
- Walks PATH and matches with PATHEXT extensions
- Returns the first matching directory when multiple PATH dirs hold the binary
- Respects PATHEXT priority within a single directory
- Returns `null` when command is not found in any PATH dir
- Returns `null` when PATH is empty and command has no separator
- Falls back to default PATHEXT when env var is unset
- Ignores empty entries in PATH
- Returns `null` when binary exists with a non-PATHEXT extension (bare-name lookup)
- Treats forward-slash input as path-like and returns `null` when missing
- Treats backslash input as path-like and returns `null` when missing
- Returns literal path when cmd ends with `.exe`
- Returns literal path when cmd ends with `.bat`
- Returns literal path when cmd ends with `.cmd`
- Returns literal path for non-PATHEXT extensions (e.g. `.py`)
- Prefers literal over PATHEXT-appended candidate when both exist

Final test count for `cli-utils.test.ts`: 119 passing (101 existing + 18 new).

Real-world validation against three dev chains, identical environment, only the patch applied:

| Chain                     | Before                            | After                                |
| ------------------------- | --------------------------------- | ------------------------------------ |
| `portless run mastra dev` | `'mastra' not recognized` exit 1  | `mastra 1.9.3 ready in 3764 ms`      |
| `portless run next dev`   | `'next' not recognized` exit 1    | `Next.js 16.2.6 Ready in 6.9s`       |
| `portless run nest`       | `'nest' not recognized` exit 1    | `nest start --watch` watching        |

`PATH` length unchanged at 8476 characters across all runs.

## Docs

No `README`, `SKILL.md`, or CLI `--help` change is necessary. The function signature and external behavior of `portless run` are unchanged. Only the internal spawn strategy for Windows differs, and the change is invisible to users beyond the bug going away.

## Notes

The patch was first validated by editing the compiled `dist/cli.js` shipped to a local install of `portless@0.13.0`. After confirming the three chains above came up cleanly, the change was forward-ported to the TypeScript source on top of `main` (commit `d564c2c`).

Happy to provide a seed script that pads `PATH` past 8191 characters with junk install directories so the bug reproduces deterministically on the AWS SSM debug instance documented in `AGENTS.md` if it would help reviewers.