### PR TITLE
feat(tld): allow multi-label TLDs (e.g. dev.example.com)

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,18 @@ The proxy auto-syncs `/etc/hosts` for route hostnames (including `.test`), so th
 
 Recommended: `.test` (IANA-reserved, no collision risk). Avoid `.local` (conflicts with mDNS/Bonjour) and `.dev` (Google-owned, forces HTTPS via HSTS).
 
+### Multi-label TLDs (own-domain access from tailnet, LAN, intranet)
+
+The `--tld` value accepts any valid DNS hostname (single-label or multi-label), so a domain you own can be used as the "TLD":
+
+```bash
+portless proxy start --tld dev.example.com
+portless myapp next dev
+# -> https://myapp.dev.example.com
+```
+
+This is useful when serving the proxy on a tailnet/LAN IP and resolving the hostname via your own DNS (wildcard A record pointing at that IP, no `/etc/hosts` edit required on devices). Each label must follow DNS rules: lowercase letters, digits, hyphens (not at the edges), 63 chars per label, 253 chars total.
+
 ## How it works
 
 ```mermaid

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -907,10 +907,22 @@ describe("readTldFromDir / writeTldFile", () => {
 });
 
 describe("validateTld", () => {
-  it("returns null for valid TLDs", () => {
+  it("returns null for valid single-label TLDs", () => {
     expect(validateTld("localhost")).toBeNull();
     expect(validateTld("test")).toBeNull();
     expect(validateTld("internal")).toBeNull();
+  });
+
+  it("returns null for valid multi-label TLDs (user-owned domains)", () => {
+    expect(validateTld("my.tld")).toBeNull();
+    expect(validateTld("example.com")).toBeNull();
+    expect(validateTld("dev.example.com")).toBeNull();
+    expect(validateTld("a.b.c.d.e")).toBeNull();
+  });
+
+  it("returns null for labels containing hyphens (not at the edges)", () => {
+    expect(validateTld("my-tld")).toBeNull();
+    expect(validateTld("multi-word.example.com")).toBeNull();
   });
 
   it("rejects empty string", () => {
@@ -918,10 +930,34 @@ describe("validateTld", () => {
   });
 
   it("rejects TLDs with invalid characters", () => {
-    expect(validateTld("my-tld")).toMatch(/must contain only/);
-    expect(validateTld("my.tld")).toMatch(/must contain only/);
-    expect(validateTld("MY_TLD")).toMatch(/must contain only/);
-    expect(validateTld("tld!")).toMatch(/must contain only/);
+    expect(validateTld("MY_TLD")).toMatch(/lowercase letters, digits, and hyphens/);
+    expect(validateTld("tld!")).toMatch(/lowercase letters, digits, and hyphens/);
+    expect(validateTld("UPPERCASE")).toMatch(/lowercase letters, digits, and hyphens/);
+  });
+
+  it("rejects labels with leading or trailing hyphens", () => {
+    expect(validateTld("-leading")).toMatch(/lowercase letters, digits, and hyphens/);
+    expect(validateTld("trailing-")).toMatch(/lowercase letters, digits, and hyphens/);
+    expect(validateTld("ok.-mid")).toMatch(/lowercase letters, digits, and hyphens/);
+  });
+
+  it("rejects empty labels (leading, trailing, or consecutive dots)", () => {
+    expect(validateTld(".start")).toMatch(/empty label/);
+    expect(validateTld("end.")).toMatch(/empty label/);
+    expect(validateTld("a..b")).toMatch(/empty label/);
+  });
+
+  it("rejects labels longer than 63 characters", () => {
+    const tooLong = "a".repeat(64);
+    expect(validateTld(tooLong)).toMatch(/exceeds 63 characters/);
+    expect(validateTld(`ok.${tooLong}`)).toMatch(/exceeds 63 characters/);
+  });
+
+  it("rejects TLDs longer than 253 characters", () => {
+    // 4 labels of 63 chars + 3 dots = 255 chars total
+    const tld = ["a".repeat(63), "b".repeat(63), "c".repeat(63), "d".repeat(63)].join(".");
+    expect(tld.length).toBeGreaterThan(253);
+    expect(validateTld(tld)).toMatch(/exceeds 253 characters/);
   });
 
   it("allows public TLDs (they produce warnings elsewhere)", () => {

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -247,12 +247,29 @@ export const RISKY_TLDS = new Map<string, string>([
 
 /**
  * Validate a TLD string. Returns an error message if invalid, or null if OK.
+ * Accepts single-label TLDs (e.g. `localhost`, `test`) and multi-label DNS
+ * names (e.g. `dev.example.com`) so users with their own domain can route
+ * tailnet or LAN traffic through portless under a memorable hostname.
+ * Each label must be a valid DNS label: lowercase letters, digits, hyphens,
+ * no leading/trailing hyphens, 63 chars max; total length 253 chars max.
  * Does not check for risky TLDs (those produce warnings, not errors).
  */
 export function validateTld(tld: string): string | null {
   if (!tld) return "TLD cannot be empty";
-  if (!/^[a-z0-9]+$/.test(tld)) {
-    return `Invalid TLD "${tld}": must contain only lowercase letters and digits`;
+  if (tld.length > 253) {
+    return `Invalid TLD "${tld}": exceeds 253 characters`;
+  }
+  const labels = tld.split(".");
+  for (const label of labels) {
+    if (label.length === 0) {
+      return `Invalid TLD "${tld}": empty label (leading, trailing, or consecutive dots)`;
+    }
+    if (label.length > 63) {
+      return `Invalid TLD "${tld}": label "${label}" exceeds 63 characters`;
+    }
+    if (!/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label)) {
+      return `Invalid TLD "${tld}": label "${label}" must be lowercase letters, digits, and hyphens (not at the start or end)`;
+    }
   }
   return null;
 }

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1550,7 +1550,7 @@ ${colors.bold("Options:")}
   --cert <path>                 Use a custom TLS certificate
   --key <path>                  Use a custom TLS private key
   --foreground                  Run proxy in foreground (for debugging)
-  --tld <tld>                   Use a custom TLD instead of .localhost (e.g. test, dev)
+  --tld <tld>                   Use a custom TLD instead of .localhost. Single-label (e.g. test) or multi-label DNS name (e.g. dev.example.com) for own-domain routing
   --wildcard                    Allow unregistered subdomains to fall back to parent route
   --state-dir <path>            Use a custom state directory with service install
   --app-port <number>           Use a fixed port for the app (skip auto-assignment)

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -171,20 +171,20 @@ Portless stores its state (routes, PID file, port file) in `~/.portless`. Overri
 
 ### Environment variables
 
-| Variable              | Description                                                                 |
-| --------------------- | --------------------------------------------------------------------------- |
-| `PORTLESS_PORT`       | Override the default proxy port (default: 443 with HTTPS, 80 without)       |
-| `PORTLESS_APP_PORT`   | Use a fixed port for the app (skip auto-assignment)                         |
-| `PORTLESS_HTTPS`      | HTTPS on by default; set to `0` to disable (same as `--no-tls`)             |
-| `PORTLESS_LAN`        | Set to `1` to always enable LAN mode (auto-detects LAN IP)                  |
-| `PORTLESS_LAN_IP`     | Pin a specific LAN IP for LAN mode                                          |
-| `PORTLESS_TLD`        | Use a custom TLD instead of localhost (e.g. test)                           |
-| `PORTLESS_WILDCARD`   | Set to `1` to allow unregistered subdomains to fall back to parent          |
-| `PORTLESS_SYNC_HOSTS` | Set to `0` to disable auto-sync of /etc/hosts (on by default)               |
-| `PORTLESS_TAILSCALE`  | Set to `1` to share apps on your Tailscale network (same as `--tailscale`)  |
-| `PORTLESS_FUNNEL`     | Set to `1` to share apps publicly via Tailscale Funnel (same as `--funnel`) |
-| `PORTLESS_STATE_DIR`  | Override the state directory                                                |
-| `PORTLESS=0`          | Bypass the proxy, run the command directly                                  |
+| Variable              | Description                                                                                                              |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `PORTLESS_PORT`       | Override the default proxy port (default: 443 with HTTPS, 80 without)                                                    |
+| `PORTLESS_APP_PORT`   | Use a fixed port for the app (skip auto-assignment)                                                                      |
+| `PORTLESS_HTTPS`      | HTTPS on by default; set to `0` to disable (same as `--no-tls`)                                                          |
+| `PORTLESS_LAN`        | Set to `1` to always enable LAN mode (auto-detects LAN IP)                                                               |
+| `PORTLESS_LAN_IP`     | Pin a specific LAN IP for LAN mode                                                                                       |
+| `PORTLESS_TLD`        | Use a custom TLD instead of localhost. Single-label (`test`, `internal`) or multi-label DNS hostname (`dev.example.com`) |
+| `PORTLESS_WILDCARD`   | Set to `1` to allow unregistered subdomains to fall back to parent                                                       |
+| `PORTLESS_SYNC_HOSTS` | Set to `0` to disable auto-sync of /etc/hosts (on by default)                                                            |
+| `PORTLESS_TAILSCALE`  | Set to `1` to share apps on your Tailscale network (same as `--tailscale`)                                               |
+| `PORTLESS_FUNNEL`     | Set to `1` to share apps publicly via Tailscale Funnel (same as `--funnel`)                                              |
+| `PORTLESS_STATE_DIR`  | Override the state directory                                                                                             |
+| `PORTLESS=0`          | Bypass the proxy, run the command directly                                                                               |
 
 ### HTTP/2 + HTTPS
 
@@ -260,48 +260,49 @@ The chosen service configuration is written into launchd, systemd, or Task Sched
 
 ## CLI Reference
 
-| Command                                | Description                                                    |
-| -------------------------------------- | -------------------------------------------------------------- |
-| `portless`                             | Run dev script through proxy                                   |
-| `portless`                             | From monorepo root: run all workspace packages                 |
-| `portless --script <name>`             | Run a specific package.json script (default: dev)              |
-| `portless run [cmd] [args...]`         | Infer name from project, run through proxy (auto-starts)       |
-| `portless run --name <name> <cmd>`     | Override inferred base name (worktree prefix still applies)    |
-| `portless <name> <cmd> [args...]`      | Run app at `https://<name>.localhost` (auto-starts proxy)      |
-| `portless get <name>`                  | Print URL for a service (for cross-service wiring)             |
-| `portless get <name> --no-worktree`    | Print URL without worktree prefix                              |
-| `portless list`                        | Show active routes                                             |
-| `portless trust`                       | Add local CA to system trust store (for HTTPS)                 |
-| `portless clean`                       | Remove state, CA trust entry, and /etc/hosts block             |
-| `portless prune`                       | Kill orphaned dev servers from crashed sessions                |
-| `portless prune --force`               | Kill orphans with SIGKILL instead of SIGTERM                   |
-| `portless proxy start`                 | Start HTTPS proxy as a daemon (port 443, auto-elevates)        |
-| `portless proxy start --no-tls`        | Start without HTTPS (plain HTTP on port 80)                    |
-| `portless proxy start --lan`           | Start in LAN mode (mDNS `.local`, auto-follows LAN IP changes) |
-| `portless proxy start -p <number>`     | Start the proxy on a custom port                               |
-| `portless proxy start --tld test`      | Use .test instead of .localhost                                |
-| `portless proxy start --foreground`    | Start the proxy in foreground (for debugging)                  |
-| `portless proxy start --wildcard`      | Allow unregistered subdomains to fall back to parent route     |
-| `portless proxy stop`                  | Stop the proxy                                                 |
-| `portless service install`             | Start the HTTPS proxy when the OS starts                       |
-| `portless service install --lan`       | Start the service in LAN mode                                  |
-| `portless service install --wildcard`  | Persist wildcard routing in the startup service                |
-| `portless service status`              | Show service and proxy status                                  |
-| `portless service uninstall`           | Remove the startup service                                     |
-| `portless alias <name> <port>`         | Register a static route (e.g. for Docker containers)           |
-| `portless alias <name> <port> --force` | Overwrite an existing route                                    |
-| `portless alias --remove <name>`       | Remove a static route                                          |
-| `portless hosts sync`                  | Add routes to /etc/hosts (fixes Safari)                        |
-| `portless hosts clean`                 | Remove portless entries from /etc/hosts                        |
-| `portless <name> --app-port <n> <cmd>` | Use a fixed port for the app instead of auto-assignment        |
-| `portless <name> --tailscale <cmd>`    | Share the app on your Tailscale network (tailnet)              |
-| `portless <name> --funnel <cmd>`       | Share the app publicly via Tailscale Funnel                    |
-| `portless <name> --force <cmd>`        | Kill the existing process and take over its route              |
-| `portless --name <name> <cmd>`         | Force `<name>` as app name (bypasses subcommand dispatch)      |
-| `portless <name> -- <cmd> [args...]`   | Stop flag parsing; everything after `--` is passed to child    |
-| `portless --help` / `-h`               | Show help                                                      |
-| `portless run --help`                  | Show help for a subcommand (also: alias, hosts, clean)         |
-| `portless --version` / `-v`            | Show version                                                   |
+| Command                                      | Description                                                    |
+| -------------------------------------------- | -------------------------------------------------------------- |
+| `portless`                                   | Run dev script through proxy                                   |
+| `portless`                                   | From monorepo root: run all workspace packages                 |
+| `portless --script <name>`                   | Run a specific package.json script (default: dev)              |
+| `portless run [cmd] [args...]`               | Infer name from project, run through proxy (auto-starts)       |
+| `portless run --name <name> <cmd>`           | Override inferred base name (worktree prefix still applies)    |
+| `portless <name> <cmd> [args...]`            | Run app at `https://<name>.localhost` (auto-starts proxy)      |
+| `portless get <name>`                        | Print URL for a service (for cross-service wiring)             |
+| `portless get <name> --no-worktree`          | Print URL without worktree prefix                              |
+| `portless list`                              | Show active routes                                             |
+| `portless trust`                             | Add local CA to system trust store (for HTTPS)                 |
+| `portless clean`                             | Remove state, CA trust entry, and /etc/hosts block             |
+| `portless prune`                             | Kill orphaned dev servers from crashed sessions                |
+| `portless prune --force`                     | Kill orphans with SIGKILL instead of SIGTERM                   |
+| `portless proxy start`                       | Start HTTPS proxy as a daemon (port 443, auto-elevates)        |
+| `portless proxy start --no-tls`              | Start without HTTPS (plain HTTP on port 80)                    |
+| `portless proxy start --lan`                 | Start in LAN mode (mDNS `.local`, auto-follows LAN IP changes) |
+| `portless proxy start -p <number>`           | Start the proxy on a custom port                               |
+| `portless proxy start --tld test`            | Use .test instead of .localhost                                |
+| `portless proxy start --tld dev.example.com` | Use a domain you own (e.g. for tailnet/LAN access)             |
+| `portless proxy start --foreground`          | Start the proxy in foreground (for debugging)                  |
+| `portless proxy start --wildcard`            | Allow unregistered subdomains to fall back to parent route     |
+| `portless proxy stop`                        | Stop the proxy                                                 |
+| `portless service install`                   | Start the HTTPS proxy when the OS starts                       |
+| `portless service install --lan`             | Start the service in LAN mode                                  |
+| `portless service install --wildcard`        | Persist wildcard routing in the startup service                |
+| `portless service status`                    | Show service and proxy status                                  |
+| `portless service uninstall`                 | Remove the startup service                                     |
+| `portless alias <name> <port>`               | Register a static route (e.g. for Docker containers)           |
+| `portless alias <name> <port> --force`       | Overwrite an existing route                                    |
+| `portless alias --remove <name>`             | Remove a static route                                          |
+| `portless hosts sync`                        | Add routes to /etc/hosts (fixes Safari)                        |
+| `portless hosts clean`                       | Remove portless entries from /etc/hosts                        |
+| `portless <name> --app-port <n> <cmd>`       | Use a fixed port for the app instead of auto-assignment        |
+| `portless <name> --tailscale <cmd>`          | Share the app on your Tailscale network (tailnet)              |
+| `portless <name> --funnel <cmd>`             | Share the app publicly via Tailscale Funnel                    |
+| `portless <name> --force <cmd>`              | Kill the existing process and take over its route              |
+| `portless --name <name> <cmd>`               | Force `<name>` as app name (bypasses subcommand dispatch)      |
+| `portless <name> -- <cmd> [args...]`         | Stop flag parsing; everything after `--` is passed to child    |
+| `portless --help` / `-h`                     | Show help                                                      |
+| `portless run --help`                        | Show help for a subcommand (also: alias, hosts, clean)         |
+| `portless --version` / `-v`                  | Show version                                                   |
 
 **Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `trust`, `clean`, `prune`, `proxy`, and `service` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name, or `portless --name <name> <cmd>` to force any name including reserved ones.
 


