### PR TITLE
Prepare v0.13.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,31 @@
 # Changelog
 
-## 0.13.0
+## 0.13.1
 
 <!-- release:start -->
+
+### New Features
+
+- **Configurable startup services**: `portless service install` now persists proxy options such as `--port`, `--no-tls`, `--lan`, `--ip`, `--tld`, `--wildcard`, `--cert`, `--key`, and `--state-dir` into launchd, systemd, and Task Scheduler. `portless service status` now reports the installed service port, HTTPS mode, TLD, LAN mode, wildcard mode, and state directory.
+
+### Bug Fixes
+
+- **Service reinstall port changes**: Reinstalling the startup service with a different port now stops any existing proxy on the previous port before starting the new service.
+- **Service install validation**: LAN service installs now fail early on platforms that cannot publish mDNS records, and service paths such as `~` are normalized before writing native service files.
+
+### Requirements
+
+- **Node.js 24**: The published package now requires Node.js 24 or newer, and repository development uses pnpm 11 with a minimum release age policy. (#307)
+
+### Contributors
+
+- @ctate
+- @skaldebane
+- @ItalianScallian
+- @neefrehman
+<!-- release:end -->
+
+## 0.13.0
 
 ### New Features
 
@@ -16,7 +39,6 @@
 
 - @ctate
 - @Anshuman71
-<!-- release:end -->
 
 ## 0.12.0
 

--- a/README.md
+++ b/README.md
@@ -255,11 +255,16 @@ Install the proxy as an OS startup service so clean HTTPS URLs are available aft
 
 ```bash
 portless service install
+portless service install --lan
+portless service install --wildcard
+PORTLESS_STATE_DIR=~/.portless-lan PORTLESS_LAN=1 portless service install
 portless service status
 portless service uninstall
 ```
 
-The service uses portless defaults: HTTPS on port 443 with `.localhost` names. macOS and Linux install a root-owned service so port 443 can bind at boot. Windows installs a Task Scheduler startup task that runs as SYSTEM. Installation and removal may require administrator privileges. `portless clean` automatically removes the service.
+The service uses portless defaults unless install options or `PORTLESS_*` environment variables are provided: HTTPS on port 443 with `.localhost` names. `service install` accepts the proxy options you would use with `proxy start`, including `--port`, `--no-tls`, `--lan`, `--ip`, `--tld`, `--wildcard`, `--cert`, and `--key`. Use `--state-dir <path>` or `PORTLESS_STATE_DIR=<path>` to choose where service state and logs are written.
+
+The chosen service configuration is written into launchd, systemd, or Task Scheduler and reused after reboot. `portless service status` reports the installed port, HTTPS mode, TLD, LAN mode, wildcard mode, and state directory. macOS and Linux install a root-owned service so port 443 can bind at boot. Windows installs a Task Scheduler startup task that runs as SYSTEM. Installation and removal may require administrator privileges. `portless clean` automatically removes the service.
 
 ## LAN mode
 
@@ -349,6 +354,8 @@ portless proxy stop              # Stop the proxy
 
 # OS startup service
 portless service install         # Start HTTPS proxy when the OS starts
+portless service install --lan   # Start service in LAN mode
+portless service install --wildcard  # Persist wildcard routing in the service
 portless service status          # Show service and proxy status
 portless service uninstall       # Remove the startup service
 ```
@@ -366,6 +373,7 @@ portless service uninstall       # Remove the startup service
 --foreground                     Run proxy in foreground instead of daemon
 --tld <tld>                      Use a custom TLD instead of .localhost (e.g. test)
 --wildcard                       Allow unregistered subdomains to fall back to parent route
+--state-dir <path>               Use a custom state directory with service install
 --script <name>                  Run a specific package.json script (default: dev)
 --app-port <number>              Use a fixed port for the app (skip auto-assignment)
 --tailscale                      Share the app on your Tailscale network (tailnet)
@@ -382,6 +390,7 @@ PORTLESS_PORT=<number>           Override the default proxy port
 PORTLESS_APP_PORT=<number>       Use a fixed port for the app (same as --app-port)
 PORTLESS_HTTPS=0                 Disable HTTPS (same as --no-tls)
 PORTLESS_LAN=1                   Enable LAN mode when set to 1 (auto-detects LAN IP)
+PORTLESS_LAN_IP=<address>        Pin a specific LAN IP for LAN mode
 PORTLESS_TLD=<tld>               Use a custom TLD (e.g. test; default: localhost)
 PORTLESS_WILDCARD=1              Allow unregistered subdomains to fall back to parent route
 PORTLESS_SYNC_HOSTS=0            Disable auto-sync of /etc/hosts (on by default)

--- a/apps/docs/src/app/changelog/page.mdx
+++ b/apps/docs/src/app/changelog/page.mdx
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.13.1
+
+### New Features
+
+- **Configurable startup services**: `portless service install` now persists proxy options such as `--port`, `--no-tls`, `--lan`, `--ip`, `--tld`, `--wildcard`, `--cert`, `--key`, and `--state-dir` into launchd, systemd, and Task Scheduler. `portless service status` now reports the installed service port, HTTPS mode, TLD, LAN mode, wildcard mode, and state directory
+
+### Bug Fixes
+
+- **Service reinstall port changes**: Reinstalling the startup service with a different port now stops any existing proxy on the previous port before starting the new service
+- **Service install validation**: LAN service installs now fail early on platforms that cannot publish mDNS records, and service paths such as `~` are normalized before writing native service files
+
+### Requirements
+
+- **Node.js 24**: The published package now requires Node.js 24 or newer, and repository development uses pnpm 11 with a minimum release age policy
+
 ## 0.13.0
 
 ### New Features

--- a/apps/docs/src/app/commands/page.mdx
+++ b/apps/docs/src/app/commands/page.mdx
@@ -191,11 +191,16 @@ portless proxy stop
 
 ```bash
 portless service install
+portless service install --lan
+portless service install --wildcard
+PORTLESS_STATE_DIR=~/.portless-lan PORTLESS_LAN=1 portless service install
 portless service status
 portless service uninstall
 ```
 
-Installs the proxy as an OS startup service using the default clean URL behavior: HTTPS on port 443 with `.localhost` names. macOS and Linux use a root-owned service so port 443 can bind at boot. Windows uses a Task Scheduler startup task that runs as SYSTEM. Installation and removal may require administrator privileges. `portless clean` automatically removes the service.
+Installs the proxy as an OS startup service. The default is HTTPS on port 443 with `.localhost` names, but `service install` accepts proxy options including `--port`, `--no-tls`, `--lan`, `--ip`, `--tld`, `--wildcard`, `--cert`, and `--key`. Use `--state-dir <path>` or `PORTLESS_STATE_DIR=<path>` to choose where service state and logs are written.
+
+The chosen service configuration is written into launchd, systemd, or Task Scheduler and reused after reboot. `portless service status` reports the installed port, HTTPS mode, TLD, LAN mode, wildcard mode, and state directory. macOS and Linux use a root-owned service so port 443 can bind at boot. Windows uses a Task Scheduler startup task that runs as SYSTEM. Installation and removal may require administrator privileges. `portless clean` automatically removes the service.
 
 ### LAN mode
 

--- a/packages/portless/package.json
+++ b/packages/portless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portless",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Replace port numbers with stable, named .localhost URLs. For humans and agents.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/portless/src/auto.test.ts
+++ b/packages/portless/src/auto.test.ts
@@ -361,6 +361,8 @@ describe("detectWorktreePrefix (git CLI path)", { timeout: 15_000 }, () => {
       "user.name=Test",
       "-c",
       "user.email=t@t",
+      "-c",
+      "commit.gpgsign=false",
       "commit",
       "--allow-empty",
       "-m",

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -3343,6 +3343,7 @@ async function handleNamedMode(args: string[]): Promise<void> {
     .split(".")
     .map((label) => truncateLabel(label))
     .join(".");
+  parseHostname(safeName, DEFAULT_TLD);
 
   const { dir, port, tls, tld, lanMode, lanIp } = await discoverState();
   const store = new RouteStore(dir, {

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1471,6 +1471,8 @@ ${colors.bold("Examples:")}
   portless run next dev               # -> https://<project>.localhost
   portless run next dev               # in worktree -> https://<worktree>.<project>.localhost
   portless service install            # Start HTTPS proxy on OS startup
+  portless service install --lan      # Persist LAN mode in the startup service
+  portless service install --wildcard # Persist wildcard routing in the startup service
   portless get backend                # -> https://backend.localhost
   portless myapp --tailscale next dev # -> also https://<node>.ts.net (tailnet)
   portless myapp --funnel next dev    # -> also https://<node>.ts.net (public)
@@ -1550,6 +1552,7 @@ ${colors.bold("Options:")}
   --foreground                  Run proxy in foreground (for debugging)
   --tld <tld>                   Use a custom TLD instead of .localhost (e.g. test, dev)
   --wildcard                    Allow unregistered subdomains to fall back to parent route
+  --state-dir <path>            Use a custom state directory with service install
   --app-port <number>           Use a fixed port for the app (skip auto-assignment)
   --tailscale                   Share the app on your Tailscale network (tailnet)
   --funnel                      Share the app publicly via Tailscale Funnel
@@ -1562,6 +1565,7 @@ ${colors.bold("Environment variables:")}
   PORTLESS_APP_PORT=<number>    Use a fixed port for the app (same as --app-port)
   PORTLESS_HTTPS=0              Disable HTTPS (same as --no-tls)
   PORTLESS_LAN=1                Enable LAN mode when set to 1 (set in .bashrc / .zshrc)
+  PORTLESS_LAN_IP=<address>     Pin a specific LAN IP for LAN mode
   PORTLESS_TLD=<tld>            Use a custom TLD (e.g. test, dev; default: localhost)
   PORTLESS_WILDCARD=1           Allow unregistered subdomains to fall back to parent route
   PORTLESS_SYNC_HOSTS=0         Disable auto-sync of ${HOSTS_DISPLAY} (on by default)

--- a/packages/portless/src/service.test.ts
+++ b/packages/portless/src/service.test.ts
@@ -39,8 +39,19 @@ vi.mock("./mdns.js", () => ({
   isMdnsSupported: vi.fn(() => ({ supported: true })),
 }));
 
+vi.mock("./cli-utils.js", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("./cli-utils.js")>();
+  return {
+    ...mod,
+    discoverState: vi.fn(mod.discoverState),
+    isProxyRunning: vi.fn(mod.isProxyRunning),
+  };
+});
+
 const { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } = await import("node:fs");
 const { isMdnsSupported } = await import("./mdns.js");
+const { discoverState, isProxyRunning } = await import("./cli-utils.js");
+const actualCliUtils = await vi.importActual<typeof import("./cli-utils.js")>("./cli-utils.js");
 
 const originalPlatform = process.platform;
 const originalGetuid = process.getuid;
@@ -74,6 +85,10 @@ afterEach(() => {
   vi.mocked(rmSync).mockRestore();
   vi.mocked(writeFileSync).mockRestore();
   vi.mocked(isMdnsSupported).mockReturnValue({ supported: true });
+  vi.mocked(discoverState).mockReset();
+  vi.mocked(discoverState).mockImplementation(actualCliUtils.discoverState);
+  vi.mocked(isProxyRunning).mockReset();
+  vi.mocked(isProxyRunning).mockImplementation(actualCliUtils.isProxyRunning);
 });
 
 describe("buildServiceSpec", () => {
@@ -457,6 +472,43 @@ describe("handleService", () => {
       command: process.execPath,
       args: ["/fake/cli.js", "proxy", "stop", "--port", "8443"],
     });
+  });
+
+  it("stops the discovered proxy before a different install port", async () => {
+    setPlatform("linux");
+    setGetuid(0);
+    const currentPort = 19000;
+    const targetPort = 19001;
+    vi.mocked(discoverState).mockResolvedValue({
+      dir: "/tmp/portless-service-current-test",
+      port: currentPort,
+      tls: true,
+      tld: "localhost",
+      lanMode: false,
+      lanIp: null,
+    });
+    vi.mocked(isProxyRunning).mockImplementation(async (port) => port === currentPort);
+    const runner = vi.fn((_: string, _args: string[]) => ({
+      status: 0,
+      stdout: "",
+      stderr: "",
+    }));
+
+    await handleService(["service", "install", "--port", targetPort.toString()], {
+      entryScript: "/fake/cli.js",
+      runner,
+    });
+
+    const stopPorts = runner.mock.calls
+      .filter(
+        ([command, args]) =>
+          command === process.execPath &&
+          args[0] === "/fake/cli.js" &&
+          args[1] === "proxy" &&
+          args[2] === "stop"
+      )
+      .map(([, args]) => args[4]);
+    expect(stopPorts).toEqual([currentPort.toString(), targetPort.toString()]);
   });
 
   it("does not validate proxy env while uninstalling", async () => {

--- a/packages/portless/src/service.test.ts
+++ b/packages/portless/src/service.test.ts
@@ -35,7 +35,12 @@ vi.mock("./utils.js", () => ({
   fixOwnership: vi.fn(),
 }));
 
+vi.mock("./mdns.js", () => ({
+  isMdnsSupported: vi.fn(() => ({ supported: true })),
+}));
+
 const { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } = await import("node:fs");
+const { isMdnsSupported } = await import("./mdns.js");
 
 const originalPlatform = process.platform;
 const originalGetuid = process.getuid;
@@ -68,6 +73,7 @@ afterEach(() => {
   vi.mocked(readFileSync).mockRestore();
   vi.mocked(rmSync).mockRestore();
   vi.mocked(writeFileSync).mockRestore();
+  vi.mocked(isMdnsSupported).mockReturnValue({ supported: true });
 });
 
 describe("buildServiceSpec", () => {
@@ -379,6 +385,29 @@ describe("handleService", () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
     const output = errorSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
     expect(output).toContain("bogus");
+  });
+
+  it("rejects unsupported LAN service installs before writing a Windows task", async () => {
+    setPlatform("win32");
+    vi.mocked(isMdnsSupported).mockReturnValue({
+      supported: false,
+      reason: "mDNS publishing is not supported on this platform",
+    });
+    const runner = vi.fn(() => ({ status: 0, stdout: "", stderr: "" }));
+
+    await expect(
+      handleService(["service", "install", "--lan"], {
+        entryScript: "/fake/cli.js",
+        runner,
+      })
+    ).rejects.toThrow("process.exit");
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(runner).not.toHaveBeenCalled();
+    expect(mkdirSync).not.toHaveBeenCalled();
+    expect(writeFileSync).not.toHaveBeenCalled();
+    const output = errorSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+    expect(output).toContain("LAN mode requires mDNS publishing");
   });
 
   it("stops an existing proxy before restarting the Linux service", async () => {

--- a/packages/portless/src/service.test.ts
+++ b/packages/portless/src/service.test.ts
@@ -13,6 +13,7 @@ vi.mock("node:fs", async (importOriginal) => {
     chmodSync: vi.fn(),
     existsSync: vi.fn(mod.existsSync),
     mkdirSync: vi.fn(),
+    readFileSync: vi.fn(mod.readFileSync),
     rmSync: vi.fn(),
     writeFileSync: vi.fn(),
   };
@@ -33,7 +34,7 @@ vi.mock("./utils.js", () => ({
   fixOwnership: vi.fn(),
 }));
 
-const { existsSync, rmSync } = await import("node:fs");
+const { existsSync, readFileSync, rmSync } = await import("node:fs");
 
 const originalPlatform = process.platform;
 const originalGetuid = process.getuid;
@@ -62,6 +63,7 @@ afterEach(() => {
     value: originalGetuid,
   });
   vi.mocked(existsSync).mockRestore();
+  vi.mocked(readFileSync).mockRestore();
   vi.mocked(rmSync).mockRestore();
 });
 
@@ -198,6 +200,65 @@ describe("buildServiceSpec", () => {
     if (spec.platform !== "darwin") throw new Error("Expected macOS service spec");
     expect(spec.plist).toContain("<key>KeepAlive</key>\n  <true/>");
     expect(spec.plist).not.toContain("SuccessfulExit");
+  });
+
+  it("persists LAN and wildcard settings in a macOS LaunchDaemon", () => {
+    const spec = buildServiceSpec({
+      platform: "darwin",
+      nodePath: "/usr/local/bin/node",
+      entryScript: "/usr/local/lib/portless/cli.js",
+      userHome: "/Users/alice",
+      uid: "501",
+      gid: "20",
+      installConfig: {
+        proxyPort: 8443,
+        lanMode: true,
+        lanIp: "192.168.1.42",
+        lanIpExplicit: true,
+        useWildcard: true,
+      },
+    });
+
+    if (spec.platform !== "darwin") throw new Error("Expected macOS service spec");
+    expect(spec.programArguments).toContain("--lan");
+    expect(spec.programArguments).toContain("--ip");
+    expect(spec.programArguments).toContain("192.168.1.42");
+    expect(spec.programArguments).toContain("--wildcard");
+    expect(spec.programArguments).toContain("8443");
+    expect(spec.plist).toContain("<key>PORTLESS_LAN</key>");
+    expect(spec.plist).toContain("<string>1</string>");
+    expect(spec.plist).toContain("<key>PORTLESS_LAN_IP</key>");
+    expect(spec.plist).toContain("<string>192.168.1.42</string>");
+    expect(spec.plist).toContain("<key>PORTLESS_WILDCARD</key>");
+  });
+
+  it("persists no-TLS, custom TLD, and custom state in a Linux service", () => {
+    const spec = buildServiceSpec({
+      platform: "linux",
+      nodePath: "/usr/bin/node",
+      entryScript: "/usr/lib/node_modules/portless/dist/cli.js",
+      userHome: "/home/alice",
+      uid: "1000",
+      gid: "1000",
+      installConfig: {
+        stateDir: "/srv/portless",
+        proxyPort: 8080,
+        useHttps: false,
+        tld: "test",
+        useWildcard: true,
+      },
+    });
+
+    if (spec.platform !== "linux") throw new Error("Expected Linux service spec");
+    expect(spec.execStart).toContain("--no-tls");
+    expect(spec.execStart).toContain("--tld");
+    expect(spec.execStart).toContain("test");
+    expect(spec.execStart).toContain("--wildcard");
+    expect(spec.unit).toContain('Environment=PORTLESS_STATE_DIR="/srv/portless"');
+    expect(spec.unit).toContain('Environment=PORTLESS_PORT="8080"');
+    expect(spec.unit).toContain('Environment=PORTLESS_HTTPS="0"');
+    expect(spec.unit).toContain('Environment=PORTLESS_TLD="test"');
+    expect(spec.stateDir).toBe("/srv/portless");
   });
 });
 
@@ -343,5 +404,76 @@ describe("handleService", () => {
 
     expect(stopIndex).toBeGreaterThanOrEqual(0);
     expect(restartIndex).toBeGreaterThan(stopIndex);
+  });
+
+  it("uses install flags when stopping an existing proxy before restart", async () => {
+    setPlatform("linux");
+    setGetuid(0);
+    const runner = vi.fn((_: string, _args: string[]) => ({
+      status: 0,
+      stdout: "",
+      stderr: "",
+    }));
+
+    await handleService(["service", "install", "--port", "8443", "--wildcard"], {
+      entryScript: "/fake/cli.js",
+      runner,
+    });
+
+    const calls = runner.mock.calls.map(([command, args]) => ({ command, args }));
+    expect(calls).toContainEqual({
+      command: process.execPath,
+      args: ["/fake/cli.js", "proxy", "stop", "--port", "8443"],
+    });
+  });
+
+  it("prints installed service config from a Linux unit", async () => {
+    setPlatform("linux");
+    setGetuid(0);
+    const installedSpec = buildServiceSpec({
+      platform: "linux",
+      nodePath: process.execPath,
+      entryScript: "/fake/cli.js",
+      userHome: "/home/alice",
+      installConfig: {
+        stateDir: "/srv/portless",
+        proxyPort: 8443,
+        useHttps: false,
+        lanMode: true,
+        lanIp: "192.168.1.42",
+        lanIpExplicit: true,
+        useWildcard: true,
+      },
+    });
+    if (installedSpec.platform !== "linux") throw new Error("Expected Linux service spec");
+
+    vi.mocked(existsSync).mockImplementation((file) => file === installedSpec.unitPath);
+    vi.mocked(readFileSync).mockImplementation((file) => {
+      if (file === installedSpec.unitPath) return installedSpec.unit;
+      return "";
+    });
+    const runner = vi.fn((command: string, args: string[]) => {
+      if (command === "systemctl" && args[0] === "is-enabled") {
+        return { status: 0, stdout: "enabled\n", stderr: "" };
+      }
+      if (command === "systemctl" && args[0] === "is-active") {
+        return { status: 1, stdout: "inactive\n", stderr: "" };
+      }
+      return { status: 0, stdout: "", stderr: "" };
+    });
+
+    await handleService(["service", "status"], {
+      entryScript: "/fake/cli.js",
+      runner,
+    });
+
+    const output = logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+    expect(output).toContain("Proxy on 8443");
+    expect(output).toContain("HTTPS: no");
+    expect(output).toContain("TLD: local");
+    expect(output).toContain("LAN mode: yes");
+    expect(output).toContain("LAN IP: 192.168.1.42");
+    expect(output).toContain("Wildcard: yes");
+    expect(output).toContain("State directory: /srv/portless");
   });
 });

--- a/packages/portless/src/service.test.ts
+++ b/packages/portless/src/service.test.ts
@@ -575,14 +575,17 @@ describe("handleService", () => {
     const stateDir = path.resolve("relative-state");
     const certPath = path.resolve("cert.pem");
     const keyPath = path.resolve("key.pem");
+    const systemdStateDir = stateDir.replace(/\\/g, "\\\\");
+    const systemdCertPath = certPath.replace(/\\/g, "\\\\");
+    const systemdKeyPath = keyPath.replace(/\\/g, "\\\\");
     const unitWrite = vi
       .mocked(writeFileSync)
       .mock.calls.find(([file]) => file === "/etc/systemd/system/portless.service");
     const unit = String(unitWrite?.[1] ?? "");
 
     expect(mkdirSync).toHaveBeenCalledWith(stateDir, { recursive: true });
-    expect(unit).toContain(`Environment=PORTLESS_STATE_DIR="${stateDir}"`);
-    expect(unit).toContain(`"--cert" "${certPath}" "--key" "${keyPath}"`);
+    expect(unit).toContain(`Environment=PORTLESS_STATE_DIR="${systemdStateDir}"`);
+    expect(unit).toContain(`"--cert" "${systemdCertPath}" "--key" "${systemdKeyPath}"`);
   });
 
   it("prints installed service config from a Linux unit", async () => {

--- a/packages/portless/src/service.test.ts
+++ b/packages/portless/src/service.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as path from "node:path";
 import {
   buildServiceSpec,
   buildServiceUninstallSudoArgs,
@@ -34,7 +35,7 @@ vi.mock("./utils.js", () => ({
   fixOwnership: vi.fn(),
 }));
 
-const { existsSync, readFileSync, rmSync } = await import("node:fs");
+const { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } = await import("node:fs");
 
 const originalPlatform = process.platform;
 const originalGetuid = process.getuid;
@@ -63,8 +64,10 @@ afterEach(() => {
     value: originalGetuid,
   });
   vi.mocked(existsSync).mockRestore();
+  vi.mocked(mkdirSync).mockRestore();
   vi.mocked(readFileSync).mockRestore();
   vi.mocked(rmSync).mockRestore();
+  vi.mocked(writeFileSync).mockRestore();
 });
 
 describe("buildServiceSpec", () => {
@@ -425,6 +428,80 @@ describe("handleService", () => {
       command: process.execPath,
       args: ["/fake/cli.js", "proxy", "stop", "--port", "8443"],
     });
+  });
+
+  it("does not validate proxy env while uninstalling", async () => {
+    setPlatform("linux");
+    setGetuid(0);
+    const originalPort = process.env.PORTLESS_PORT;
+    const originalTld = process.env.PORTLESS_TLD;
+    process.env.PORTLESS_PORT = "abc";
+    process.env.PORTLESS_TLD = "bad-name";
+    const runner = vi.fn((_: string, _args: string[]) => ({
+      status: 0,
+      stdout: "",
+      stderr: "",
+    }));
+
+    try {
+      await handleService(["service", "uninstall"], {
+        entryScript: "/fake/cli.js",
+        runner,
+      });
+    } finally {
+      if (originalPort === undefined) {
+        delete process.env.PORTLESS_PORT;
+      } else {
+        process.env.PORTLESS_PORT = originalPort;
+      }
+      if (originalTld === undefined) {
+        delete process.env.PORTLESS_TLD;
+      } else {
+        process.env.PORTLESS_TLD = originalTld;
+      }
+    }
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(runner).toHaveBeenCalledWith("systemctl", ["disable", "--now", "portless.service"]);
+  });
+
+  it("normalizes relative install paths before writing the Linux service", async () => {
+    setPlatform("linux");
+    setGetuid(0);
+    const runner = vi.fn((_: string, _args: string[]) => ({
+      status: 0,
+      stdout: "",
+      stderr: "",
+    }));
+
+    await handleService(
+      [
+        "service",
+        "install",
+        "--state-dir",
+        "relative-state",
+        "--cert",
+        "cert.pem",
+        "--key",
+        "key.pem",
+      ],
+      {
+        entryScript: "/fake/cli.js",
+        runner,
+      }
+    );
+
+    const stateDir = path.resolve("relative-state");
+    const certPath = path.resolve("cert.pem");
+    const keyPath = path.resolve("key.pem");
+    const unitWrite = vi
+      .mocked(writeFileSync)
+      .mock.calls.find(([file]) => file === "/etc/systemd/system/portless.service");
+    const unit = String(unitWrite?.[1] ?? "");
+
+    expect(mkdirSync).toHaveBeenCalledWith(stateDir, { recursive: true });
+    expect(unit).toContain(`Environment=PORTLESS_STATE_DIR="${stateDir}"`);
+    expect(unit).toContain(`"--cert" "${certPath}" "--key" "${keyPath}"`);
   });
 
   it("prints installed service config from a Linux unit", async () => {

--- a/packages/portless/src/service.ts
+++ b/packages/portless/src/service.ts
@@ -7,6 +7,7 @@ import { ensureCerts, isCATrusted, trustCA } from "./certs.js";
 import {
   buildProxyStartConfig,
   DEFAULT_TLD,
+  discoverState,
   getProtocolPort,
   isProxyRunning,
   validateTld,
@@ -900,7 +901,7 @@ function isPermissionError(err: unknown): boolean {
   );
 }
 
-function stopExistingProxy(entryScript: string, runner: CommandRunner, proxyPort: number): void {
+function stopProxyOnPort(entryScript: string, runner: CommandRunner, proxyPort: number): void {
   runRequired(runner, process.execPath, [
     entryScript,
     "proxy",
@@ -908,6 +909,27 @@ function stopExistingProxy(entryScript: string, runner: CommandRunner, proxyPort
     "--port",
     proxyPort.toString(),
   ]);
+}
+
+async function stopExistingProxy(
+  entryScript: string,
+  runner: CommandRunner,
+  proxyPort: number
+): Promise<void> {
+  const ports = new Set<number>();
+  try {
+    const currentState = await discoverState();
+    if (currentState.port !== proxyPort && (await isProxyRunning(currentState.port))) {
+      ports.add(currentState.port);
+    }
+  } catch {
+    // Best effort. The target port stop below still performs stale state cleanup.
+  }
+
+  ports.add(proxyPort);
+  for (const port of ports) {
+    stopProxyOnPort(entryScript, runner, port);
+  }
 }
 
 function prepareServiceState(stateDir: string): void {
@@ -968,7 +990,7 @@ async function installService(
 
   if (spec.platform === "darwin") {
     runOptional(runner, "launchctl", ["bootout", "system", spec.plistPath]);
-    stopExistingProxy(entryScript, runner, spec.config.proxyPort);
+    await stopExistingProxy(entryScript, runner, spec.config.proxyPort);
     fs.writeFileSync(spec.plistPath, spec.plist);
     fs.chmodSync(spec.plistPath, 0o644);
     runRequired(runner, "chown", ["root:wheel", spec.plistPath]);
@@ -977,7 +999,7 @@ async function installService(
     runRequired(runner, "launchctl", ["kickstart", "-k", `system/${spec.label}`]);
   } else if (spec.platform === "linux") {
     runOptional(runner, "systemctl", ["disable", "--now", spec.serviceName]);
-    stopExistingProxy(entryScript, runner, spec.config.proxyPort);
+    await stopExistingProxy(entryScript, runner, spec.config.proxyPort);
     fs.writeFileSync(spec.unitPath, spec.unit);
     fs.chmodSync(spec.unitPath, 0o644);
     runRequired(runner, "systemctl", ["daemon-reload"]);
@@ -985,7 +1007,7 @@ async function installService(
     runRequired(runner, "systemctl", ["restart", spec.serviceName]);
   } else {
     runOptional(runner, "schtasks", ["/End", "/TN", spec.taskName]);
-    stopExistingProxy(entryScript, runner, spec.config.proxyPort);
+    await stopExistingProxy(entryScript, runner, spec.config.proxyPort);
     fs.mkdirSync(spec.scriptDir, { recursive: true });
     fs.writeFileSync(spec.scriptPath, spec.script);
     runRequired(runner, "schtasks", spec.createArgs);

--- a/packages/portless/src/service.ts
+++ b/packages/portless/src/service.ts
@@ -9,14 +9,16 @@ import {
   DEFAULT_TLD,
   getProtocolPort,
   isProxyRunning,
+  validateTld,
 } from "./cli-utils.js";
 import { fixOwnership } from "./utils.js";
 
-const SERVICE_PORT = getProtocolPort(true);
+const DEFAULT_SERVICE_PORT = getProtocolPort(true);
 const SERVICE_LABEL = "sh.portless.proxy";
 const SYSTEMD_SERVICE = "portless.service";
 const WINDOWS_TASK_NAME = "Portless Proxy";
 const INTERNAL_ELEVATED_ENV = "PORTLESS_INTERNAL_SERVICE_ELEVATED";
+const SERVICE_ENV_KEYS = new Set(["PORTLESS_SYNC_HOSTS"]);
 
 type SupportedPlatform = "darwin" | "linux" | "win32";
 
@@ -46,6 +48,38 @@ type ServiceContext = {
   user: UserContext;
   pathEnv: string;
   programData: string;
+  config: NormalizedServiceConfig;
+};
+
+export type ServiceInstallConfig = {
+  stateDir?: string;
+  proxyPort: number;
+  useHttps: boolean;
+  customCertPath: string | null;
+  customKeyPath: string | null;
+  lanMode: boolean;
+  lanIp: string | null;
+  lanIpExplicit: boolean;
+  tld: string;
+  useWildcard: boolean;
+  extraEnv: Record<string, string>;
+};
+
+export type NormalizedServiceConfig = ServiceInstallConfig & {
+  stateDir: string;
+};
+
+const DEFAULT_SERVICE_CONFIG: ServiceInstallConfig = {
+  proxyPort: DEFAULT_SERVICE_PORT,
+  useHttps: true,
+  customCertPath: null,
+  customKeyPath: null,
+  lanMode: false,
+  lanIp: null,
+  lanIpExplicit: false,
+  tld: DEFAULT_TLD,
+  useWildcard: false,
+  extraEnv: {},
 };
 
 export type ServiceSpec =
@@ -55,6 +89,7 @@ export type ServiceSpec =
       plistPath: string;
       plist: string;
       stateDir: string;
+      config: NormalizedServiceConfig;
       programArguments: string[];
     }
   | {
@@ -63,12 +98,14 @@ export type ServiceSpec =
       unitPath: string;
       unit: string;
       stateDir: string;
+      config: NormalizedServiceConfig;
       execStart: string[];
     }
   | {
       platform: "win32";
       taskName: string;
       stateDir: string;
+      config: NormalizedServiceConfig;
       scriptDir: string;
       scriptPath: string;
       script: string;
@@ -83,6 +120,7 @@ type ServiceStatus = {
   installed: boolean;
   managerState: string;
   proxyRunning: boolean;
+  config: NormalizedServiceConfig;
   details?: string;
 };
 
@@ -119,6 +157,176 @@ function systemdEscape(value: string): string {
 
 function windowsQuote(value: string): string {
   return `"${value.replace(/"/g, '\\"')}"`;
