### PR TITLE
fix(proxy): dial loopback upstreams family-agnostically (fixes #320)

### DIFF
--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -21,6 +21,7 @@ import {
   getProtocolPort,
   isHttpsEnvDisabled,
   injectFrameworkFlags,
+  isPortListening,
   isProxyRunning,
   parsePidFromNetstat,
   readLanMarker,
@@ -135,6 +136,45 @@ describe("isProxyRunning", () => {
 
     const result = await isProxyRunning(port);
     expect(result).toBe(false);
+  });
+});
+
+describe("isPortListening", () => {
+  const servers: net.Server[] = [];
+
+  afterEach(async () => {
+    for (const s of servers) {
+      await new Promise<void>((resolve) => s.close(() => resolve()));
+    }
+    servers.length = 0;
+  });
+
+  function listenOn(host: string): Promise<number> {
+    const server = net.createServer();
+    servers.push(server);
+    return new Promise<number>((resolve) => {
+      server.listen(0, host, () => {
+        const addr = server.address();
+        if (addr && typeof addr !== "string") {
+          resolve(addr.port);
+        }
+      });
+    });
+  }
+
+  it("returns false when nothing is listening", async () => {
+    expect(await isPortListening(19877)).toBe(false);
+  });
+
+  it("detects a listener on IPv4 loopback", async () => {
+    const port = await listenOn("127.0.0.1");
+    expect(await isPortListening(port)).toBe(true);
+  });
+
+  it("detects a listener on IPv6 loopback (::1) only", async () => {
+    // e.g. Vite's default `localhost` host on Node 17+ binds ::1 only
+    const port = await listenOn("::1");
+    expect(await isPortListening(port)).toBe(true);
   });
 });
 

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -6,7 +6,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import * as readline from "node:readline";
 import { execSync, spawn } from "node:child_process";
-import { PORTLESS_HEADER } from "./proxy.js";
+import { LOOPBACK_DIAL_OPTIONS, PORTLESS_HEADER } from "./proxy.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -602,10 +602,14 @@ export function isProxyRunning(port: number, tls = false): Promise<boolean> {
   });
 }
 