### PR DESCRIPTION
## Motivation

`validateTld` currently enforces `/^[a-z0-9]+$/`, rejecting any TLD containing dots or hyphens. This blocks a real use case I hit while setting up dev URLs for a Tailscale tailnet: routing a portless proxy under a domain I own (e.g. `dev.example.com`) when the proxy listens on a tailnet/LAN/intranet IP, with public DNS handling resolution. With that setup, no `/etc/hosts` edits are needed per device, certs can be obtained for the real domain, and the URL pattern is memorable.

Today the only workaround is patching the installed `cli.js` in place. This PR removes the need for that.

## Change

After:

```bash
portless proxy start --tld dev.example.com
portless myapp next dev
# -> https://myapp.dev.example.com
```

`validateTld` now accepts any valid DNS hostname: per-label `[a-z0-9](?:[a-z0-9-]*[a-z0-9])?`, 63 chars max per label, 253 chars total. Hyphens are allowed within a label but not at the edges. Single-label TLDs (the original use case) continue to work unchanged.

The rest of the codebase (`parseHostname`, route matcher, cert generation with wildcard SAN, Vite allowed-hosts injection) already handles dotted hostnames correctly. The TLD validator was the only blocker.

## Test updates

The previous tests asserted that `my.tld` and `my-tld` are invalid. Both are valid DNS labels, so those assertions flip to expecting success. New positive tests cover `example.com`, `dev.example.com`, `a.b.c.d.e`, and hyphenated labels. New negative tests cover:

- Empty labels (leading dot, trailing dot, consecutive dots)
- Leading/trailing hyphens within a label
- Labels exceeding 63 characters
- Total TLDs exceeding 253 characters

Full suite still passes (530 tests). Two pre-existing failures unrelated to this change: `cli.test.ts` requires `pnpm build` first, and `routes.test.ts > RouteStore > locking` is flaky concurrency test.

## Docs

Per AGENTS.md "Docs Updates" rule:

- `README.md` "Custom TLD" section gains a "Multi-label TLDs" subsection
- `skills/portless/SKILL.md` env var table and CLI reference table updated
- `packages/portless/src/cli.ts` `--help` text for `--tld <tld>` updated

Prettier auto-reformatted the SKILL.md tables to fit the longer description; that's the only "unrelated" looking change.

## Compatibility

Backwards compatible. All existing single-label TLDs still validate. The only previously-rejected inputs that now pass are valid DNS hostnames, which were never useful as TLDs before this change.