+}
+
+function xmlUnescape(value: string): string {
+  return value
+    .replace(/&apos;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&gt;/g, ">")
+    .replace(/&lt;/g, "<")
+    .replace(/&amp;/g, "&");
+}
+
+function parseBooleanEnv(value: string | undefined): boolean | null {
+  if (value === undefined) return null;
+  if (value === "1" || value === "true") return true;
+  if (value === "0" || value === "false") return false;
+  return null;
+}
+
+function parsePortValue(value: string, source: string): number {
+  const port = parseInt(value, 10);
+  if (isNaN(port) || port < 1 || port > 65535) {
+    throw new Error(`${source} must be a number between 1 and 65535.`);
+  }
+  return port;
+}
+
+function getFlagValue(args: string[], index: number, flag: string): string {
+  const value = args[index + 1];
+  if (!value || value.startsWith("-")) {
+    throw new Error(`${flag} requires a value.`);
+  }
+  return value;
+}
+
+function collectServiceExtraEnv(
+  env: NodeJS.ProcessEnv | Record<string, string>
+): Record<string, string> {
+  const extraEnv: Record<string, string> = {};
+  for (const key of SERVICE_ENV_KEYS) {
+    const value = env[key];
+    if (value) extraEnv[key] = value;
+  }
+  return extraEnv;
+}
+
+function parseServiceInstallConfig(
+  args: string[],
+  env: NodeJS.ProcessEnv | Record<string, string> = process.env,
+  options: { allowRuntimeFlags?: boolean } = {}
+): ServiceInstallConfig {
+  const config: ServiceInstallConfig = {
+    ...DEFAULT_SERVICE_CONFIG,
+    extraEnv: collectServiceExtraEnv(env),
+  };
+
+  if (env.PORTLESS_STATE_DIR) {
+    config.stateDir = env.PORTLESS_STATE_DIR;
+  }
+
+  const envHttps = parseBooleanEnv(env.PORTLESS_HTTPS);
+  if (envHttps !== null) {
+    config.useHttps = envHttps;
+  }
+
+  const envLan = parseBooleanEnv(env.PORTLESS_LAN);
+  if (envLan !== null) {
+    config.lanMode = envLan;
+  }
+
+  if (env.PORTLESS_LAN_IP) {
+    config.lanMode = true;
+    config.lanIp = env.PORTLESS_LAN_IP;
+    config.lanIpExplicit = true;
+  }
+
+  if (env.PORTLESS_TLD) {
+    const tld = env.PORTLESS_TLD.trim().toLowerCase();
+    const err = validateTld(tld);
+    if (err) throw new Error(`PORTLESS_TLD: ${err}`);
+    config.tld = tld;
+  }
+
+  const envWildcard = parseBooleanEnv(env.PORTLESS_WILDCARD);
+  if (envWildcard !== null) {
+    config.useWildcard = envWildcard;
+  }
+
+  if (env.PORTLESS_PORT) {
+    config.proxyPort = parsePortValue(env.PORTLESS_PORT, "PORTLESS_PORT");
+  } else {
+    config.proxyPort = getProtocolPort(config.useHttps);
+  }
+
+  const tokens = args[0] === "service" ? args.slice(2) : args;
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    switch (token) {
+      case "-p":
+      case "--port":
+        config.proxyPort = parsePortValue(getFlagValue(tokens, i, token), token);
+        i += 1;
+        break;
+      case "--https":
+        config.useHttps = true;
+        break;
+      case "--no-tls":
+        config.useHttps = false;
+        break;
+      case "--lan":
+        config.lanMode = true;
+        break;
+      case "--ip":
+        config.lanMode = true;
+        config.lanIp = getFlagValue(tokens, i, token);
+        config.lanIpExplicit = true;
+        i += 1;
+        break;
+      case "--tld": {
+        const tld = getFlagValue(tokens, i, token).trim().toLowerCase();
+        const err = validateTld(tld);
+        if (err) throw new Error(err);
+        config.tld = tld;
+        i += 1;
+        break;
+      }
+      case "--wildcard":
+        config.useWildcard = true;
+        break;
+      case "--cert":
+        config.customCertPath = getFlagValue(tokens, i, token);
+        config.useHttps = true;
+        i += 1;
+        break;
+      case "--key":
+        config.customKeyPath = getFlagValue(tokens, i, token);
+        config.useHttps = true;
+        i += 1;
+        break;
+      case "--state-dir":
+        config.stateDir = getFlagValue(tokens, i, token);
+        i += 1;
+        break;
+      case "--foreground":
+      case "--skip-trust":
+        if (!options.allowRuntimeFlags) {
+          throw new Error(`Unknown service install option "${token}".`);
+        }
+        break;
+      default:
+        throw new Error(`Unknown service install option "${token}".`);
+    }
+  }
+
+  if (
+    (config.customCertPath && !config.customKeyPath) ||
+    (!config.customCertPath && config.customKeyPath)
+  ) {
+    throw new Error("--cert and --key must be used together.");
+  }
+
+  if (!env.PORTLESS_PORT && !tokens.includes("--port") && !tokens.includes("-p")) {
+    config.proxyPort = getProtocolPort(config.useHttps);
+  }
+
+  if (!config.lanMode) {
+    config.lanIp = null;
+    config.lanIpExplicit = false;
+  }
+
+  return config;
 }
 
 function readPasswdHome(username: string): string | null {
@@ -165,23 +373,43 @@ function resolveUserContext(platform: SupportedPlatform): UserContext {
   };
 }
 
