### PR TITLE
fix: run cleanup handler on SIGHUP

### DIFF
--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -641,6 +641,7 @@ function startProxyServer(
     setTimeout(() => process.exit(0), EXIT_TIMEOUT_MS).unref();
   };
 
+  process.on("SIGHUP", cleanup);
   process.on("SIGINT", cleanup);
   process.on("SIGTERM", cleanup);
 
@@ -3134,6 +3135,7 @@ async function runWithTurbo(
     removeManifest();
   };
 
+  process.on("SIGHUP", cleanup);
   process.on("SIGINT", cleanup);
   process.on("SIGTERM", cleanup);
 
@@ -3220,6 +3222,7 @@ async function runWithDirectSpawn(
     }
   };
 
+  process.on("SIGHUP", cleanup);
   process.on("SIGINT", cleanup);
   process.on("SIGTERM", cleanup);
 

--- a/tests/e2e/src/zombie.test.ts
+++ b/tests/e2e/src/zombie.test.ts
@@ -242,6 +242,26 @@ describe("zombie process prevention", () => {
     expect(survivors).toEqual([]);
   });
 
+  it("SIGHUP kills the dev server and removes the route", async () => {
+    if (isWindows) return;
+
+    // SIGHUP is delivered when the controlling terminal goes away
+    // (tmux kill-session, ssh disconnect, parent shell exit). Without an
+    // explicit handler, Node terminates immediately and skips cleanup, leaving
+    // a stale routes.json entry and (with wrapper) an orphaned grandchild.
+    const { hostname, appPort } = await startCliApp("zombie-sighup", state, "wrapper.js");
+
+    state.cliChild!.kill("SIGHUP");
+    await sleep(2000);
+
+    const survivors = findPidsOnPort(appPort);
+    expect(survivors).toEqual([]);
+
+    const routesPath = path.join(state.stateDir!, "routes.json");
+    const routes: Array<{ hostname: string }> = JSON.parse(fs.readFileSync(routesPath, "utf-8"));
+    expect(routes.find((r) => r.hostname === hostname)).toBeUndefined();
+  });
+
   it("SIGKILL leaves orphan, portless prune cleans it up", async () => {
     if (isWindows) return;
 


### PR DESCRIPTION

## Summary

- Register the existing `cleanup` handler on `SIGHUP` in addition to `SIGINT` and `SIGTERM` for the three signal-handling sites in `packages/portless/src/cli.ts` (`startProxyServer`, `runWithTurbo`, `runWithDirectSpawn`).
- Add an e2e case to `tests/e2e/src/zombie.test.ts` covering the wrap-mode path: SIGHUP must tear down the child process group and remove the route from `routes.json`.

## Why

On non-Windows platforms the default Node disposition for `SIGHUP` is to terminate the process without running any user code. The wrap-mode and turbo paths only install handlers for `SIGINT` and `SIGTERM`, so `SIGHUP` makes the CLI exit immediately and skip `cleanup()`.

That leaves two artifacts behind. First, the route entry in `routes.json` stays. On the next `portless proxy` restart it is reloaded with `pid: 0` and becomes indistinguishable from an alias registration. `portless prune` only targets entries whose stored PID exists but is dead, so it skips this one and prints `No orphaned routes found`. The next wrap-mode start for the same name then fails with `Error: "<name>.localhost" is already registered by a running process (PID 0). Use --force to override.`, and the only way out is `portless alias --remove <name>`.

Second, the grandchild dev server can be reparented to PID 1 and continue holding its port. This is the same zombie-class outcome that #255 addresses for the `SIGKILL` path, just triggered by `SIGHUP` instead.

`SIGHUP` is delivered by routine workflows: `tmux kill-session`, SSH disconnect, the parent shell exiting, or detaching without `nohup`. It deserves the same cleanup as `SIGTERM`.

## Repro

```bash
mkdir -p /tmp/portless-repro && cd /tmp/portless-repro
portless myapp node -e 'require("http").createServer((_,r)=>r.end("ok")).listen(process.env.PORT)' &
PID=$!
sleep 2

kill -HUP $PID
sleep 1

portless list | grep myapp        # before this PR: route still listed
portless prune --force            # before this PR: "No orphaned routes found"
portless myapp node -e '...'      # before this PR: "already registered by a running process (PID 0)"
```

## Fix

Each of the three blocks already does:

```ts
process.on("SIGINT", cleanup);
process.on("SIGTERM", cleanup);
```

This PR adds one line per site:

```ts
process.on("SIGHUP", cleanup);
```

No new code paths, no signature changes, no behavioral change for `SIGINT` / `SIGTERM`. The proxy daemon site is included so that `portless proxy start --foreground` honors hangup; the non-foreground daemon keeps `stdio: ["ignore", logFd, logFd]` plus `detached: true`, so `SIGHUP` is not delivered there in normal operation and the handler is a no-op for that case.

## Test plan

- `pnpm --filter portless type-check`
- `pnpm --filter portless lint`
- `pnpm --filter portless test`
- New e2e case: `tests/e2e/src/zombie.test.ts > zombie process prevention > SIGHUP kills the dev server and removes the route` — exercises the wrap-mode path with the `wrapper.js` fixture used by the existing `SIGTERM` test, then asserts the route is gone from `routes.json`.

---
Assisted-by: Claude Code:claude-opus-4-7[1m]