-/** Check whether any process is listening on the given port at 127.0.0.1. */
+/**
+ * Check whether any process is listening on the given port on loopback.
+ * Tries both 127.0.0.1 and ::1 so apps bound to IPv6 loopback only (e.g.
+ * Vite's default `localhost` host on Node 17+) are not reported as dead.
+ */
 export function isPortListening(port: number): Promise<boolean> {
   return new Promise((resolve) => {
-    const socket = net.createConnection({ host: "127.0.0.1", port });
+    const socket = net.createConnection({ ...LOOPBACK_DIAL_OPTIONS, port });
     let settled = false;
 
     const finish = (result: boolean) => {
@@ -928,8 +932,10 @@ function findFrameworkBasename(commandArgs: string[]): string | null {
  * Handles both direct invocation (`vite dev`) and invocation via package
  * runners (`bunx --bun vite dev`, `npx vite dev`, `yarn dlx vite dev`).
  *
- * The portless proxy connects to 127.0.0.1 (IPv4), so we also inject
- * `--host 127.0.0.1` to prevent frameworks from binding to IPv6 `::1`.
+ * We also inject `--host 127.0.0.1` so the bind address is predictable.
+ * (The proxy dials both loopback families, so an IPv6-only `::1` bind still
+ * works — but injection cannot see through package.json scripts, so the
+ * proxy-side fallback is the safety net, not this flag.)
  *
  * Note: Expo's `--host` flag is *not* a bind address (it is a connection mode:
  * lan|tunnel|localhost). In LAN mode we skip `--host` entirely — Expo defaults

--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -153,6 +153,30 @@ describe("createProxyServer", () => {
       expect(res.body).toBe("hello from backend");
     });
 
+    it("proxies to a backend listening on IPv6 loopback (::1) only", async () => {
+      // Dev servers that bind `localhost` may listen on ::1 only — Node 17+
+      // resolves localhost to ::1 first (e.g. Vite's default server.host).
+      const backend = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("hello from ipv6 backend");
+        })
+      );
+      await new Promise<void>((resolve) => backend.listen(0, "::1", () => resolve()));
+      const backendAddr = backend.address();
+      if (!backendAddr || typeof backendAddr === "string") throw new Error("no addr");
+
+      const routes: RouteInfo[] = [{ hostname: "myapp.localhost", port: backendAddr.port }];
+      const server = trackServer(
+        createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "myapp.localhost" });
+      expect(res.status).toBe(200);
+      expect(res.body).toBe("hello from ipv6 backend");
+    });
+
     it("routes wildcard subdomain to matching parent route when strict is false", async () => {
       const backend = trackServer(
         http.createServer((_req, res) => {

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -9,6 +9,46 @@ import { ARROW_SVG, renderPage } from "./pages.js";
 export const PORTLESS_HEADER = "X-Portless";
 
 /**
+ * Dial options that make upstream loopback connections family-agnostic.
+ *
+ * Dev servers that bind `localhost` can end up listening on IPv6 `::1` only:
+ * Node 17+ resolves `localhost` to `::1` first, and frameworks like Vite
+ * default `server.host` to `localhost` (flag injection cannot reach them when
+ * the dev command goes through a package.json script). A hardcoded
+ * `127.0.0.1` dial gets ECONNREFUSED from such servers even though the app
+ * is healthy.
+ *
+ * The fixed lookup result keeps behavior deterministic regardless of how the
+ * OS resolves `localhost`: IPv4 is tried first (preserving prior behavior)
+ * and `autoSelectFamily` falls back to `::1`. Refused connections fail
+ * instantly on loopback, so the fallback adds no measurable latency.
+ *
+ * `hostname` (used by `http.request`) and `host` (used by
+ * `net.createConnection`) must be a name, not an IP literal, or the custom
+ * lookup is bypassed.
+ */
+export const LOOPBACK_DIAL_OPTIONS = {
+  hostname: "localhost",
+  host: "localhost",
+  autoSelectFamily: true,
+  lookup: ((_hostname, _options, callback) => {
+    callback(null, [
+      { address: "127.0.0.1", family: 4 },
+      { address: "::1", family: 6 },
+    ]);
+  }) as net.LookupFunction,
+} as const;
+
+/**
+ * Format a dial error for logging. When both loopback families are refused,
+ * the error is an AggregateError whose `message` is empty but whose `code`
+ * is set (e.g. ECONNREFUSED).
+ */
+function dialErrorMessage(err: NodeJS.ErrnoException): string {
+  return err.message || err.code || "connection failed";
+}
+
+/**
  * HTTP/1.1 hop-by-hop headers that are forbidden in HTTP/2 responses.
  * These must be stripped when proxying an HTTP/1.1 backend response
  * back to an HTTP/2 client.
@@ -192,7 +232,7 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
 
     const proxyReq = http.request(
       {
-        hostname: "127.0.0.1",
+        ...LOOPBACK_DIAL_OPTIONS,
         port: route.port,
         path: req.url,
         method: req.method,
@@ -222,7 +262,7 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
     );
 
     proxyReq.on("error", (err) => {
-      onError(`Proxy error for ${getRequestHost(req)}: ${err.message}`);
+      onError(`Proxy error for ${getRequestHost(req)}: ${dialErrorMessage(err)}`);
       if (!res.headersSent) {
         const errWithCode = err as NodeJS.ErrnoException;
         const detail =
@@ -299,7 +339,7 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
     }
 
     const proxyReq = http.request({
-      hostname: "127.0.0.1",
+      ...LOOPBACK_DIAL_OPTIONS,
       port: route.port,
       path: req.url,
       method: req.method,
@@ -337,7 +377,7 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
     });
 
     proxyReq.on("error", (err) => {
-      onError(`WebSocket proxy error for ${getRequestHost(req)}: ${err.message}`);
+      onError(`WebSocket proxy error for ${getRequestHost(req)}: ${dialErrorMessage(err)}`);
       socket.destroy();
     });
 


### PR DESCRIPTION
Fixes #320

## Problem

Dev servers that bind `localhost` can listen on IPv6 `::1` **only**: Node 17+ resolves `localhost` to `::1` first, and e.g. Vite defaults `server.host` to `localhost`. The proxy dialed `127.0.0.1` exclusively, so such apps returned 502 (`connect ECONNREFUSED 127.0.0.1:<port>`) even though they were healthy.

The existing `--host 127.0.0.1` flag injection can't fully prevent this: when the dev command goes through a package.json script (`portless pnpm run dev` where the script runs `vite`), the injector can't see through the script, so no `--host` is injected and Vite falls back to its `localhost` default. (Same family of gap as #285; #292 documents the identical symptom for Expo/Metro.)

## Fix

Make loopback dials family-agnostic instead of patching per framework:

- **`proxy.ts`** — new `LOOPBACK_DIAL_OPTIONS`: a fixed two-address lookup (`127.0.0.1` first, then `::1`) combined with `autoSelectFamily: true`. IPv4 stays the primary, `::1` is the fallback; refused connections fail instantly on loopback so the fallback adds no measurable latency. The fixed lookup keeps behavior deterministic regardless of how the OS resolves `localhost`. Applied to both the HTTP dial site and the WebSocket upgrade path.
- **`cli-utils.ts`** — `isPortListening` uses the same options, so a `::1`-only app is no longer reported dead.
- **Error logs** — when both families are refused, the error is an `AggregateError` with `code` set but an **empty `message`**; proxy error logs now fall back to the code. (The 502 page's `ECONNREFUSED` detail check is unaffected since `code` is preserved.)

`--host` injection is kept as-is (predictable bind address when it does apply); its comment is updated to reflect that the proxy-side fallback is now the safety net.

## Tests

- `proxy.test.ts`: proxies to a backend listening on `::1` only
- `cli-utils.test.ts`: new `isPortListening` suite — nothing listening / IPv4 listener / `::1`-only listener
- Full suite: 149 passed; `tsc` and eslint clean

## Repro (before this change)

```sh
# vite app behind portless via a package.json script, Node 24, macOS
$ lsof -nP -iTCP:4158 -sTCP:LISTEN
node ... TCP [::1]:4158 (LISTEN)
$ curl -sk https://myapp.localhost/   # → portless 502 page
# proxy log: Proxy error for myapp.localhost: connect ECONNREFUSED 127.0.0.1:4158
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