-function buildProxyCommand(entryScript: string): string[] {
-  const config = buildProxyStartConfig({
-    useHttps: true,
-    lanMode: false,
-    tld: DEFAULT_TLD,
+function buildProxyCommand(entryScript: string, serviceConfig: ServiceInstallConfig): string[] {
+  const proxyConfig = buildProxyStartConfig({
+    useHttps: serviceConfig.useHttps,
+    customCertPath: serviceConfig.customCertPath,
+    customKeyPath: serviceConfig.customKeyPath,
+    lanMode: serviceConfig.lanMode,
+    lanIp: serviceConfig.lanIp,
+    lanIpExplicit: serviceConfig.lanIpExplicit,
+    tld: serviceConfig.tld,
+    useWildcard: serviceConfig.useWildcard,
     foreground: true,
     includePort: true,
-    proxyPort: SERVICE_PORT,
+    proxyPort: serviceConfig.proxyPort,
     skipTrust: true,
   });
-  return [entryScript, "proxy", "start", ...config.args];
+  return [entryScript, "proxy", "start", ...proxyConfig.args];
 }
 
 function buildServiceEnv(ctx: ServiceContext): Record<string, string> {
   const env: Record<string, string> = {
     PORTLESS_STATE_DIR: ctx.stateDir,
+    PORTLESS_PORT: ctx.config.proxyPort.toString(),
+    PORTLESS_HTTPS: ctx.config.useHttps ? "1" : "0",
+    PORTLESS_LAN: ctx.config.lanMode ? "1" : "0",
+    PORTLESS_WILDCARD: ctx.config.useWildcard ? "1" : "0",
+    ...ctx.config.extraEnv,
   };
+
+  if (ctx.config.lanMode && ctx.config.lanIpExplicit && ctx.config.lanIp) {
+    env.PORTLESS_LAN_IP = ctx.config.lanIp;
+  }
+
+  if (ctx.config.lanMode) {
+    env.PORTLESS_TLD = "local";
+  } else if (ctx.config.tld !== DEFAULT_TLD) {
+    env.PORTLESS_TLD = ctx.config.tld;
+  }
 
   if (ctx.platform === "win32") {
     env.USERPROFILE = ctx.user.home;
@@ -284,12 +512,26 @@ export function buildServiceSpec(options: {
   stateDir?: string;
   pathEnv?: string;
   programData?: string;
+  installConfig?: Partial<ServiceInstallConfig>;
 }): ServiceSpec {
+  const installConfig: ServiceInstallConfig = {
+    ...DEFAULT_SERVICE_CONFIG,
+    ...options.installConfig,
+    extraEnv: options.installConfig?.extraEnv ?? {},
+  };
+  const stateDir =
+    options.stateDir ||
+    installConfig.stateDir ||
+    defaultStateDir(options.platform, options.userHome);
+  const normalizedConfig: NormalizedServiceConfig = {
+    ...installConfig,
+    stateDir,
+  };
   const ctx: ServiceContext = {
     platform: options.platform,
     nodePath: options.nodePath,
     entryScript: options.entryScript,
-    stateDir: options.stateDir || defaultStateDir(options.platform, options.userHome),
+    stateDir,
     user: {
       home: options.userHome,
       uid: options.uid,
@@ -298,8 +540,9 @@ export function buildServiceSpec(options: {
     },
     pathEnv: options.pathEnv || "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
     programData: options.programData || "C:\\ProgramData",
+    config: normalizedConfig,
   };
-  const proxyCommand = buildProxyCommand(ctx.entryScript);
+  const proxyCommand = buildProxyCommand(ctx.entryScript, ctx.config);
 
   if (ctx.platform === "darwin") {
     const programArguments = [ctx.nodePath, ...proxyCommand];
@@ -309,6 +552,7 @@ export function buildServiceSpec(options: {
       plistPath: `/Library/LaunchDaemons/${SERVICE_LABEL}.plist`,
       plist: buildLaunchdPlist(ctx, programArguments),
       stateDir: ctx.stateDir,
+      config: ctx.config,
       programArguments,
     };
   }
@@ -321,6 +565,7 @@ export function buildServiceSpec(options: {
       unitPath: `/etc/systemd/system/${SYSTEMD_SERVICE}`,
       unit: buildSystemdUnit(ctx, execStart),
       stateDir: ctx.stateDir,
+      config: ctx.config,
       execStart,
     };
   }
@@ -333,6 +578,7 @@ export function buildServiceSpec(options: {
     platform: "win32",
     taskName: WINDOWS_TASK_NAME,
     stateDir: ctx.stateDir,
+    config: ctx.config,
     scriptDir,
     scriptPath,
     script,
@@ -357,7 +603,10 @@ export function buildServiceSpec(options: {
   };
 }
 
-function currentServiceSpec(entryScript: string): ServiceSpec {
+function currentServiceSpec(
+  entryScript: string,
+  installConfig: ServiceInstallConfig = parseServiceInstallConfig(["service", "install"])
+): ServiceSpec {
   if (!isSupportedPlatform(process.platform)) {
     throw new Error(`Unsupported platform: ${process.platform}`);
   }
@@ -371,10 +620,159 @@ function currentServiceSpec(entryScript: string): ServiceSpec {
     uid: user.uid,
     gid: user.gid,
     username: user.username,
-    stateDir: process.env.PORTLESS_STATE_DIR || defaultStateDir(process.platform, user.home),
+    stateDir:
+      installConfig.stateDir ||
+      process.env.PORTLESS_STATE_DIR ||
+      defaultStateDir(process.platform, user.home),
     pathEnv: process.env.PATH,
     programData: process.env.ProgramData,
+    installConfig,
   });
+}
+
+type InstalledServiceSnapshot = {
+  command: string[];
+  env: Record<string, string>;
+};
+
+function parseQuotedWords(input: string, options: { unescapeBackslash?: boolean } = {}): string[] {
+  const words: string[] = [];
+  let current = "";
+  let inQuote = false;
+  let inWord = false;
+  const unescapeBackslash = options.unescapeBackslash ?? true;
+
+  for (let i = 0; i < input.length; i += 1) {
+    const char = input[i];
+    if (char === '"') {
+      inQuote = !inQuote;
+      inWord = true;
+      continue;
+    }
+    if (
+      char === "\\" &&
+      i + 1 < input.length &&
+      (input[i + 1] === '"' || (unescapeBackslash && input[i + 1] === "\\"))
+    ) {
+      current += input[i + 1];
+      inWord = true;
+      i += 1;
+      continue;
+    }
+    if (/\s/.test(char) && !inQuote) {
+      if (inWord) {
+        words.push(current);
+        current = "";
+        inWord = false;
+      }
+      continue;
+    }
+    current += char;
+    inWord = true;
+  }
+
+  if (inWord) {
+    words.push(current);
+  }
+
+  return words;
+}
+
+function parsePlistStrings(block: string): string[] {
+  return [...block.matchAll(/<string>([\s\S]*?)<\/string>/g)].map((match) => xmlUnescape(match[1]));
+}
+
+function parsePlistEnv(block: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const match of block.matchAll(/<key>([\s\S]*?)<\/key>\s*<string>([\s\S]*?)<\/string>/g)) {
+    env[xmlUnescape(match[1])] = xmlUnescape(match[2]);
+  }
+  return env;
+}
+
+function readInstalledServiceSnapshot(spec: ServiceSpec): InstalledServiceSnapshot | null {
+  try {
+    if (spec.platform === "darwin") {
+      if (!fs.existsSync(spec.plistPath)) return null;
+      const plist = fs.readFileSync(spec.plistPath, "utf-8");
+      const argsBlock = plist.match(/<key>ProgramArguments<\/key>\s*<array>([\s\S]*?)<\/array>/);
+      const envBlock = plist.match(/<key>EnvironmentVariables<\/key>\s*<dict>([\s\S]*?)<\/dict>/);
+      if (!argsBlock) return null;
+      return {
+        command: parsePlistStrings(argsBlock[1]),
+        env: envBlock ? parsePlistEnv(envBlock[1]) : {},
+      };
+    }
+
+    if (spec.platform === "linux") {
+      if (!fs.existsSync(spec.unitPath)) return null;
+      const unit = fs.readFileSync(spec.unitPath, "utf-8");
+      const env: Record<string, string> = {};
+      let command: string[] | null = null;
+      for (const line of unit.split("\n")) {
+        if (line.startsWith("Environment=")) {
+          const entry = line.slice("Environment=".length);
+          const eq = entry.indexOf("=");
+          if (eq > 0) {
+            const key = entry.slice(0, eq);
+            const value = parseQuotedWords(entry.slice(eq + 1))[0] ?? "";
+            env[key] = value;
+          }
+        } else if (line.startsWith("ExecStart=")) {
+          command = parseQuotedWords(line.slice("ExecStart=".length));
+        }
+      }
+      return command ? { command, env } : null;
+    }
+
+    if (!fs.existsSync(spec.scriptPath)) return null;
+    const script = fs.readFileSync(spec.scriptPath, "utf-8");
+    const env: Record<string, string> = {};
+    let commandLine: string | null = null;
+    for (const rawLine of script.split(/\r?\n/)) {
+      const line = rawLine.trim();
+      if (!line || line.toLowerCase() === "@echo off") continue;
+      const envMatch = line.match(/^set "([^=]+)=(.*)"$/);
+      if (envMatch) {
+        env[envMatch[1]] = envMatch[2].replace(/%%/g, "%");
+        continue;
+      }
+      commandLine = line;
+    }
+    return commandLine
+      ? { command: parseQuotedWords(commandLine, { unescapeBackslash: false }), env }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function installedConfigFromSnapshot(
+  snapshot: InstalledServiceSnapshot,
+  fallback: NormalizedServiceConfig
+): NormalizedServiceConfig | null {
+  const proxyIndex = snapshot.command.findIndex(
+    (arg, index) => arg === "proxy" && snapshot.command[index + 1] === "start"
+  );
+  if (proxyIndex === -1) return null;
+
+  try {
+    const parsed = parseServiceInstallConfig(
+      ["service", "install", ...snapshot.command.slice(proxyIndex + 2)],
+      snapshot.env,
+      { allowRuntimeFlags: true }
+    );
+    const stateDir = parsed.stateDir || snapshot.env.PORTLESS_STATE_DIR || fallback.stateDir;
+    return { ...parsed, stateDir };
+  } catch {
+    return null;
+  }
+}
+
+function readInstalledServiceConfig(spec: ServiceSpec): NormalizedServiceConfig | null {
+  const snapshot = readInstalledServiceSnapshot(spec);
+  if (!snapshot) return null;
+  return installedConfigFromSnapshot(snapshot, spec.config);
 }
 
 function collectPortlessEnvArgs(
@@ -476,19 +874,22 @@ function isPermissionError(err: unknown): boolean {
   );
 }
 
-function stopExistingProxy(entryScript: string, runner: CommandRunner): void {
+function stopExistingProxy(entryScript: string, runner: CommandRunner, proxyPort: number): void {
   runRequired(runner, process.execPath, [
     entryScript,
     "proxy",
     "stop",
     "--port",
-    SERVICE_PORT.toString(),
+    proxyPort.toString(),
   ]);
 }
 
-function prepareTrust(stateDir: string): void {
+function prepareServiceState(stateDir: string): void {
   fs.mkdirSync(stateDir, { recursive: true });
   fixOwnership(stateDir);
+}
+
+function prepareTrust(stateDir: string): void {
   try {
     ensureCerts(stateDir);
   } catch (err) {
@@ -513,14 +914,23 @@ function prepareTrust(stateDir: string): void {
   console.warn(colors.yellow("Run `portless trust` if browsers show certificate warnings."));
 }
 
-async function installService(entryScript: string, runner: CommandRunner): Promise<void> {
-  requireUnixElevation([entryScript, "service", "install"], runner);
-  const spec = currentServiceSpec(entryScript);
-  prepareTrust(spec.stateDir);
+async function installService(
+  entryScript: string,
+  runner: CommandRunner,
+  args: string[]
+): Promise<void> {
+  const installConfig = parseServiceInstallConfig(args);
+  requireUnixElevation([entryScript, ...args], runner);
+  const spec = currentServiceSpec(entryScript, installConfig);
+  prepareServiceState(spec.stateDir);
+
+  if (spec.config.useHttps && !spec.config.customCertPath) {
+    prepareTrust(spec.stateDir);
+  }
 
   if (spec.platform === "darwin") {
     runOptional(runner, "launchctl", ["bootout", "system", spec.plistPath]);
-    stopExistingProxy(entryScript, runner);
+    stopExistingProxy(entryScript, runner, spec.config.proxyPort);
     fs.writeFileSync(spec.plistPath, spec.plist);
     fs.chmodSync(spec.plistPath, 0o644);
     runRequired(runner, "chown", ["root:wheel", spec.plistPath]);
@@ -529,7 +939,7 @@ async function installService(entryScript: string, runner: CommandRunner): Promi
     runRequired(runner, "launchctl", ["kickstart", "-k", `system/${spec.label}`]);
   } else if (spec.platform === "linux") {
     runOptional(runner, "systemctl", ["disable", "--now", spec.serviceName]);
-    stopExistingProxy(entryScript, runner);
+    stopExistingProxy(entryScript, runner, spec.config.proxyPort);
     fs.writeFileSync(spec.unitPath, spec.unit);
     fs.chmodSync(spec.unitPath, 0o644);
     runRequired(runner, "systemctl", ["daemon-reload"]);
@@ -537,7 +947,7 @@ async function installService(entryScript: string, runner: CommandRunner): Promi
     runRequired(runner, "systemctl", ["restart", spec.serviceName]);
   } else {
     runOptional(runner, "schtasks", ["/End", "/TN", spec.taskName]);
-    stopExistingProxy(entryScript, runner);
+    stopExistingProxy(entryScript, runner, spec.config.proxyPort);
     fs.mkdirSync(spec.scriptDir, { recursive: true });
     fs.writeFileSync(spec.scriptPath, spec.script);
     runRequired(runner, "schtasks", spec.createArgs);
@@ -546,6 +956,7 @@ async function installService(entryScript: string, runner: CommandRunner): Promi
 
   console.log(colors.green("Portless service installed."));
   console.log(colors.gray(`State directory: ${spec.stateDir}`));
+  console.log(colors.gray(`Proxy port: ${spec.config.proxyPort}`));
 }
 
 async function uninstallService(entryScript: string, runner: CommandRunner): Promise<void> {
@@ -617,7 +1028,8 @@ async function getServiceStatus(
   runner: CommandRunner
 ): Promise<ServiceStatus> {
   const spec = currentServiceSpec(entryScript);
-  const proxyRunning = await isProxyRunning(SERVICE_PORT);
+  const installedConfig = readInstalledServiceConfig(spec) ?? spec.config;
+  const proxyRunning = await isProxyRunning(installedConfig.proxyPort, installedConfig.useHttps);
 
   if (spec.platform === "darwin") {
     const installed = fs.existsSync(spec.plistPath);
@@ -629,7 +1041,13 @@ async function getServiceStatus(
         : installed
           ? "installed"
           : "not installed";
-    return { installed, managerState, proxyRunning, details: spec.plistPath };
+    return {
+      installed,
+      managerState,
+      proxyRunning,
+      config: installedConfig,
+      details: spec.plistPath,
+    };
   }
 
   if (spec.platform === "linux") {
@@ -642,6 +1060,7 @@ async function getServiceStatus(
       managerState:
         active.status === 0 ? activeText || "active" : installed ? "installed" : "not installed",
       proxyRunning,
+      config: installedConfig,
       details: spec.unitPath,
     };
   }
@@ -654,18 +1073,28 @@ async function getServiceStatus(
     installed,
     managerState: installed ? stateMatch?.[1]?.trim() || "installed" : "not installed",
     proxyRunning,
+    config: installedConfig,
     details: spec.taskName,
   };
 }
 
 async function printServiceStatus(entryScript: string, runner: CommandRunner): Promise<void> {
-  const spec = currentServiceSpec(entryScript);
   const status = await getServiceStatus(entryScript, runner);
+  const config = status.config;
   console.log(colors.bold("portless service"));
   console.log(`  Manager state: ${status.managerState}`);
   console.log(`  Installed: ${status.installed ? "yes" : "no"}`);
-  console.log(`  Proxy on 443: ${status.proxyRunning ? "responding" : "not responding"}`);
-  console.log(`  State directory: ${spec.stateDir}`);
+  console.log(
+    `  Proxy on ${config.proxyPort}: ${status.proxyRunning ? "responding" : "not responding"}`
+  );
+  console.log(`  HTTPS: ${config.useHttps ? "yes" : "no"}`);
+  console.log(`  TLD: ${config.lanMode ? "local" : config.tld}`);
+  console.log(`  LAN mode: ${config.lanMode ? "yes" : "no"}`);
+  if (config.lanIpExplicit && config.lanIp) {
+    console.log(`  LAN IP: ${config.lanIp}`);
+  }
+  console.log(`  Wildcard: ${config.useWildcard ? "yes" : "no"}`);
+  console.log(`  State directory: ${config.stateDir}`);
   if (status.details) {
     console.log(`  Service entry: ${status.details}`);
   }
@@ -676,12 +1105,27 @@ export function printServiceHelp(): void {
 ${colors.bold("portless service")} - Start portless automatically when the OS starts.
 
 ${colors.bold("Usage:")}
-  ${colors.cyan("portless service install")}      Install and start the HTTPS service on port 443
-  ${colors.cyan("portless service uninstall")}    Stop and remove the startup service
-  ${colors.cyan("portless service status")}       Show service and proxy status
+  ${colors.cyan("portless service install")}             Install and start the HTTPS service on port 443
+  ${colors.cyan("portless service install --lan")}       Enable LAN mode for the startup service
+  ${colors.cyan("portless service install -p 8443")}     Use a custom proxy port
+  ${colors.cyan("portless service uninstall")}           Stop and remove the startup service
+  ${colors.cyan("portless service status")}              Show service and proxy status
+
+${colors.bold("Install options:")}
+  -p, --port <number>              Port for the proxy service
+  --no-tls                         Disable HTTPS
+  --https                          Enable HTTPS
+  --lan                            Enable LAN mode
+  --ip <address>                   Pin a specific LAN IP
+  --tld <tld>                      Use a custom TLD outside LAN mode
+  --wildcard                       Allow subdomain fallback
+  --cert <path>                    Use a custom TLS certificate
+  --key <path>                     Use a custom TLS private key
+  --state-dir <path>               Use a custom service state directory
 
 ${colors.bold("Notes:")}
-  The service uses the default clean URL mode: HTTPS on port 443.
+  The service uses the default clean URL mode unless options or PORTLESS_*
+  environment variables are provided during install.
   macOS and Linux install a root-owned service so port 443 can bind at boot.
   Windows installs a Task Scheduler startup task that runs as SYSTEM.
 `);
@@ -701,7 +1145,7 @@ export async function handleService(
 
   try {
     if (action === "install") {
-      await installService(options.entryScript, runner);
+      await installService(options.entryScript, runner, args);
       return;
     }
     if (action === "uninstall") {

--- a/packages/portless/src/service.ts
+++ b/packages/portless/src/service.ts
@@ -11,6 +11,7 @@ import {
   isProxyRunning,
   validateTld,
 } from "./cli-utils.js";
+import { isMdnsSupported } from "./mdns.js";
 import { fixOwnership } from "./utils.js";
 
 const DEFAULT_SERVICE_PORT = getProtocolPort(true);
@@ -939,12 +940,24 @@ function prepareTrust(stateDir: string): void {
   console.warn(colors.yellow("Run `portless trust` if browsers show certificate warnings."));
 }
 
+function ensureServiceConfigSupported(config: ServiceInstallConfig): void {
+  if (!config.lanMode) return;
+  const mdnsSupport = isMdnsSupported();
+  if (mdnsSupport.supported) return;
+
+  const reason = mdnsSupport.reason ? `\n${mdnsSupport.reason}` : "";
+  throw new Error(
+    `LAN mode requires mDNS publishing, which is not supported on this platform.${reason}`
+  );
+}
+
 async function installService(
   entryScript: string,
   runner: CommandRunner,
   args: string[]
 ): Promise<void> {
   const installConfig = normalizeServiceInstallPaths(parseServiceInstallConfig(args));
+  ensureServiceConfigSupported(installConfig);
   requireUnixElevation([entryScript, ...args], runner);
   const spec = currentServiceSpec(entryScript, installConfig);
   prepareServiceState(spec.stateDir);

--- a/packages/portless/src/service.ts
+++ b/packages/portless/src/service.ts
@@ -191,6 +191,25 @@ function getFlagValue(args: string[], index: number, flag: string): string {
   return value;
 }
 
+function resolveServicePath(value: string): string {
+  const expanded =
+    value === "~"
+      ? os.homedir()
+      : value.startsWith("~/") || value.startsWith("~\\")
+        ? path.join(os.homedir(), value.slice(2))
+        : value;
+  return path.resolve(expanded);
+}
+
+function normalizeServiceInstallPaths(config: ServiceInstallConfig): ServiceInstallConfig {
+  return {
+    ...config,
+    stateDir: config.stateDir ? resolveServicePath(config.stateDir) : undefined,
+    customCertPath: config.customCertPath ? resolveServicePath(config.customCertPath) : null,
+    customKeyPath: config.customKeyPath ? resolveServicePath(config.customKeyPath) : null,
+  };
+}
+
 function collectServiceExtraEnv(
   env: NodeJS.ProcessEnv | Record<string, string>
 ): Record<string, string> {
@@ -605,13 +624,22 @@ export function buildServiceSpec(options: {
 
 function currentServiceSpec(
   entryScript: string,
-  installConfig: ServiceInstallConfig = parseServiceInstallConfig(["service", "install"])
+  installConfig?: ServiceInstallConfig
 ): ServiceSpec {
   if (!isSupportedPlatform(process.platform)) {
     throw new Error(`Unsupported platform: ${process.platform}`);
   }
 
   const user = resolveUserContext(process.platform);
+  const stateDir =
+    installConfig?.stateDir ||
+    process.env.PORTLESS_STATE_DIR ||
+    defaultStateDir(process.platform, user.home);
+  const config = installConfig ?? {
+    ...DEFAULT_SERVICE_CONFIG,
+    stateDir,
+    extraEnv: collectServiceExtraEnv(process.env),
+  };
   return buildServiceSpec({
     platform: process.platform,
     nodePath: process.execPath,
@@ -620,13 +648,10 @@ function currentServiceSpec(
     uid: user.uid,
     gid: user.gid,
     username: user.username,
-    stateDir:
-      installConfig.stateDir ||
-      process.env.PORTLESS_STATE_DIR ||
-      defaultStateDir(process.platform, user.home),
+    stateDir,
     pathEnv: process.env.PATH,
     programData: process.env.ProgramData,
-    installConfig,
+    installConfig: config,
   });
 }
 
@@ -919,7 +944,7 @@ async function installService(
   runner: CommandRunner,
   args: string[]
 ): Promise<void> {
-  const installConfig = parseServiceInstallConfig(args);
+  const installConfig = normalizeServiceInstallPaths(parseServiceInstallConfig(args));
   requireUnixElevation([entryScript, ...args], runner);
   const spec = currentServiceSpec(entryScript, installConfig);
   prepareServiceState(spec.stateDir);

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -177,6 +177,7 @@ Portless stores its state (routes, PID file, port file) in `~/.portless`. Overri
 | `PORTLESS_APP_PORT`   | Use a fixed port for the app (skip auto-assignment)                         |
 | `PORTLESS_HTTPS`      | HTTPS on by default; set to `0` to disable (same as `--no-tls`)             |
 | `PORTLESS_LAN`        | Set to `1` to always enable LAN mode (auto-detects LAN IP)                  |
+| `PORTLESS_LAN_IP`     | Pin a specific LAN IP for LAN mode                                          |
 | `PORTLESS_TLD`        | Use a custom TLD instead of localhost (e.g. test)                           |
 | `PORTLESS_WILDCARD`   | Set to `1` to allow unregistered subdomains to fall back to parent          |
 | `PORTLESS_SYNC_HOSTS` | Set to `0` to disable auto-sync of /etc/hosts (on by default)               |
@@ -246,11 +247,16 @@ Use the service command when users want the proxy to start automatically after r
 
 ```bash
 portless service install
+portless service install --lan
+portless service install --wildcard
+PORTLESS_STATE_DIR=~/.portless-lan PORTLESS_LAN=1 portless service install
 portless service status
 portless service uninstall
 ```
 
-The service uses the default clean URL behavior: HTTPS on port 443 with `.localhost` names. macOS and Linux install a root-owned service so port 443 can bind at boot. Windows installs a Task Scheduler startup task that runs as SYSTEM. Installation and removal may require administrator privileges. `portless clean` automatically removes the service.
+The service uses portless defaults unless install options or `PORTLESS_*` environment variables are provided: HTTPS on port 443 with `.localhost` names. `service install` accepts proxy options including `--port`, `--no-tls`, `--lan`, `--ip`, `--tld`, `--wildcard`, `--cert`, and `--key`. Use `--state-dir <path>` or `PORTLESS_STATE_DIR=<path>` to choose where service state and logs are written.
+
+The chosen service configuration is written into launchd, systemd, or Task Scheduler and reused after reboot. `portless service status` reports the installed port, HTTPS mode, TLD, LAN mode, wildcard mode, and state directory. macOS and Linux install a root-owned service so port 443 can bind at boot. Windows installs a Task Scheduler startup task that runs as SYSTEM. Installation and removal may require administrator privileges. `portless clean` automatically removes the service.
 
 ## CLI Reference
 
@@ -278,6 +284,8 @@ The service uses the default clean URL behavior: HTTPS on port 443 with `.localh
 | `portless proxy start --wildcard`      | Allow unregistered subdomains to fall back to parent route     |
 | `portless proxy stop`                  | Stop the proxy                                                 |
 | `portless service install`             | Start the HTTPS proxy when the OS starts                       |
+| `portless service install --lan`       | Start the service in LAN mode                                  |
+| `portless service install --wildcard`  | Persist wildcard routing in the startup service                |
 | `portless service status`              | Show service and proxy status                                  |
 | `portless service uninstall`           | Remove the startup service                                     |
 | `portless alias <name> <port>`         | Register a static route (e.g. for Docker containers)           |


### PR DESCRIPTION
## Summary
- bump portless package to 0.13.1
- add 0.13.1 changelog entries and move release markers
- harden worktree tests against inherited Git signing config