### PR TITLE
feat(tailscale): add Service sharing mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,16 @@ portless myapp --tailscale next dev     # -> https://devbox.ts.net
 portless api --tailscale pnpm start     # -> https://devbox.ts.net:8443
 ```
 
+Use `--tailscale-service` to share through a [Tailscale Service](https://tailscale.com/docs/features/tailscale-services) with a stable Service MagicDNS name. The Service name defaults to the same inferred base name as the local route:
+
+```bash
+portless os --tailscale-service --app-port 3000 -- pnpm --filter os-web-app dev:app
+# -> https://os.localhost                (local)
+# -> https://os.yourteam.ts.net          (tailnet)
+```
+
+Service mode always advertises HTTPS on the Service's port 443, so multiple apps can use clean names without rotating `:8443` style ports. Use `--tailscale-service=<name>` when the Service name should differ from the app name. The Service must already exist in Tailscale, this device must use a tag-based identity, and an admin may need to approve the host advertisement in the Tailscale admin console. When approval is required, portless prints the Service URL as pending because MagicDNS will not resolve it until the Service host is approved. Service mode cannot be combined with `--funnel`.
+
 Use `--funnel` to expose your dev server to the public internet via [Tailscale Funnel](https://tailscale.com/kb/1223/funnel/):
 
 ```bash
@@ -314,7 +324,7 @@ portless myapp --funnel next dev
 
 Tailscale HTTPS certificates must be enabled before `--tailscale` or `--funnel` can register HTTPS URLs. Funnel must also be enabled for the tailnet and node before `--funnel` can register the public URL. If either setting is missing, portless exits before starting the child process.
 
-Set `PORTLESS_TAILSCALE=1` in your shell profile or `.env` to share every app by default. `portless list` shows both local and tailnet URLs. Tailscale serve registrations are cleaned up automatically when the app exits.
+Set `PORTLESS_TAILSCALE=1` in your shell profile or `.env` to share every app by default. Set `PORTLESS_TAILSCALE_SERVICE=1` in a package script or local env file to use inferred Service names without repeating the flag, or set `PORTLESS_TAILSCALE_SERVICE=<name>` to use a specific Service name. `portless list` shows both local and tailnet URLs. Tailscale serve registrations are cleaned up automatically when the app exits.
 
 Requires the Tailscale CLI to be installed and connected (`tailscale up`), with Tailscale HTTPS certificates enabled.
 
@@ -369,6 +379,7 @@ portless service uninstall       # Remove the startup service
 --script <name>                  Run a specific package.json script (default: dev)
 --app-port <number>              Use a fixed port for the app (skip auto-assignment)
 --tailscale                      Share the app on your Tailscale network (tailnet)
+--tailscale-service[=<name>]     Share the app through a Tailscale Service
 --funnel                         Share the app publicly via Tailscale Funnel
 --force                          Kill the existing process and take over its route
 --name <name>                    Use <name> as the app name
