### PR TITLE
Expose getUrl() for programmatic service URL retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,28 @@ NODE_EXTRA_CA_CERTS              Path to the portless CA (when HTTPS is active)
 
 > **Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `trust`, `clean`, `prune`, `proxy`, and `service` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name from your project, or `portless --name <name> <cmd>` to force any name including reserved ones.
 
+## Programmatic API
+
+For Node-based config files (Playwright, Vite proxy, `next.config.js`, etc.) you can `import { getUrl } from "portless"` to resolve service URLs without spawning the CLI:
+
+```ts
+import { getUrl } from "portless";
+
+const cms = await getUrl("cms");
+// cms.url      -> "https://cms.localhost"
+//                  ("https://feature-x.cms.localhost" in a linked worktree)
+// cms.port     -> 443
+// cms.tls      -> true
+
+// toString() coerces to the URL string:
+await fetch(`${cms}/api/health`);
+
+// Skip the worktree prefix for OAuth callbacks etc.:
+const stable = await getUrl("cms", { worktree: false });
+```
+
+Same hostname and worktree logic as `portless get`, reading port, TLS, and TLD from the active proxy's persisted state. The returned `ServiceUrl` object JSON-serializes to `{ url, hostname, port, tls, tld }`.
+
 ## Uninstall / reset
 
 To remove portless data from your machine (proxy state under `~/.portless` and the system state directory, the local CA from the OS trust store when portless installed it, and the portless block in `/etc/hosts`):

--- a/packages/portless/package.json
+++ b/packages/portless/package.json
@@ -3,12 +3,12 @@
   "version": "0.13.0",
   "description": "Replace port numbers with stable, named .localhost URLs. For humans and agents.",
   "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./dist/api.js",
