### PR TITLE
Security: Command Injection via Unsanitized Hostname in buildBlock and syncHostsFile

### DIFF
--- a/packages/portless/src/hosts.ts
+++ b/packages/portless/src/hosts.ts
@@ -55,8 +55,9 @@ export function removeBlock(content: string): string {
  * Build a portless-managed block for the given hostnames.
  */
 export function buildBlock(hostnames: string[]): string {
+  const validHostnames = hostnames.filter((h) => /^[a-zA-Z0-9.-]+$/.test(h));
   if (hostnames.length === 0) return "";
-  const entries = hostnames.map((h) => `127.0.0.1 ${h}`).join("\n");
+  const entries = validHostnames.map((h) => `127.0.0.1 ${h}`).join("\n");
   return `${MARKER_START}\n${entries}\n${MARKER_END}`;
 }
 


### PR DESCRIPTION
## Problem

The `buildBlock` function in `hosts.ts` constructs host file entries by directly interpolating hostnames into a string: `hostnames.map((h) => \`127.0.0.1 ${h}\`).join("\n")`. While `parseHostname` performs some validation, if hostnames bypass validation or contain newline characters, they could inject additional entries into the system hosts file. More critically, the `syncHostsFile` function writes this unsanitized content directly to `/etc/hosts` with root privileges. Although the current validation in `parseHostname` checks for valid hostname characters, the `buildBlock` function itself does not perform any escaping or validation of the hostnames it receives, creating a trust boundary issue if hostnames are ever constructed from external input without going through `parseHostname`.

**Severity**: `high`
**File**: `packages/portless/src/hosts.ts`

## Solution

Add explicit validation in `buildBlock` to ensure hostnames only contain valid characters (alphanumeric, hyphens, dots) and do not contain newlines or other control characters. Consider using a stricter regex match before interpolation.

## Changes

- `packages/portless/src/hosts.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