@@ -386,6 +397,10 @@ PORTLESS_TLD=<tld>               Use a custom TLD (e.g. test; default: localhost
 PORTLESS_WILDCARD=1              Allow unregistered subdomains to fall back to parent route
 PORTLESS_SYNC_HOSTS=0            Disable auto-sync of /etc/hosts (on by default)
 PORTLESS_TAILSCALE=1             Share apps on your Tailscale network (same as --tailscale)
+PORTLESS_TAILSCALE_SERVICE=1
+                                  Share apps on your Tailscale network with inferred Service hostnames and no port
+PORTLESS_TAILSCALE_SERVICE=<name>
+                                  Share apps on your Tailscale network with a specific Service hostname and no port
 PORTLESS_FUNNEL=1                Share apps publicly via Tailscale Funnel (same as --funnel)
 PORTLESS_STATE_DIR=<path>        Override the state directory
 

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -1370,8 +1370,10 @@ describe("CLI", () => {
       const { status, stdout } = run(["--help"]);
       expect(status).toBe(0);
       expect(stdout).toContain("--tailscale");
+      expect(stdout).toContain("--tailscale-service[=<name>]");
       expect(stdout).toContain("--funnel");
       expect(stdout).toContain("PORTLESS_TAILSCALE");
+      expect(stdout).toContain("PORTLESS_TAILSCALE_SERVICE");
     });
 
     it("fails with actionable message when tailscale is not installed", () => {
@@ -1385,6 +1387,44 @@ describe("CLI", () => {
     it("fails with --funnel when tailscale is not installed", () => {
       const { status, stderr } = run(["--funnel", "myapp", "echo", "hello"], {
         env: { PATH: "/tmp/portless-no-ts-path" },
+      });
+      expect(status).toBe(1);
+      expect(stderr).toContain("Tailscale");
+    });
+
+    it("fails with --tailscale-service when tailscale is not installed", () => {
+      const { status, stderr } = run(["myapp", "--tailscale-service", "echo", "hello"], {
+        env: { PATH: "/tmp/portless-no-ts-path" },
+      });
+      expect(status).toBe(1);
+      expect(stderr).toContain("Tailscale");
+    });
+
+    it("accepts --tailscale-service=<name> override syntax", () => {
+      const { status, stderr } = run(["myapp", "--tailscale-service=os", "echo", "hello"], {
+        env: { PATH: "/tmp/portless-no-ts-path" },
+      });
+      expect(status).toBe(1);
+      expect(stderr).toContain("Tailscale");
+    });
+
+    it("rejects an empty --tailscale-service= override", () => {
+      const { status, stderr } = run(["--tailscale-service="]);
+      expect(status).toBe(1);
+      expect(stderr).toContain("--tailscale-service= requires a service name");
+    });
+
+    it("rejects invalid PORTLESS_TAILSCALE_SERVICE values before tailscale preflight", () => {
+      const { status, stderr } = run(["myapp", "echo", "hello"], {
+        env: { PORTLESS_TAILSCALE_SERVICE: "bad.name" },
+      });
+      expect(status).toBe(1);
+      expect(stderr).toContain("Invalid Tailscale Service name");
+    });
+
+    it("accepts PORTLESS_TAILSCALE_SERVICE=1 as inferred service mode", () => {
+      const { status, stderr } = run(["myapp", "echo", "hello"], {
+        env: { PORTLESS_TAILSCALE_SERVICE: "1", PATH: "/tmp/portless-no-ts-path" },
       });
       expect(status).toBe(1);
       expect(stderr).toContain("Tailscale");
@@ -1411,6 +1451,21 @@ describe("CLI", () => {
       try {
         fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ name: "test-app" }));
         const { status, stderr } = run(["run", "--tailscale", "echo", "hello"], {
+          cwd: tmpDir,
+          env: { PATH: "/tmp/portless-no-ts-path" },
+        });
+        expect(status).toBe(1);
+        expect(stderr).toContain("Tailscale");
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("accepts --tailscale-service in run subcommand", () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-cli-ts-service-run-"));
+      try {
+        fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ name: "test-app" }));
+        const { status, stderr } = run(["run", "--tailscale-service", "echo", "hello"], {
           cwd: tmpDir,
           env: { PATH: "/tmp/portless-no-ts-path" },
         });

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -15,12 +15,16 @@ import { FILE_MODE, RouteConflictError, RouteStore } from "./routes.js";
 import {
   ensureTailscaleReady,
   findAvailableServePort,
+  formatTailscaleServiceUrl,
   formatTailscaleUrl,
   getUsedServePorts,
+  normalizeServiceName,
   registerFunnel,
   registerServe,
+  registerTailscaleService,
   unregisterTailscale,
 } from "./tailscale.js";
+import type { TailscaleServiceName } from "./tailscale.js";
 import {
   inferProjectName,
   detectWorktreePrefix,
@@ -812,7 +816,11 @@ function listRoutes(store: RouteStore, proxyPort: number, tls: boolean): void {
       `  ${colors.cyan(url)}  ${colors.gray("->")}  ${colors.white(`localhost:${route.port}`)}  ${colors.gray(label)}`
     );
     if (route.tailscaleUrl) {
-      const tsLabel = route.tailscaleFunnel ? "funnel" : "tailscale";
+      const tsLabel = route.tailscaleServiceName
+        ? "tailscale service"
+        : route.tailscaleFunnel
+          ? "funnel"
+          : "tailscale";
       console.log(`    ${colors.gray(tsLabel + ":")} ${colors.green(route.tailscaleUrl)}`);
     }
   }
@@ -982,25 +990,51 @@ async function runApp(
   // Check tailscale readiness early, before auto-starting the proxy.
   // No point starting the proxy if tailscale will fail afterward.
   const wantsFunnel = process.env.PORTLESS_FUNNEL === "1" || process.env.PORTLESS_FUNNEL === "true";
+  const serviceNameFromEnv = tailscaleServiceNameForApp(name, autoInfo);
+  let tailscaleService: TailscaleServiceName | undefined;
+  if (serviceNameFromEnv) {
+    try {
+      tailscaleService = normalizeServiceName(serviceNameFromEnv);
+    } catch (err) {
+      console.error(colors.red(`Error: ${(err as Error).message}`));
+      process.exit(1);
+    }
+  }
   const wantsTailscale =
+    Boolean(tailscaleService) ||
     wantsFunnel ||
     process.env.PORTLESS_TAILSCALE === "1" ||
     process.env.PORTLESS_TAILSCALE === "true";
   let tsBaseUrl: string | undefined;
+  let tsMagicDnsSuffix: string | undefined;
 
   if (wantsTailscale) {
+    if (wantsFunnel && tailscaleService) {
+      console.error(colors.red("Error: --funnel cannot be combined with --tailscale-service."));
+      console.error(
+        colors.blue(
+          "Use --tailscale-service for tailnet-only sharing or --funnel for public sharing."
+        )
+      );
+      process.exit(1);
+    }
     try {
       const tsReady = ensureTailscaleReady({
         requireFunnel: wantsFunnel,
         requireHttps: true,
+        requireServiceHost: Boolean(tailscaleService),
       });
       tsBaseUrl = tsReady.baseUrl;
+      tsMagicDnsSuffix = tsReady.magicDnsSuffix;
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       console.error(colors.red(`Error: ${message}`));
       if (message.includes("not found")) {
         console.error(colors.blue("Install Tailscale: https://tailscale.com/download"));
-      } else if (!message.includes("not enabled on your tailnet")) {
+      } else if (
+        !message.includes("not enabled on your tailnet") &&
+        !message.includes("tag-based identity")
+      ) {
         console.error(colors.blue("Make sure Tailscale is connected:"));
         console.error(colors.cyan("  tailscale up"));
       }
@@ -1108,35 +1142,67 @@ async function runApp(
   // Readiness was already checked at the top of runApp().
   let tailscaleHttpsPort: number | undefined;
   let tailscaleUrl: string | undefined;
+  let tailscaleServiceApprovalRequired = false;
 
   if (wantsTailscale && tsBaseUrl) {
-    const maxAttempts = 3;
-    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      const usedPorts = getUsedServePorts();
-      tailscaleHttpsPort = findAvailableServePort(usedPorts, wantsFunnel ? "funnel" : "serve");
+    if (tailscaleService) {
+      tailscaleHttpsPort = 443;
       try {
-        if (wantsFunnel) {
-          registerFunnel(port, tailscaleHttpsPort);
-        } else {
-          registerServe(port, tailscaleHttpsPort);
-        }
-        break;
+        tailscaleServiceApprovalRequired = registerTailscaleService(
+          tailscaleService,
+          port,
+          tailscaleHttpsPort
+        );
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err);
-        const isConflict = message.includes("already in use");
-        if (isConflict && attempt < maxAttempts) continue;
         console.error(colors.red(`Error: ${message}`));
         process.exit(1);
       }
+      tailscaleUrl = formatTailscaleServiceUrl(tailscaleService.displayName, tsMagicDnsSuffix!);
+    } else {
+      const maxAttempts = 3;
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        const usedPorts = getUsedServePorts();
+        tailscaleHttpsPort = findAvailableServePort(usedPorts, wantsFunnel ? "funnel" : "serve");
+        try {
+          if (wantsFunnel) {
+            registerFunnel(port, tailscaleHttpsPort);
+          } else {
+            registerServe(port, tailscaleHttpsPort);
+          }
+          break;
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          const isConflict = message.includes("already in use");
+          if (isConflict && attempt < maxAttempts) continue;
+          console.error(colors.red(`Error: ${message}`));
+          process.exit(1);
+        }
+      }
+      tailscaleUrl = formatTailscaleUrl(tsBaseUrl, tailscaleHttpsPort!);
     }
 
     // tailscaleHttpsPort is always assigned: the loop either breaks after
     // a successful register or exits the process on final failure.
-    tailscaleUrl = formatTailscaleUrl(tsBaseUrl, tailscaleHttpsPort!);
-    const label = wantsFunnel ? "Funnel (public)" : "Tailscale";
+    const label = tailscaleService
+      ? "Tailscale Service"
+      : wantsFunnel
+        ? "Funnel (public)"
+        : "Tailscale";
     console.log(chalk.green(`  ${label} -> ${tailscaleUrl}`));
     if (wantsFunnel) {
       console.log(chalk.gray("  (accessible from the public internet via Tailscale Funnel)\n"));
+    } else if (tailscaleServiceApprovalRequired) {
+      console.log(
+        chalk.yellow("  (pending admin approval in Tailscale; DNS will not resolve yet)")
+      );
+      console.log(
+        chalk.gray(
+          `  Define or approve ${tailscaleService?.serviceId ?? "the service"} at https://login.tailscale.com/admin/services\n`
+        )
+      );
+    } else if (tailscaleService) {
+      console.log(chalk.gray("  (accessible from your tailnet via its Service name)\n"));
     } else {
       console.log(chalk.gray("  (accessible from your tailnet)\n"));
     }
@@ -1146,6 +1212,8 @@ async function runApp(
         tailscaleUrl: tailscaleUrl,
         tailscaleHttpsPort,
         tailscaleFunnel: wantsFunnel || undefined,
+        tailscaleServiceId: tailscaleService?.serviceId,
+        tailscaleServiceName: tailscaleService?.displayName,
       });
     } catch {
       // Non-fatal: route display metadata only
@@ -1215,6 +1283,7 @@ async function runApp(
         unregisterTailscale({
           tailscaleHttpsPort,
           tailscaleFunnel: wantsFunnel || undefined,
+          tailscaleServiceId: tailscaleService?.serviceId,
         });
       } catch {
         // Best-effort cleanup; non-fatal
@@ -1284,6 +1353,54 @@ function applyTailscaleFlag(flag: string): boolean {
   return false;
 }
 
+function baseServiceNameForApp(
+  name: string,
+  autoInfo?: { nameSource: string; prefix?: string; prefixSource?: string }
+): string {
+  if (!autoInfo?.prefix) return name;
+  const prefix = `${autoInfo.prefix}.`;
+  return name.startsWith(prefix) ? name.slice(prefix.length) : name;
+}
+
+function tailscaleServiceNameForApp(
+  name: string,
+  autoInfo?: { nameSource: string; prefix?: string; prefixSource?: string }
+): string | undefined {
+  const inferredName = baseServiceNameForApp(name, autoInfo);
+  const serviceName = process.env.PORTLESS_TAILSCALE_SERVICE?.trim();
+  if (!serviceName || serviceName === "0" || serviceName.toLowerCase() === "false")
+    return undefined;
+  if (serviceName === "1" || serviceName.toLowerCase() === "true") return inferredName;
+  return serviceName;
+}
+
+function applyTailscaleServiceFlag(value?: string): void {
+  const serviceName = value?.trim();
+  if (serviceName === "") {
+    console.error(colors.red("Error: --tailscale-service= requires a service name."));
+    console.error(colors.cyan("  portless --tailscale-service=<name> <app> <command...>"));
+    process.exit(1);
+  }
+  if (serviceName) {
+    process.env.PORTLESS_TAILSCALE_SERVICE = serviceName;
+  } else {
+    process.env.PORTLESS_TAILSCALE_SERVICE = "1";
+  }
+}
+
+function applyTailscaleServiceArg(arg: string): boolean {
+  const prefix = "--tailscale-service=";
+  if (arg.startsWith(prefix)) {
+    applyTailscaleServiceFlag(arg.slice(prefix.length));
+    return true;
+  }
+  if (arg === "--tailscale-service") {
+    applyTailscaleServiceFlag();
+    return true;
+  }
+  return false;
+}
+
 /**
  * Parse `run` subcommand arguments: `[--name <name>] [--force] [--] <command...>`
  *
@@ -1315,6 +1432,9 @@ ${colors.bold("Options:")}
   --name <name>          Override the inferred base name (worktree prefix still applies)
   --force                Kill the existing process and take over its route
   --app-port <number>    Use a fixed port for the app (skip auto-assignment)
+  --tailscale-service[=<name>]
+                        Share via a Tailscale Service name
+                        Defaults to the inferred base name
   --help, -h             Show this help
 
 ${colors.bold("Name inference (in order):")}
@@ -1333,6 +1453,8 @@ ${colors.bold("Examples:")}
   portless run --name myapp next dev  # -> https://myapp.localhost
   portless run vite dev               # -> https://<project>.localhost
   portless run --app-port 3000 pnpm start
+  portless run --tailscale-service next dev
+  portless run --tailscale-service=api next dev
 `);
       process.exit(0);
     } else if (args[i] === "--force") {
@@ -1340,6 +1462,8 @@ ${colors.bold("Examples:")}
     } else if (args[i] === "--app-port") {
       i++;
       appPort = parseAppPort(args[i]);
+    } else if (applyTailscaleServiceArg(args[i])) {
+      // handled
     } else if (args[i] === "--name") {
       i++;
       if (!args[i] || args[i].startsWith("-")) {
@@ -1353,7 +1477,9 @@ ${colors.bold("Examples:")}
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
       console.error(
-        colors.blue("Known flags: --name, --force, --app-port, --tailscale, --funnel, --help")
+        colors.blue(
+          "Known flags: --name, --force, --app-port, --tailscale, --tailscale-service, --funnel, --help"
+        )
       );
       process.exit(1);
     }
@@ -1387,11 +1513,15 @@ function parseAppArgs(args: string[]): ParsedAppArgs {
     } else if (args[i] === "--app-port") {
       i++;
       appPort = parseAppPort(args[i]);
+    } else if (applyTailscaleServiceArg(args[i])) {
+      // handled
     } else if (applyTailscaleFlag(args[i])) {
       // handled
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
-      console.error(colors.blue("Known flags: --force, --app-port, --tailscale, --funnel"));
+      console.error(
+        colors.blue("Known flags: --force, --app-port, --tailscale, --tailscale-service, --funnel")
+      );
       process.exit(1);
     }
     i++;
@@ -1411,11 +1541,15 @@ function parseAppArgs(args: string[]): ParsedAppArgs {
     } else if (args[i] === "--app-port") {
       i++;
       appPort = parseAppPort(args[i]);
+    } else if (applyTailscaleServiceArg(args[i])) {
+      // handled
     } else if (applyTailscaleFlag(args[i])) {
       // handled
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
-      console.error(colors.blue("Known flags: --force, --app-port, --tailscale, --funnel"));
+      console.error(
+        colors.blue("Known flags: --force, --app-port, --tailscale, --tailscale-service, --funnel")
+      );
       process.exit(1);
     }
     i++;
@@ -1473,6 +1607,8 @@ ${colors.bold("Examples:")}
   portless service install            # Start HTTPS proxy on OS startup
   portless get backend                # -> https://backend.localhost
   portless myapp --tailscale next dev # -> also https://<node>.ts.net (tailnet)
+  portless myapp --tailscale-service next dev
+                                      # -> also https://myapp.<tailnet>.ts.net
   portless myapp --funnel next dev    # -> also https://<node>.ts.net (public)
 
 ${colors.bold("Configuration (portless.json):")}
@@ -1528,11 +1664,19 @@ ${colors.bold("Tailscale sharing:")}
   Use --tailscale to share your dev server with teammates on your tailnet.
   Each app is root-mounted on its own Tailscale HTTPS port (443, then 8443,
   8444, etc.) so no basePath configuration is needed.
+  Use --tailscale-service to share through a Tailscale Service at
+  https://<name>.<tailnet>. The Service name defaults to the inferred base
+  name. Use --tailscale-service=<name> to override it. The Service must
+  already exist, this device must use a tag-based identity, and an admin
+  may need to approve the host advertisement in the Tailscale admin console.
+  When approval is required, MagicDNS will not resolve the Service name yet.
   Use --funnel to expose your dev server to the public internet via
   Tailscale Funnel. Requires Tailscale CLI to be installed and connected,
   with Tailscale HTTPS certificates enabled. Funnel must also be enabled
   on your tailnet.
   ${colors.cyan("portless myapp --tailscale next dev")}
+  ${colors.cyan("portless myapp --tailscale-service next dev")}
+  ${colors.cyan("portless myapp --tailscale-service=api next dev")}
   ${colors.cyan("portless myapp --funnel next dev")}
 
 ${colors.bold("Options:")}
@@ -1552,6 +1696,7 @@ ${colors.bold("Options:")}
   --wildcard                    Allow unregistered subdomains to fall back to parent route
   --app-port <number>           Use a fixed port for the app (skip auto-assignment)
   --tailscale                   Share the app on your Tailscale network (tailnet)
+  --tailscale-service[=<name>]  Share the app through a Tailscale Service
   --funnel                      Share the app publicly via Tailscale Funnel
   --force                       Kill the existing process and take over its route
   --name <name>                 Use <name> as the app name (bypasses subcommand dispatch)
@@ -1566,6 +1711,10 @@ ${colors.bold("Environment variables:")}
   PORTLESS_WILDCARD=1           Allow unregistered subdomains to fall back to parent route
   PORTLESS_SYNC_HOSTS=0         Disable auto-sync of ${HOSTS_DISPLAY} (on by default)
   PORTLESS_TAILSCALE=1          Share apps on your Tailscale network (same as --tailscale)
+  PORTLESS_TAILSCALE_SERVICE=1
+                                Share apps through inferred Tailscale Service names
+  PORTLESS_TAILSCALE_SERVICE=<name>
+                                Share apps through a specific Tailscale Service
   PORTLESS_FUNNEL=1             Share apps publicly via Tailscale Funnel (same as --funnel)
   PORTLESS_STATE_DIR=<path>     Override the state directory
   PORTLESS=0                    Run command directly without proxy
@@ -1713,7 +1862,11 @@ ${colors.bold("Options:")}
     if (route.tailscaleHttpsPort) {
       try {
         unregisterTailscale(route);
-        console.log(colors.green(`Removed tailscale serve on port ${route.tailscaleHttpsPort}.`));
+        if (route.tailscaleServiceId) {
+          console.log(colors.green(`Removed tailscale service ${route.tailscaleServiceId}.`));
+        } else {
+          console.log(colors.green(`Removed tailscale serve on port ${route.tailscaleHttpsPort}.`));
+        }
       } catch {
         // Tailscale may not be installed; non-fatal
       }
@@ -1800,9 +1953,10 @@ ${colors.bold("Options:")}
     if (route.tailscaleHttpsPort) {
       try {
         unregisterTailscale(route);
-        console.log(
-          `  ${route.hostname} - removed tailscale serve on port ${route.tailscaleHttpsPort}`
-        );
+        const removed = route.tailscaleServiceId
+          ? `removed tailscale service ${route.tailscaleServiceId}`
+          : `removed tailscale serve on port ${route.tailscaleHttpsPort}`;
+        console.log(`  ${route.hostname} - ${removed}`);
       } catch {
         // Tailscale CLI may not be installed; non-fatal during prune
       }
@@ -3415,6 +3569,17 @@ async function main() {
     return value;
   };
 
+  const stripGlobalEqualsFlag = (flag: string): string | null => {
+    const sep = args.indexOf("--");
+    const end = sep === -1 ? args.length : sep;
+    const prefix = `${flag}=`;
+    const idx = args.findIndex((arg, index) => index < end && arg.startsWith(prefix));
+    if (idx === -1) return null;
+    const value = args[idx].slice(prefix.length);
+    args.splice(idx, 1);
+    return value;
+  };
+
   if (stripGlobalFlag("--lan", false)) {
     process.env.PORTLESS_LAN = "1";
   }
@@ -3440,6 +3605,12 @@ async function main() {
 
   if (stripGlobalFlag("--tailscale", false)) {
     process.env.PORTLESS_TAILSCALE = "1";
+  }
+  const tailscaleServiceValue = stripGlobalEqualsFlag("--tailscale-service");
+  if (tailscaleServiceValue !== null) {
+    applyTailscaleServiceFlag(tailscaleServiceValue);
+  } else if (stripGlobalFlag("--tailscale-service", false)) {
+    applyTailscaleServiceFlag();
   }
   if (stripGlobalFlag("--funnel", false)) {
     process.env.PORTLESS_FUNNEL = "1";

--- a/packages/portless/src/routes.test.ts
+++ b/packages/portless/src/routes.test.ts
@@ -426,6 +426,20 @@ describe("RouteStore", () => {
       expect(routes[0].tailscaleFunnel).toBe(true);
     });
 
+    it("persists Tailscale Service metadata via updateRoute", () => {
+      store.addRoute("os.localhost", 3000, process.pid);
+      store.updateRoute("os.localhost", {
+        tailscaleUrl: "https://os.example.ts.net",
+        tailscaleHttpsPort: 443,
+        tailscaleServiceId: "svc:os",
+        tailscaleServiceName: "os",
+      });
+      const routes = store.loadRoutes();
+      expect(routes).toHaveLength(1);
+      expect(routes[0].tailscaleServiceId).toBe("svc:os");
+      expect(routes[0].tailscaleServiceName).toBe("os");
+    });
+
     it("loads routes without tailscale fields (backward compat)", () => {
       store.addRoute("legacy.localhost", 4000, process.pid);
       const routes = store.loadRoutes();

--- a/packages/portless/src/routes.ts
+++ b/packages/portless/src/routes.ts
@@ -26,7 +26,20 @@ export interface RouteMapping extends RouteInfo {
   tailscaleUrl?: string;
   tailscaleHttpsPort?: number;
   tailscaleFunnel?: boolean;
+  tailscaleServiceId?: string;
+  tailscaleServiceName?: string;
 }
+
+type RouteMetadataUpdate = Partial<
+  Pick<
+    RouteMapping,
+    | "tailscaleUrl"
+    | "tailscaleHttpsPort"
+    | "tailscaleFunnel"
+    | "tailscaleServiceId"
+    | "tailscaleServiceName"
+  >
+>;
 
 /** Runtime check that a parsed JSON value is a valid RouteMapping. */
 function isValidRoute(value: unknown): value is RouteMapping {
@@ -299,10 +312,7 @@ export class RouteStore {
    * Update metadata on an existing route entry. Only provided fields are
    * merged; the route must already exist (matched by hostname).
    */
-  updateRoute(
-    hostname: string,
-    fields: Partial<Pick<RouteMapping, "tailscaleUrl" | "tailscaleHttpsPort" | "tailscaleFunnel">>
-  ): void {
+  updateRoute(hostname: string, fields: RouteMetadataUpdate): void {
     this.ensureDir();
     if (!this.acquireLock()) {
       throw new Error("Failed to acquire route lock");
@@ -315,6 +325,10 @@ export class RouteStore {
       if (fields.tailscaleHttpsPort !== undefined)
         route.tailscaleHttpsPort = fields.tailscaleHttpsPort;
       if (fields.tailscaleFunnel !== undefined) route.tailscaleFunnel = fields.tailscaleFunnel;
+      if (fields.tailscaleServiceId !== undefined)
+        route.tailscaleServiceId = fields.tailscaleServiceId;
+      if (fields.tailscaleServiceName !== undefined)
+        route.tailscaleServiceName = fields.tailscaleServiceName;
       this.saveRoutes(routes);
     } finally {
       this.releaseLock();

--- a/packages/portless/src/tailscale.test.ts
+++ b/packages/portless/src/tailscale.test.ts
@@ -2,10 +2,13 @@ import { describe, it, expect } from "vitest";
 import {
   ensureTailscaleReady,
   findAvailableServePort,
+  formatTailscaleServiceUrl,
   formatTailscaleUrl,
   getUsedServePorts,
+  normalizeServiceName,
   registerFunnel,
   registerServe,
+  registerTailscaleService,
   unregisterFunnel,
   unregisterServe,
   unregisterTailscale,
@@ -57,6 +60,7 @@ describe("tailscale", () => {
       });
       const ready = ensureTailscaleReady({ runner });
       expect(ready.dnsName).toBe("devbox.example.ts.net");
+      expect(ready.magicDnsSuffix).toBe("example.ts.net");
       expect(ready.baseUrl).toBe("https://devbox.example.ts.net");
     });
 
@@ -73,6 +77,22 @@ describe("tailscale", () => {
       });
       const ready = ensureTailscaleReady({ runner });
       expect(ready.dnsName).toBe("devbox.example.ts.net");
+      expect(ready.magicDnsSuffix).toBe("example.ts.net");
+    });
+
+    it("prefers CurrentTailnet MagicDNSSuffix when present", () => {
+      const runner = createRunner({
+        version: { status: 0 },
+        "status --json": {
+          status: 0,
+          stdout: JSON.stringify({
+            Self: { DNSName: "devbox.device.example.ts.net." },
+            CurrentTailnet: { MagicDNSSuffix: "example.ts.net." },
+          }),
+        },
+      });
+      const ready = ensureTailscaleReady({ runner });
+      expect(ready.magicDnsSuffix).toBe("example.ts.net");
     });
 
     it("throws when Funnel is required but not enabled on the tailnet", () => {
@@ -125,6 +145,61 @@ describe("tailscale", () => {
       expect(() => ensureTailscaleReady({ runner, requireHttps: true })).toThrow(
         "Tailscale HTTPS is not enabled on your tailnet"
       );
+    });
+
+    it("throws when Service host mode is required but the device is untagged", () => {
+      const runner = createRunner({
+        version: { status: 0 },
+        "status --json": {
+          status: 0,
+          stdout: JSON.stringify({
+            Self: {
+              DNSName: "devbox.example.ts.net.",
+              Capabilities: ["https"],
+              Tags: [],
+            },
+          }),
+        },
+      });
+      expect(() => ensureTailscaleReady({ runner, requireServiceHost: true })).toThrow(
+        "tag-based identity"
+      );
+    });
+
+    it("throws when Service host mode is required but tag data is missing", () => {
+      const runner = createRunner({
+        version: { status: 0 },
+        "status --json": {
+          status: 0,
+          stdout: JSON.stringify({
+            Self: {
+              DNSName: "devbox.example.ts.net.",
+              Capabilities: ["https"],
+            },
+          }),
+        },
+      });
+      expect(() => ensureTailscaleReady({ runner, requireServiceHost: true })).toThrow(
+        "tag-based identity"
+      );
+    });
+
+    it("allows Service host mode when the device is tagged", () => {
+      const runner = createRunner({
+        version: { status: 0 },
+        "status --json": {
+          status: 0,
+          stdout: JSON.stringify({
+            Self: {
+              DNSName: "devbox.example.ts.net.",
+              Capabilities: ["https"],
+              Tags: ["tag:dev"],
+            },
+          }),
+        },
+      });
+      const ready = ensureTailscaleReady({ runner, requireServiceHost: true });
+      expect(ready.baseUrl).toBe("https://devbox.example.ts.net");
     });
 
     it("allows HTTPS when the node has an HTTPS capability", () => {
@@ -307,6 +382,24 @@ describe("tailscale", () => {
   // registerServe / unregisterServe
   // -----------------------------------------------------------------------
 
+  describe("normalizeServiceName", () => {
+    it("normalizes plain and svc-prefixed service names", () => {
+      expect(normalizeServiceName("os")).toEqual({
+        displayName: "os",
+        serviceId: "svc:os",
+      });
+      expect(normalizeServiceName("svc:My-App")).toEqual({
+        displayName: "my-app",
+        serviceId: "svc:my-app",
+      });
+    });
+
+    it("rejects invalid service names", () => {
+      expect(() => normalizeServiceName("bad.name")).toThrow("Invalid Tailscale Service name");
+      expect(() => normalizeServiceName("-bad")).toThrow("Invalid Tailscale Service name");
+    });
+  });
+
   describe("registerServe", () => {
     it("calls tailscale serve with correct args", () => {
       const calls: string[][] = [];
@@ -403,6 +496,54 @@ describe("tailscale", () => {
         "serve --yes --https=443 off": { status: null, error: enoent },
       });
       expect(() => unregisterServe(443, { runner })).not.toThrow();
+    });
+  });
+
+  describe("registerTailscaleService", () => {
+    it("calls tailscale serve with service args", () => {
+      const calls: string[][] = [];
+      const service = normalizeServiceName("os");
+      const runner = createRunner(
+        {
+          "serve --yes --service=svc:os --https=443 http://127.0.0.1:4123": { status: 0 },
+        },
+        calls
+      );
+      const approvalRequired = registerTailscaleService(service, 4123, 443, { runner });
+      expect(calls[0]).toEqual([
+        "serve",
+        "--yes",
+        "--service=svc:os",
+        "--https=443",
+        "http://127.0.0.1:4123",
+      ]);
+      expect(approvalRequired).toBe(false);
+    });
+
+    it("detects service host registrations that are pending approval", () => {
+      const service = normalizeServiceName("os");
+      const runner = createRunner({
+        "serve --yes --service=svc:os --https=443 http://127.0.0.1:4123": {
+          status: 0,
+          stdout:
+            "This machine is configured as a service proxy for svc:os, but approval from an admin is required.",
+        },
+      });
+      const approvalRequired = registerTailscaleService(service, 4123, 443, { runner });
+      expect(approvalRequired).toBe(true);
+    });
+
+    it("throws with service context on non-conflict failure", () => {
+      const service = normalizeServiceName("os");
+      const runner = createRunner({
+        "serve --yes --service=svc:os --https=443 http://127.0.0.1:4123": {
+          status: 1,
+          stderr: "approval required",
+        },
+      });
+      expect(() => registerTailscaleService(service, 4123, 443, { runner })).toThrow(
+        "approval required"
+      );
     });
   });
 
@@ -513,6 +654,16 @@ describe("tailscale", () => {
     it("is a no-op when tailscaleHttpsPort is missing", () => {
       expect(() => unregisterTailscale({ tailscaleFunnel: true })).not.toThrow();
     });
+
+    it("uses service-specific cleanup when service metadata exists", () => {
+      const calls: string[][] = [];
+      const runner = createRunner(
+        { "serve --yes --service=svc:os --https=443 off": { status: 0 } },
+        calls
+      );
+      unregisterTailscale({ tailscaleHttpsPort: 443, tailscaleServiceId: "svc:os" }, { runner });
+      expect(calls[0]).toEqual(["serve", "--yes", "--service=svc:os", "--https=443", "off"]);
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -536,6 +687,10 @@ describe("tailscale", () => {
       expect(formatTailscaleUrl("https://devbox.example.ts.net/", 443)).toBe(
         "https://devbox.example.ts.net"
       );
+    });
+
+    it("formats service URLs with the MagicDNS suffix", () => {
+      expect(formatTailscaleServiceUrl("os", "example.ts.net.")).toBe("https://os.example.ts.net");
     });
   });
 });

--- a/packages/portless/src/tailscale.ts
+++ b/packages/portless/src/tailscale.ts
@@ -30,6 +30,7 @@ interface TailscaleStatusJson {
     DNSName?: string;
     HostName?: string;
     ID?: string;
+    Tags?: string[];
   };
   CurrentTailnet?: {
     MagicDNSSuffix?: string;
@@ -38,12 +39,14 @@ interface TailscaleStatusJson {
 
 export interface TailscaleReadyResult {
   dnsName: string;
+  magicDnsSuffix: string;
   baseUrl: string;
 }
 
 export interface EnsureTailscaleReadyOptions {
   requireFunnel?: boolean;
   requireHttps?: boolean;
+  requireServiceHost?: boolean;
   runner?: TailscaleCommandRunner;
 }
 
@@ -121,6 +124,22 @@ function statusToDnsName(status: TailscaleStatusJson): string {
   );
 }
 
+function statusToMagicDnsSuffix(status: TailscaleStatusJson, dnsName: string): string {
+  const suffix = status.CurrentTailnet?.MagicDNSSuffix;
+  if (typeof suffix === "string" && suffix.length > 0) {
+    return trimDot(suffix);
+  }
+
+  const labels = dnsName.split(".");
+  if (labels.length > 1) {
+    return labels.slice(1).join(".");
+  }
+
+  throw new Error(
+    "Could not determine Tailscale MagicDNS suffix from `tailscale status --json`. Is MagicDNS enabled?"
+  );
+}
+
 function isFunnelCapability(value: string): boolean {
   const normalized = value.toLowerCase();
   return normalized === "funnel" || normalized.endsWith("/funnel");
@@ -172,6 +191,13 @@ function throwFunnelNotEnabled(status: TailscaleStatusJson): never {
   );
 }
 
+function throwServiceHostNotTagged(): never {
+  throw new Error(
+    "Tailscale Services require this device to use a tag-based identity. " +
+      "Tag this device in Tailscale, then run portless again, or use --tailscale for node-based sharing."
+  );
+}
+
 /**
  * Verify that the Tailscale CLI is installed and the node is connected.
  * Returns the node's DNS name and base URL.
@@ -184,14 +210,22 @@ export function ensureTailscaleReady(
   const statusResult = runOrThrow(["status", "--json"], "read tailscale status", runner);
   const status = parseStatusJson(statusResult.stdout);
   const dnsName = statusToDnsName(status);
+  const magicDnsSuffix = statusToMagicDnsSuffix(status, dnsName);
   if (options.requireHttps && !hasHttpsCapability(status)) {
     throwHttpsNotEnabled();
   }
   if (options.requireFunnel && !hasFunnelCapability(status)) {
     throwFunnelNotEnabled(status);
   }
+  if (
+    options.requireServiceHost &&
+    (!Array.isArray(status.Self?.Tags) || status.Self.Tags.length === 0)
+  ) {
+    throwServiceHostNotTagged();
+  }
   return {
     dnsName,
+    magicDnsSuffix,
     baseUrl: `https://${dnsName}`,
   };
 }
@@ -301,6 +335,11 @@ export interface RegisterServeOptions {
   runner?: TailscaleCommandRunner;
 }
 
+export interface TailscaleServiceName {
+  displayName: string;
+  serviceId: string;
+}
+
 const CONFLICT_MESSAGES: Record<TailscaleMode, string> = {
   serve: "Stop the existing serve or let portless auto-assign a different port.",
   funnel: "Tailscale Funnel supports ports 443, 8443, and 10000.",
@@ -348,6 +387,66 @@ function register(
   }
 }
 
+const SERVICE_NAME_PATTERN = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
+
+export function normalizeServiceName(input: string): TailscaleServiceName {
+  const displayName = input.trim().replace(/^svc:/i, "").toLowerCase();
+  if (!SERVICE_NAME_PATTERN.test(displayName)) {
+    throw new Error(
+      `Invalid Tailscale Service name "${input}". Use a DNS label with lowercase letters, digits, and hyphens.`
+    );
+  }
+  return {
+    displayName,
+    serviceId: `svc:${displayName}`,
+  };
+}
+
+function registerService(
+  service: TailscaleServiceName,
+  localPort: number,
+  httpsPort: number,
+  runner: TailscaleCommandRunner
+): boolean {
+  const target = `http://127.0.0.1:${localPort}`;
+  const result = runner([
+    "serve",
+    "--yes",
+    `--service=${service.serviceId}`,
+    `--https=${httpsPort}`,
+    target,
+  ]);
+  if (result.error) {
+    const errno = result.error as NodeJS.ErrnoException;
+    if (errno.code === "ENOENT") {
+      throw new Error(
+        "Tailscale CLI not found. Install Tailscale (https://tailscale.com/download) and ensure `tailscale` is on PATH."
+      );
+    }
+    throw new Error(
+      `Failed to register tailscale service ${service.serviceId}: ${result.error.message}`
+    );
+  }
+  if (result.status !== 0) {
+    if (isConflictError(result.stderr, result.stdout)) {
+      throw new Error(
+        `Tailscale Service ${service.serviceId} HTTPS port ${httpsPort} is already in use. ` +
+          "Choose a different service name or remove the existing service mapping."
+      );
+    }
+    const details = normalizeSpace(result.stderr || result.stdout);
+    throw new Error(
+      `Failed to register tailscale service ${service.serviceId} on port ${httpsPort}: ${details || "unknown tailscale error"}`
+    );
+  }
+  return isServiceApprovalRequired(result);
+}
+
+function isServiceApprovalRequired(result: TailscaleCommandResult): boolean {
+  const text = `${result.stderr}\n${result.stdout}`.toLowerCase();
+  return text.includes("approval from an admin is required") || text.includes("approval required");
+}
+
 function unregister(
   mode: TailscaleMode,
   httpsPort: number,
@@ -375,12 +474,54 @@ function unregister(
   }
 }
 
+function unregisterService(
+  serviceId: string,
+  httpsPort: number,
+  options?: { ignoreMissing?: boolean; runner?: TailscaleCommandRunner }
+): void {
+  const runner = options?.runner ?? defaultRunner;
+  const result = runner([
+    "serve",
+    "--yes",
+    `--service=${serviceId}`,
+    `--https=${httpsPort}`,
+    "off",
+  ]);
+  if (result.error) {
+    const errno = result.error as NodeJS.ErrnoException;
+    if (errno.code === "ENOENT") return;
+    throw new Error(`Failed to remove tailscale service ${serviceId}: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const text = `${result.stderr}\n${result.stdout}`.toLowerCase();
+    const looksLikeMissing =
+      text.includes("not found") ||
+      text.includes("no serve config") ||
+      text.includes("nothing to remove") ||
+      text.includes("does not exist");
+    if (options?.ignoreMissing && looksLikeMissing) return;
+    const details = normalizeSpace(result.stderr || result.stdout);
+    throw new Error(
+      `Failed to remove tailscale service ${serviceId} on port ${httpsPort}: ${details || "unknown tailscale error"}`
+    );
+  }
+}
+
 export function registerServe(
   localPort: number,
   httpsPort: number,
   options?: RegisterServeOptions
 ): void {
   register("serve", localPort, httpsPort, options?.runner ?? defaultRunner);
+}
+
+export function registerTailscaleService(
+  service: TailscaleServiceName,
+  localPort: number,
+  httpsPort: number,
+  options?: RegisterServeOptions
+): boolean {
+  return registerService(service, localPort, httpsPort, options?.runner ?? defaultRunner);
 }
 
 export function registerFunnel(
@@ -409,13 +550,24 @@ export function unregisterFunnel(
  * Best-effort cleanup of a tailscale serve or funnel registration from a
  * route's metadata. Picks the right subcommand based on `tailscaleFunnel`.
  */
-export function unregisterTailscale(route: {
-  tailscaleHttpsPort?: number;
-  tailscaleFunnel?: boolean;
-}): void {
+export function unregisterTailscale(
+  route: {
+    tailscaleHttpsPort?: number;
+    tailscaleFunnel?: boolean;
+    tailscaleServiceId?: string;
+  },
+  options?: { runner?: TailscaleCommandRunner }
+): void {
   if (!route.tailscaleHttpsPort) return;
+  if (route.tailscaleServiceId) {
+    unregisterService(route.tailscaleServiceId, route.tailscaleHttpsPort, {
+      ignoreMissing: true,
+      runner: options?.runner,
+    });
+    return;
+  }
   const mode: TailscaleMode = route.tailscaleFunnel ? "funnel" : "serve";
-  unregister(mode, route.tailscaleHttpsPort, { ignoreMissing: true });
+  unregister(mode, route.tailscaleHttpsPort, { ignoreMissing: true, runner: options?.runner });
 }
 
 // ---------------------------------------------------------------------------
@@ -427,4 +579,8 @@ export function formatTailscaleUrl(baseUrl: string, httpsPort: number): string {
   const trimmed = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
   if (httpsPort === 443) return trimmed;
   return `${trimmed}:${httpsPort}`;
+}
+
+export function formatTailscaleServiceUrl(serviceName: string, magicDnsSuffix: string): string {
+  return `https://${serviceName}.${trimDot(magicDnsSuffix)}`;
 }

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -171,19 +171,20 @@ Portless stores its state (routes, PID file, port file) in `~/.portless`. Overri
 
 ### Environment variables
 
-| Variable              | Description                                                                 |
-| --------------------- | --------------------------------------------------------------------------- |
-| `PORTLESS_PORT`       | Override the default proxy port (default: 443 with HTTPS, 80 without)       |
-| `PORTLESS_APP_PORT`   | Use a fixed port for the app (skip auto-assignment)                         |
-| `PORTLESS_HTTPS`      | HTTPS on by default; set to `0` to disable (same as `--no-tls`)             |
-| `PORTLESS_LAN`        | Set to `1` to always enable LAN mode (auto-detects LAN IP)                  |
-| `PORTLESS_TLD`        | Use a custom TLD instead of localhost (e.g. test)                           |
-| `PORTLESS_WILDCARD`   | Set to `1` to allow unregistered subdomains to fall back to parent          |
-| `PORTLESS_SYNC_HOSTS` | Set to `0` to disable auto-sync of /etc/hosts (on by default)               |
-| `PORTLESS_TAILSCALE`  | Set to `1` to share apps on your Tailscale network (same as `--tailscale`)  |
-| `PORTLESS_FUNNEL`     | Set to `1` to share apps publicly via Tailscale Funnel (same as `--funnel`) |
-| `PORTLESS_STATE_DIR`  | Override the state directory                                                |
-| `PORTLESS=0`          | Bypass the proxy, run the command directly                                  |
+| Variable                     | Description                                                                    |
+| ---------------------------- | ------------------------------------------------------------------------------ |
+| `PORTLESS_PORT`              | Override the default proxy port (default: 443 with HTTPS, 80 without)          |
+| `PORTLESS_APP_PORT`          | Use a fixed port for the app (skip auto-assignment)                            |
+| `PORTLESS_HTTPS`             | HTTPS on by default; set to `0` to disable (same as `--no-tls`)                |
+| `PORTLESS_LAN`               | Set to `1` to always enable LAN mode (auto-detects LAN IP)                     |
+| `PORTLESS_TLD`               | Use a custom TLD instead of localhost (e.g. test)                              |
+| `PORTLESS_WILDCARD`          | Set to `1` to allow unregistered subdomains to fall back to parent             |
+| `PORTLESS_SYNC_HOSTS`        | Set to `0` to disable auto-sync of /etc/hosts (on by default)                  |
+| `PORTLESS_TAILSCALE`         | Set to `1` to share apps on your Tailscale network (same as `--tailscale`)     |
+| `PORTLESS_TAILSCALE_SERVICE` | Set to `1` to share apps via Tailscale Service (same as `--tailscale-service`) |
+| `PORTLESS_FUNNEL`            | Set to `1` to share apps publicly via Tailscale Funnel (same as `--funnel`)    |
+| `PORTLESS_STATE_DIR`         | Override the state directory                                                   |
+| `PORTLESS=0`                 | Bypass the proxy, run the command directly                                     |
 
 ### HTTP/2 + HTTPS
 
@@ -224,12 +225,16 @@ LAN mode depends on the system mDNS helpers that portless launches: macOS includ
 
 ### Tailscale sharing
 
-Share dev servers with teammates on your Tailscale network using `--tailscale`, or expose to the public internet with `--funnel`:
+Share dev servers with teammates on your Tailscale network using `--tailscale`, through a Tailscale Service using `--tailscale-service`, or expose to the public internet with `--funnel`:
 
 ```bash
 portless myapp --tailscale next dev
 # -> https://myapp.localhost           (local)
 # -> https://devbox.yourteam.ts.net    (tailnet)
+
+portless myapp --tailscale-service next dev
+# -> https://myapp.localhost           (local)
+# -> https://myapp.yourteam.ts.net     (tailnet)
 
 portless myapp --funnel next dev
 # -> https://myapp.localhost           (local)
@@ -238,7 +243,7 @@ portless myapp --funnel next dev
 
 Tailscale HTTPS certificates must be enabled before `--tailscale` or `--funnel` can register HTTPS URLs. Funnel must also be enabled for the tailnet and node before `--funnel` can register the public URL. If either setting is missing, portless exits before starting the child process.
 
-Each `--tailscale` app is root-mounted on its own Tailscale HTTPS port (443, then 8443, 8444, etc.) so no framework `basePath` configuration is needed. Set `PORTLESS_TAILSCALE=1` to share every app by default. `portless list` shows both local and tailnet URLs. Tailscale serve registrations are cleaned up when the app exits. Requires `tailscale` CLI installed and connected, with Tailscale HTTPS certificates enabled.
+Each `--tailscale` app is root-mounted on its own Tailscale HTTPS port (443, then 8443, 8444, etc.) so no framework `basePath` configuration is needed. Service mode uses the Service's port 443 and a stable Service MagicDNS name. The Service name defaults to the inferred base app name; use `--tailscale-service=<name>` to override it. The Service must already exist, the host device must use a tag-based identity, and an admin may need to approve the host advertisement. When approval is required, portless prints the Service URL as pending because MagicDNS will not resolve it until the Service host is approved. Set `PORTLESS_TAILSCALE=1` to share every app by default, set `PORTLESS_TAILSCALE_SERVICE=1` to use inferred Service names, or set `PORTLESS_TAILSCALE_SERVICE=<name>` in a package script or local env file to use one specific Service name. `portless list` shows both local and tailnet URLs. Tailscale serve registrations are cleaned up when the app exits. Requires `tailscale` CLI installed and connected, with Tailscale HTTPS certificates enabled.
 
 ## OS startup service
 
@@ -254,46 +259,48 @@ The service uses the default clean URL behavior: HTTPS on port 443 with `.localh
 
 ## CLI Reference
 
-| Command                                | Description                                                    |
-| -------------------------------------- | -------------------------------------------------------------- |
-| `portless`                             | Run dev script through proxy                                   |
-| `portless`                             | From monorepo root: run all workspace packages                 |
-| `portless --script <name>`             | Run a specific package.json script (default: dev)              |
-| `portless run [cmd] [args...]`         | Infer name from project, run through proxy (auto-starts)       |
-| `portless run --name <name> <cmd>`     | Override inferred base name (worktree prefix still applies)    |
-| `portless <name> <cmd> [args...]`      | Run app at `https://<name>.localhost` (auto-starts proxy)      |
-| `portless get <name>`                  | Print URL for a service (for cross-service wiring)             |
-| `portless get <name> --no-worktree`    | Print URL without worktree prefix                              |
-| `portless list`                        | Show active routes                                             |
-| `portless trust`                       | Add local CA to system trust store (for HTTPS)                 |
-| `portless clean`                       | Remove state, CA trust entry, and /etc/hosts block             |
-| `portless prune`                       | Kill orphaned dev servers from crashed sessions                |
-| `portless prune --force`               | Kill orphans with SIGKILL instead of SIGTERM                   |
-| `portless proxy start`                 | Start HTTPS proxy as a daemon (port 443, auto-elevates)        |
-| `portless proxy start --no-tls`        | Start without HTTPS (plain HTTP on port 80)                    |
-| `portless proxy start --lan`           | Start in LAN mode (mDNS `.local`, auto-follows LAN IP changes) |
-| `portless proxy start -p <number>`     | Start the proxy on a custom port                               |
-| `portless proxy start --tld test`      | Use .test instead of .localhost                                |
-| `portless proxy start --foreground`    | Start the proxy in foreground (for debugging)                  |
-| `portless proxy start --wildcard`      | Allow unregistered subdomains to fall back to parent route     |
-| `portless proxy stop`                  | Stop the proxy                                                 |
-| `portless service install`             | Start the HTTPS proxy when the OS starts                       |
-| `portless service status`              | Show service and proxy status                                  |
-| `portless service uninstall`           | Remove the startup service                                     |
-| `portless alias <name> <port>`         | Register a static route (e.g. for Docker containers)           |
-| `portless alias <name> <port> --force` | Overwrite an existing route                                    |
-| `portless alias --remove <name>`       | Remove a static route                                          |
-| `portless hosts sync`                  | Add routes to /etc/hosts (fixes Safari)                        |
-| `portless hosts clean`                 | Remove portless entries from /etc/hosts                        |
-| `portless <name> --app-port <n> <cmd>` | Use a fixed port for the app instead of auto-assignment        |
-| `portless <name> --tailscale <cmd>`    | Share the app on your Tailscale network (tailnet)              |
-| `portless <name> --funnel <cmd>`       | Share the app publicly via Tailscale Funnel                    |
-| `portless <name> --force <cmd>`        | Kill the existing process and take over its route              |
-| `portless --name <name> <cmd>`         | Force `<name>` as app name (bypasses subcommand dispatch)      |
-| `portless <name> -- <cmd> [args...]`   | Stop flag parsing; everything after `--` is passed to child    |
-| `portless --help` / `-h`               | Show help                                                      |
-| `portless run --help`                  | Show help for a subcommand (also: alias, hosts, clean)         |
-| `portless --version` / `-v`            | Show version                                                   |
+| Command                                               | Description                                                    |
+| ----------------------------------------------------- | -------------------------------------------------------------- |
+| `portless`                                            | Run dev script through proxy                                   |
+| `portless`                                            | From monorepo root: run all workspace packages                 |
+| `portless --script <name>`                            | Run a specific package.json script (default: dev)              |
+| `portless run [cmd] [args...]`                        | Infer name from project, run through proxy (auto-starts)       |
+| `portless run --name <name> <cmd>`                    | Override inferred base name (worktree prefix still applies)    |
+| `portless <name> <cmd> [args...]`                     | Run app at `https://<name>.localhost` (auto-starts proxy)      |
+| `portless get <name>`                                 | Print URL for a service (for cross-service wiring)             |
+| `portless get <name> --no-worktree`                   | Print URL without worktree prefix                              |
+| `portless list`                                       | Show active routes                                             |
+| `portless trust`                                      | Add local CA to system trust store (for HTTPS)                 |
+| `portless clean`                                      | Remove state, CA trust entry, and /etc/hosts block             |
+| `portless prune`                                      | Kill orphaned dev servers from crashed sessions                |
+| `portless prune --force`                              | Kill orphans with SIGKILL instead of SIGTERM                   |
+| `portless proxy start`                                | Start HTTPS proxy as a daemon (port 443, auto-elevates)        |
+| `portless proxy start --no-tls`                       | Start without HTTPS (plain HTTP on port 80)                    |
+| `portless proxy start --lan`                          | Start in LAN mode (mDNS `.local`, auto-follows LAN IP changes) |
+| `portless proxy start -p <number>`                    | Start the proxy on a custom port                               |
+| `portless proxy start --tld test`                     | Use .test instead of .localhost                                |
+| `portless proxy start --foreground`                   | Start the proxy in foreground (for debugging)                  |
+| `portless proxy start --wildcard`                     | Allow unregistered subdomains to fall back to parent route     |
+| `portless proxy stop`                                 | Stop the proxy                                                 |
+| `portless service install`                            | Start the HTTPS proxy when the OS starts                       |
+| `portless service status`                             | Show service and proxy status                                  |
+| `portless service uninstall`                          | Remove the startup service                                     |
+| `portless alias <name> <port>`                        | Register a static route (e.g. for Docker containers)           |
+| `portless alias <name> <port> --force`                | Overwrite an existing route                                    |
+| `portless alias --remove <name>`                      | Remove a static route                                          |
+| `portless hosts sync`                                 | Add routes to /etc/hosts (fixes Safari)                        |
+| `portless hosts clean`                                | Remove portless entries from /etc/hosts                        |
+| `portless <name> --app-port <n> <cmd>`                | Use a fixed port for the app instead of auto-assignment        |
+| `portless <name> --tailscale <cmd>`                   | Share the app on your Tailscale network (tailnet)              |
+| `portless <name> --tailscale-service <cmd>`           | Share through an inferred Tailscale Service                    |
+| `portless <name> --tailscale-service=<service> <cmd>` | Share through a specific Tailscale Service                     |
+| `portless <name> --funnel <cmd>`                      | Share the app publicly via Tailscale Funnel                    |
+| `portless <name> --force <cmd>`                       | Kill the existing process and take over its route              |
+| `portless --name <name> <cmd>`                        | Force `<name>` as app name (bypasses subcommand dispatch)      |
+| `portless <name> -- <cmd> [args...]`                  | Stop flag parsing; everything after `--` is passed to child    |
+| `portless --help` / `-h`                              | Show help                                                      |
+| `portless run --help`                                 | Show help for a subcommand (also: alias, hosts, clean)         |
+| `portless --version` / `-v`                           | Show version                                                   |
 
 **Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `trust`, `clean`, `prune`, `proxy`, and `service` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name, or `portless --name <name> <cmd>` to force any name including reserved ones.
 


### PR DESCRIPTION
Adds Tailscale Service sharing to Portless so apps can use stable Service MagicDNS names like `https://service_name.<tailnet>` instead of rotating node ports. The new --tailscale-service flag infers the Service name from the app name by default, supports explicit overrides with --tailscale-service=<name>, persists Service metadata for cleanup, and surfaces pending admin approval when MagicDNS is not ready yet.

I have manually tested happy and failure paths, along with ensuring there are no regression with existing tailscale and tailscale funnel functionality. I believe I have updated all docs and tests as well.

Here is my 𝕏 post on the before and after https://x.com/jonbeckman/status/2057452432171421736?s=20