+  "types": "./dist/api.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/api.js",
+      "types": "./dist/api.d.ts"
     }
   },
   "bin": {

--- a/packages/portless/src/api.test.ts
+++ b/packages/portless/src/api.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getUrl } from "./api.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function writeStateMarkers(
+  dir: string,
+  options: { port?: number; tls?: boolean; tld?: string } = {}
+): void {
+  fs.mkdirSync(dir, { recursive: true });
+  if (options.port !== undefined) {
+    fs.writeFileSync(path.join(dir, "proxy.port"), String(options.port));
+  }
+  if (options.tls) {
+    fs.writeFileSync(path.join(dir, "proxy.tls"), "1");
+  }
+  if (options.tld !== undefined) {
+    fs.writeFileSync(path.join(dir, "proxy.tld"), options.tld);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// getUrl — basic shape and component fields
+// ---------------------------------------------------------------------------
+
+describe("getUrl", () => {
+  let tmpDir: string;
+  let stateDir: string;
+  const originalStateDir = process.env.PORTLESS_STATE_DIR;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-api-"));
+    stateDir = path.join(tmpDir, "state");
+    process.env.PORTLESS_STATE_DIR = stateDir;
+  });
+
+  afterEach(() => {
+    if (originalStateDir === undefined) {
+      delete process.env.PORTLESS_STATE_DIR;
+    } else {
+      process.env.PORTLESS_STATE_DIR = originalStateDir;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // These tests pass `worktree: false` so the assertions are independent of
+  // the cwd the test runner happens to be in (the suite itself runs inside
+  // the portless worktree, which would otherwise inject a branch prefix).
+
+  it("returns the URL and components from persisted markers (HTTPS + default TLD)", async () => {
+    writeStateMarkers(stateDir, { port: 443, tls: true });
+
+    const result = await getUrl("myapp", { worktree: false });
+
+    expect(result.url).toBe("https://myapp.localhost");
+    expect(result.hostname).toBe("myapp.localhost");
+    expect(result.port).toBe(443);
+    expect(result.tls).toBe(true);
+    expect(result.tld).toBe("localhost");
+  });
+
+  it("returns HTTP with the proxy port when TLS marker is absent", async () => {
+    writeStateMarkers(stateDir, { port: 1355 });
+
+    const result = await getUrl("myapp", { worktree: false });
+
+    expect(result.url).toBe("http://myapp.localhost:1355");
+    expect(result.tls).toBe(false);
+  });
+
+  it("uses a custom TLD when proxy.tld is set", async () => {
+    writeStateMarkers(stateDir, { port: 443, tls: true, tld: "test" });
+
+    const result = await getUrl("myapp", { worktree: false });
+
+    expect(result.url).toBe("https://myapp.test");
+    expect(result.hostname).toBe("myapp.test");
+    expect(result.tld).toBe("test");
+  });
+
+  it("preserves dotted service names as subdomain chains", async () => {
+    writeStateMarkers(stateDir, { port: 443, tls: true });
+
+    const result = await getUrl("api.myapp", { worktree: false });
+
+    expect(result.url).toBe("https://api.myapp.localhost");
+    expect(result.hostname).toBe("api.myapp.localhost");
+  });
+
+  it("rejects invalid hostname characters", async () => {
+    writeStateMarkers(stateDir, { port: 443 });
+
+    await expect(getUrl("my@app", { worktree: false })).rejects.toThrow(/Invalid hostname/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getUrl — string coercion via toString()
+// ---------------------------------------------------------------------------
+
+describe("getUrl — string coercion", () => {
+  let tmpDir: string;
+  let stateDir: string;
+  const originalStateDir = process.env.PORTLESS_STATE_DIR;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-api-coerce-"));
+    stateDir = path.join(tmpDir, "state");
+    process.env.PORTLESS_STATE_DIR = stateDir;
+    writeStateMarkers(stateDir, { port: 443, tls: true });
+  });
+
+  afterEach(() => {
+    if (originalStateDir === undefined) {
+      delete process.env.PORTLESS_STATE_DIR;
+    } else {
+      process.env.PORTLESS_STATE_DIR = originalStateDir;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("coerces to the URL string in template literals", async () => {
+    const result = await getUrl("myapp", { worktree: false });
+    expect(`${result}`).toBe("https://myapp.localhost");
+  });
+
+  it("coerces to the URL string via String()", async () => {
+    const result = await getUrl("myapp", { worktree: false });
+    expect(String(result)).toBe("https://myapp.localhost");
+  });
+
+  it("coerces to the URL string in concatenation", async () => {
+    const result = await getUrl("myapp", { worktree: false });
+    expect(result + "/health").toBe("https://myapp.localhost/health");
+  });
+
+  it("works with the URL constructor", async () => {
+    const result = await getUrl("myapp", { worktree: false });
+    expect(new URL(String(result)).hostname).toBe("myapp.localhost");
+  });
+
+  it("does not include toString in JSON.stringify output", async () => {
+    const result = await getUrl("myapp", { worktree: false });
+    const parsed = JSON.parse(JSON.stringify(result));
+    expect(parsed).toEqual({
+      url: "https://myapp.localhost",
+      hostname: "myapp.localhost",
+      port: 443,
+      tls: true,
+      tld: "localhost",
+    });
+  });
+
+  it("does not include toString in Object.keys", async () => {
+    const result = await getUrl("myapp", { worktree: false });
+    expect(Object.keys(result).sort()).toEqual(["hostname", "port", "tld", "tls", "url"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getUrl — worktree prefix behavior
+// ---------------------------------------------------------------------------
+
+describe("getUrl — worktree behavior", { timeout: 15_000 }, () => {
+  let gitInitWorks = true;
+  try {
+    execFileSync("git", ["--version"], { stdio: "ignore" });
+    const probe = fs.mkdtempSync(path.join(os.tmpdir(), "portless-api-git-probe-"));
+    try {
+      execFileSync("git", ["init"], { cwd: probe, stdio: "ignore" });
+    } finally {
+      fs.rmSync(probe, { recursive: true, force: true });
+    }
+  } catch {
+    gitInitWorks = false;
+  }
+
+  if (!gitInitWorks) {
+    it.skip("git init not available (sandboxed environment)", () => {});
+    return;
+  }
+
+  function runGit(cwd: string, args: string[]): string {
+    return execFileSync("git", args, {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  }
+
+  function initRepoWithCommit(repoDir: string): void {
+    fs.mkdirSync(repoDir, { recursive: true });
+    runGit(repoDir, ["init"]);
+    runGit(repoDir, ["branch", "-M", "main"]);
+    runGit(repoDir, [
+      "-c",
+      "user.name=Test",
+      "-c",
+      "user.email=t@t",
+      "commit",
+      "--allow-empty",
+      "-m",
+      "init",
+    ]);
+  }
+
+  let tmpDir: string;
+  let stateDir: string;
+  const originalStateDir = process.env.PORTLESS_STATE_DIR;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-api-wt-"));
+    stateDir = path.join(tmpDir, "state");
+    process.env.PORTLESS_STATE_DIR = stateDir;
+    writeStateMarkers(stateDir, { port: 443, tls: true });
+  });
+
+  afterEach(() => {
+    if (originalStateDir === undefined) {
+      delete process.env.PORTLESS_STATE_DIR;
+    } else {
+      process.env.PORTLESS_STATE_DIR = originalStateDir;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("applies the branch as a subdomain inside a linked worktree", async () => {
+    const repo = path.join(tmpDir, "repo");
+    initRepoWithCommit(repo);
+    runGit(repo, ["branch", "feature-x"]);
+    const wtDir = path.join(tmpDir, "wt-feature-x");
+    runGit(repo, ["worktree", "add", wtDir, "feature-x"]);
+
+    const result = await getUrl("myapp", { cwd: wtDir });
+
+    expect(result.url).toBe("https://feature-x.myapp.localhost");
+    expect(result.hostname).toBe("feature-x.myapp.localhost");
+  });
+
+  it("returns the bare URL on the primary checkout, even when linked worktrees exist", async () => {
+    const repo = path.join(tmpDir, "repo");
+    initRepoWithCommit(repo);
+    runGit(repo, ["branch", "feature-x"]);
+    runGit(repo, ["worktree", "add", path.join(tmpDir, "wt-feature-x"), "feature-x"]);
+
+    const result = await getUrl("myapp", { cwd: repo });
+
+    expect(result.url).toBe("https://myapp.localhost");
+    expect(result.hostname).toBe("myapp.localhost");
+  });
+
+  it("skips the worktree prefix when worktree: false", async () => {
+    const repo = path.join(tmpDir, "repo");
+    initRepoWithCommit(repo);
+    runGit(repo, ["branch", "feature-x"]);
+    const wtDir = path.join(tmpDir, "wt-feature-x");
+    runGit(repo, ["worktree", "add", wtDir, "feature-x"]);
+
+    const result = await getUrl("myapp", { cwd: wtDir, worktree: false });
+
+    expect(result.url).toBe("https://myapp.localhost");
+    expect(result.hostname).toBe("myapp.localhost");
+  });
+
+  it("ignores worktree: true (default behavior) when not in a linked worktree", async () => {
+    const repo = path.join(tmpDir, "repo");
+    initRepoWithCommit(repo);
+
+    const result = await getUrl("myapp", { cwd: repo });
+
+    expect(result.url).toBe("https://myapp.localhost");
+  });
+});

--- a/packages/portless/src/api.ts
+++ b/packages/portless/src/api.ts
@@ -1,0 +1,106 @@
+import { discoverState } from "./cli-utils.js";
+import { detectWorktreePrefix } from "./auto.js";
+import { parseHostname, formatUrl } from "./utils.js";
+
+/**
+ * Service URL information returned by {@link getUrl}.
+ *
+ * The object has a non-enumerable `toString()` method that returns
+ * {@link url}, so a `ServiceUrl` can be used directly wherever a URL string
+ * is expected (template literals, `String(value)`, `new URL(value)`).
+ *
+ * `JSON.stringify` produces a plain `{ url, hostname, port, tls, tld }`
+ * payload, matching the shape of `portless list --json` and
+ * `portless get --json` (see #257).
+ */
+export interface ServiceUrl {
+  /** The full URL, including protocol and (when non-default) port. */
+  url: string;
+  /** The resolved hostname including TLD, with any worktree prefix applied. */
+  hostname: string;
+  /** The proxy port. */
+  port: number;
+  /** Whether the proxy is serving over HTTPS. */
+  tls: boolean;
+  /** The TLD configured on the proxy (e.g. `localhost`, `test`). */
+  tld: string;
+  /** Returns {@link url}; lets the object coerce to its URL string. */
+  toString(): string;
+}
+
+/**
+ * Options for {@link getUrl}.
+ */
+export interface GetUrlOptions {
+  /**
+   * When `false`, skip git worktree prefix detection. Use this for URLs that
+   * must remain stable across branches (e.g. registered OAuth callbacks).
+   * Defaults to `true`.
+   */
+  worktree?: boolean;
+  /**
+   * Working directory used for git worktree detection. Defaults to
+   * `process.cwd()`.
+   */
+  cwd?: string;
+}
+
+/**
+ * Resolve the URL for a portless-managed service by name.
+ *
+ * Equivalent to the `portless get <name>` CLI command. Reads the active
+ * proxy's port, TLS mode, and TLD from persisted state, applies the same
+ * hostname and worktree logic as `portless run`, and returns the resulting
+ * URL plus the components used to build it.
+ *
+ * The returned object has a `toString()` so it can be used directly wherever
+ * a URL string is expected. Access fields like `.port` or `.tls` when the
+ * components matter.
+ *
+ * Returned URLs stay stable across reboots and TLS/TLD config changes.
+ * In linked git worktrees the branch name is prepended as a subdomain
+ * (e.g. `https://feature-x.cms.localhost`), so apps running in the same
+ * worktree automatically address the matching peer service. Pass
+ * `worktree: false` to opt out.
+ *
+ * @example
+ * ```ts
+ * import { getUrl } from "portless";
+ *
+ * // From any config file (Playwright, Vite proxy, next.config.js, ...)
+ * const cms = await getUrl("cms");
+ * // cms.url      -> "https://cms.localhost"
+ * //                  ("https://feature-x.cms.localhost" inside a linked worktree)
+ * // cms.hostname -> "cms.localhost"
+ * // cms.port     -> 443
+ * // cms.tls      -> true
+ *
+ * // toString() means the value coerces to its URL string:
+ * await fetch(`${cms}/api/health`);
+ *
+ * // OAuth-callback-safe (no worktree prefix):
+ * const stable = await getUrl("cms", { worktree: false });
+ * ```
+ *
+ * @param name The service name (with or without a TLD suffix).
+ * @param options See {@link GetUrlOptions}.
+ * @returns A {@link ServiceUrl} describing the service.
+ */
+export async function getUrl(name: string, options?: GetUrlOptions): Promise<ServiceUrl> {
+  const skipWorktree = options?.worktree === false;
+  const worktree = skipWorktree ? null : detectWorktreePrefix(options?.cwd);
+  const effectiveName = worktree ? `${worktree.prefix}.${name}` : name;
+
+  const { port, tls, tld } = await discoverState();
+  const hostname = parseHostname(effectiveName, tld);
+  const url = formatUrl(hostname, port, tls);
+
+  const result = { url, hostname, port, tls, tld } as ServiceUrl;
+  Object.defineProperty(result, "toString", {
+    value: () => url,
+    enumerable: false,
+    configurable: true,
+    writable: true,
+  });
+  return result;
+}

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -10,6 +10,7 @@ import { StringDecoder } from "node:string_decoder";
 import { createSNICallback, ensureCerts, isCATrusted, trustCA, untrustCA } from "./certs.js";
 import { createHttpRedirectServer, createProxyServer } from "./proxy.js";
 import { fixOwnership, formatUrl, isErrnoException, parseHostname } from "./utils.js";
+import { getUrl } from "./api.js";
 import { syncHostsFile, cleanHostsFile, shouldAutoSyncHosts } from "./hosts.js";
 import { FILE_MODE, RouteConflictError, RouteStore } from "./routes.js";
 import {
@@ -1896,12 +1897,7 @@ ${colors.bold("Examples:")}
   }
 
   const name = positional[0];
-  const worktree = skipWorktree ? null : detectWorktreePrefix();
-  const effectiveName = worktree ? `${worktree.prefix}.${name}` : name;
-
-  const { port, tls, tld } = await discoverState();
-  const hostname = parseHostname(effectiveName, tld);
-  const url = formatUrl(hostname, port, tls);
+  const { url } = await getUrl(name, { worktree: !skipWorktree });
   // Print bare URL to stdout so it works in $(portless get <name>)
   process.stdout.write(url + "\n");
 }

--- a/packages/portless/src/index.ts
+++ b/packages/portless/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./types.js";
+export * from "./proxy.js";
+export * from "./routes.js";
+export * from "./utils.js";
+export * from "./hosts.js";

--- a/packages/portless/src/index.ts
+++ b/packages/portless/src/index.ts
@@ -3,3 +3,4 @@ export * from "./proxy.js";
 export * from "./routes.js";
 export * from "./utils.js";
 export * from "./hosts.js";
+export * from "./api.js";

--- a/packages/portless/src/index.ts
+++ b/packages/portless/src/index.ts
@@ -1,6 +1,0 @@
-export * from "./types.js";
-export * from "./proxy.js";
-export * from "./routes.js";
-export * from "./utils.js";
-export * from "./hosts.js";
-export * from "./api.js";

--- a/packages/portless/tsup.config.ts
+++ b/packages/portless/tsup.config.ts
@@ -4,7 +4,11 @@ import { readFileSync } from "node:fs";
 const pkg = JSON.parse(readFileSync("./package.json", "utf-8"));
 
 export default defineConfig({
-  entry: ["src/cli.ts", "src/api.ts"],
+  // api.ts is the public package entry (see package.json "exports").
+  // index.ts is kept as an internal bundle: routes.test.ts spawns worker
+  // processes that import RouteStore from dist/index.js to exercise
+  // cross-process file locking.
+  entry: ["src/cli.ts", "src/index.ts", "src/api.ts"],
   format: ["esm"],
   dts: true,
   clean: true,

--- a/packages/portless/tsup.config.ts
+++ b/packages/portless/tsup.config.ts
@@ -4,7 +4,7 @@ import { readFileSync } from "node:fs";
 const pkg = JSON.parse(readFileSync("./package.json", "utf-8"));
 
 export default defineConfig({
-  entry: ["src/cli.ts", "src/index.ts"],
+  entry: ["src/cli.ts", "src/api.ts"],
   format: ["esm"],
   dts: true,
   clean: true,

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -297,6 +297,35 @@ The service uses the default clean URL behavior: HTTPS on port 443 with `.localh
 
 **Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `trust`, `clean`, `prune`, `proxy`, and `service` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name, or `portless --name <name> <cmd>` to force any name including reserved ones.
 
+## Programmatic API
+
+For Node-based config files (Playwright, Vite proxy, `next.config.js`, etc.) `import { getUrl } from "portless"` to resolve service URLs without spawning the CLI:
+
+```ts
+import { getUrl } from "portless";
+
+const cms = await getUrl("cms");
+// cms.url      -> "https://cms.localhost"
+//                  ("https://feature-x.cms.localhost" in a linked worktree)
+// cms.hostname -> "cms.localhost"
+// cms.port     -> 443
+// cms.tls      -> true
+// cms.tld      -> "localhost"
+
+// toString() coerces to the URL string:
+await fetch(`${cms}/api/health`);
+
+// Skip the worktree prefix for OAuth callbacks etc.:
+const stable = await getUrl("cms", { worktree: false });
+```
+
+Same defaults as `portless get`: worktree prefix applied by default in linked worktrees, reads persisted markers under `~/.portless/proxy.{port,tls,tld}`. The returned `ServiceUrl` JSON-serializes to `{ url, hostname, port, tls, tld }`.
+
+| Option     | Default         | Description                                      |
+| ---------- | --------------- | ------------------------------------------------ |
+| `worktree` | `true`          | When `false`, skip git worktree prefix detection |
+| `cwd`      | `process.cwd()` | Working directory used for worktree detection    |
+
 ## portless.json
 
 Optional config file. Portless looks for it in the current directory.


### PR DESCRIPTION
## Problem

When wiring portless URLs into Node config files (Playwright `webServer.url`, Vite cross-app proxy `target`, Next.js callbacks), the only way today is `execFileSync("portless", ["get", name])`. Requires the binary on `PATH`, costs a subprocess per resolution, and is the documented workaround in #94.

## Changes

`getUrl()` is now a published programmatic entry:

```ts
import { getUrl } from "portless";

const cms = await getUrl("cms");
// cms.url = "https://cms.localhost"
//           ("https://feature-x.cms.localhost" inside a linked worktree)
await fetch(`${cms}/api/health`);                          // toString() coerces
const stable = await getUrl("cms", { worktree: false });   // OAuth-callback-safe
```

Returns `{ url, hostname, port, tls, tld }` with a non-enumerable `toString()`. JSON-serializes to the same shape #257 proposes for `portless get --json`. The CLI `handleGet` now calls `getUrl`, sharing the same path.

The package entry points at `src/api.ts`. The previous `src/index.ts` mechanically re-exported `types.ts`, `proxy.ts`, `routes.ts`, `utils.ts`, `hosts.ts`, exposing about two dozen symbols including internal helpers like `fixOwnership`, `escapeHtml`, `FILE_MODE`. That surface was accidental: three commits ever, all "add `export *` for the new module," no README/CHANGELOG mention, zero `from "portless"` imports anywhere in the repo. The new entry is curated to `getUrl`, `ServiceUrl`, `GetUrlOptions`.

`BREAKING CHANGE:` callers reading `RouteStore` / `formatUrl` / etc. from the root entry will break.
