### PR TITLE
Add ngrok sharing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,20 @@ Set `PORTLESS_TAILSCALE=1` in your shell profile or `.env` to share every app by
 
 Requires the Tailscale CLI to be installed and connected (`tailscale up`), with Tailscale HTTPS certificates enabled.
 
+## ngrok sharing
+
+Expose your dev server to the public internet with [ngrok](https://ngrok.com):
+
+```bash
+portless myapp --ngrok next dev
+# -> https://myapp.localhost           (local)
+# -> https://abc123.ngrok.app          (public)
+```
+
+Set `PORTLESS_NGROK=1` in your shell profile or `.env` to enable ngrok by default when portless runs an app. `portless list` shows both local and ngrok URLs. The ngrok tunnel is cleaned up automatically when the app exits.
+
+Requires the ngrok CLI to be installed and authenticated. If ngrok reports an authentication error, run `ngrok config add-authtoken <token>` and try again.
+
 ## Commands
 
 ```bash
@@ -378,6 +392,7 @@ portless service uninstall       # Remove the startup service
 --app-port <number>              Use a fixed port for the app (skip auto-assignment)
 --tailscale                      Share the app on your Tailscale network (tailnet)
 --funnel                         Share the app publicly via Tailscale Funnel
+--ngrok                          Share the app publicly via ngrok
 --force                          Kill the existing process and take over its route
 --name <name>                    Use <name> as the app name
 ```
@@ -396,6 +411,7 @@ PORTLESS_WILDCARD=1              Allow unregistered subdomains to fall back to p
 PORTLESS_SYNC_HOSTS=0            Disable auto-sync of /etc/hosts (on by default)
 PORTLESS_TAILSCALE=1             Share apps on your Tailscale network (same as --tailscale)
 PORTLESS_FUNNEL=1                Share apps publicly via Tailscale Funnel (same as --funnel)
+PORTLESS_NGROK=1                 Share apps publicly via ngrok (same as --ngrok)
 PORTLESS_STATE_DIR=<path>        Override the state directory
 
 # Injected into child processes
@@ -403,6 +419,7 @@ PORT                             Ephemeral port the child should listen on
 HOST                             Usually 127.0.0.1 (omitted for Expo in LAN mode)
 PORTLESS_URL                     Public URL (e.g. https://myapp.localhost)
 PORTLESS_TAILSCALE_URL           Tailscale URL of the app (when --tailscale is active)
+PORTLESS_NGROK_URL               ngrok URL of the app (when --ngrok is active)
 NODE_EXTRA_CA_CERTS              Path to the portless CA (when HTTPS is active)
 ```
 
@@ -486,3 +503,4 @@ pnpm format           # Format all files with Prettier
 - Node.js 24+
 - macOS, Linux, or Windows
 - Tailscale CLI (optional, for `--tailscale` and `--funnel`)
+- ngrok CLI (optional, for `--ngrok`)

--- a/apps/docs/src/app/commands/page.mdx
+++ b/apps/docs/src/app/commands/page.mdx
@@ -60,8 +60,26 @@ portless docs.myapp next dev
       <td>`--force`</td>
       <td>Override an existing route registered by another process</td>
     </tr>
+    <tr>
+      <td>`--tailscale`</td>
+      <td>Share the app on your Tailscale network.</td>
+    </tr>
+    <tr>
+      <td>`--funnel`</td>
+      <td>Share the app publicly via Tailscale Funnel.</td>
+    </tr>
+    <tr>
+      <td>`--ngrok`</td>
+      <td>Share the app publicly via ngrok.</td>
+    </tr>
   </tbody>
 </table>
+
+```bash
+portless myapp --tailscale next dev
+portless myapp --funnel next dev
+portless myapp --ngrok next dev
+```
 
 ## Get a service URL
 

--- a/apps/docs/src/app/configuration/page.mdx
+++ b/apps/docs/src/app/configuration/page.mdx
@@ -183,7 +183,7 @@ For `appPort`: CLI `--app-port` flag > `PORTLESS_APP_PORT` env var > `package.js
     <tr>
       <td>`PORTLESS_APP_PORT`</td>
       <td>Use a fixed port for the app (skip auto-assignment)</td>
-      <td>random 4000--4999</td>
+      <td>random 4000 to 4999</td>
     </tr>
     <tr>
       <td>`PORTLESS_SYNC_HOSTS`</td>
@@ -194,6 +194,21 @@ For `appPort`: CLI `--app-port` flag > `PORTLESS_APP_PORT` env var > `package.js
       <td>`PORTLESS_STATE_DIR`</td>
       <td>Override the state directory</td>
       <td>`~/.portless`</td>
+    </tr>
+    <tr>
+      <td>`PORTLESS_TAILSCALE`</td>
+      <td>Set to `1` to share apps on your Tailscale network</td>
+      <td>off</td>
+    </tr>
+    <tr>
+      <td>`PORTLESS_FUNNEL`</td>
+      <td>Set to `1` to share apps publicly via Tailscale Funnel</td>
+      <td>off</td>
+    </tr>
+    <tr>
+      <td>`PORTLESS_NGROK`</td>
+      <td>Set to `1` to share apps publicly via ngrok</td>
+      <td>off</td>
     </tr>
     <tr>
       <td>`PORTLESS`</td>

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -128,6 +128,9 @@ describe("CLI", () => {
       expect(stdout).toContain("--foreground");
       expect(stdout).toContain("PORTLESS_STATE_DIR");
       expect(stdout).toContain("PORTLESS_URL");
+      expect(stdout).toContain("--ngrok");
+      expect(stdout).toContain("PORTLESS_NGROK");
+      expect(stdout).toContain("PORTLESS_NGROK_URL");
       expect(stdout).toContain("portless clean");
     });
 
@@ -1416,6 +1419,55 @@ describe("CLI", () => {
         });
         expect(status).toBe(1);
         expect(stderr).toContain("Tailscale");
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe("--ngrok flag", () => {
+    it("shows --ngrok in help output", () => {
+      const { status, stdout } = run(["--help"]);
+      expect(status).toBe(0);
+      expect(stdout).toContain("--ngrok");
+      expect(stdout).toContain("PORTLESS_NGROK");
+      expect(stdout).toContain("PORTLESS_NGROK_URL");
+    });
+
+    it("fails with actionable message when ngrok is not installed", () => {
+      const { status, stderr } = run(["--ngrok", "myapp", "echo", "hello"], {
+        env: { PATH: "/tmp/portless-no-ngrok-path" },
+      });
+      expect(status).toBe(1);
+      expect(stderr).toContain("ngrok CLI not found");
+    });
+
+    it("accepts PORTLESS_NGROK=1 env var", () => {
+      const { status, stderr } = run(["myapp", "echo", "hello"], {
+        env: { PORTLESS_NGROK: "1", PATH: "/tmp/portless-no-ngrok-path" },
+      });
+      expect(status).toBe(1);
+      expect(stderr).toContain("ngrok CLI not found");
+    });
+
+    it("accepts --ngrok after app name", () => {
+      const { status, stderr } = run(["myapp", "--ngrok", "echo", "hello"], {
+        env: { PATH: "/tmp/portless-no-ngrok-path" },
+      });
+      expect(status).toBe(1);
+      expect(stderr).toContain("ngrok CLI not found");
+    });
+
+    it("accepts --ngrok in run subcommand", () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-cli-ngrok-run-"));
+      try {
+        fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ name: "test-app" }));
+        const { status, stderr } = run(["run", "--ngrok", "echo", "hello"], {
+          cwd: tmpDir,
+          env: { PATH: "/tmp/portless-no-ngrok-path" },
+        });
+        expect(status).toBe(1);
+        expect(stderr).toContain("ngrok CLI not found");
       } finally {
         fs.rmSync(tmpDir, { recursive: true, force: true });
       }

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -21,6 +21,7 @@ import {
   registerServe,
   unregisterTailscale,
 } from "./tailscale.js";
+import { ensureNgrokAvailable, startNgrok, stopNgrok, stopNgrokProcess } from "./ngrok.js";
 import {
   inferProjectName,
   detectWorktreePrefix,
@@ -403,6 +404,10 @@ function runServiceUninstallWithSudo(reason: string): boolean {
     timeout: SUDO_SPAWN_TIMEOUT_MS,
   });
   return result.status === 0;
+}
+
+function isEnabledEnv(value: string | undefined): boolean {
+  return value === "1" || value === "true";
 }
 
 // ---------------------------------------------------------------------------
@@ -815,6 +820,9 @@ function listRoutes(store: RouteStore, proxyPort: number, tls: boolean): void {
       const tsLabel = route.tailscaleFunnel ? "funnel" : "tailscale";
       console.log(`    ${colors.gray(tsLabel + ":")} ${colors.green(route.tailscaleUrl)}`);
     }
+    if (route.ngrokUrl) {
+      console.log(`    ${colors.gray("ngrok:")} ${colors.green(route.ngrokUrl)}`);
+    }
   }
   console.log();
 }
@@ -981,11 +989,9 @@ async function runApp(
 
   // Check tailscale readiness early, before auto-starting the proxy.
   // No point starting the proxy if tailscale will fail afterward.
-  const wantsFunnel = process.env.PORTLESS_FUNNEL === "1" || process.env.PORTLESS_FUNNEL === "true";
-  const wantsTailscale =
-    wantsFunnel ||
-    process.env.PORTLESS_TAILSCALE === "1" ||
-    process.env.PORTLESS_TAILSCALE === "true";
+  const wantsFunnel = isEnabledEnv(process.env.PORTLESS_FUNNEL);
+  const wantsTailscale = wantsFunnel || isEnabledEnv(process.env.PORTLESS_TAILSCALE);
+  const wantsNgrok = isEnabledEnv(process.env.PORTLESS_NGROK);
   let tsBaseUrl: string | undefined;
 
   if (wantsTailscale) {
@@ -1003,6 +1009,19 @@ async function runApp(
       } else if (!message.includes("not enabled on your tailnet")) {
         console.error(colors.blue("Make sure Tailscale is connected:"));
         console.error(colors.cyan("  tailscale up"));
+      }
+      process.exit(1);
+    }
+  }
+
+  if (wantsNgrok) {
+    try {
+      ensureNgrokAvailable();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(colors.red(`Error: ${message}`));
+      if (message.includes("not found")) {
+        console.error(colors.blue("Install ngrok: https://ngrok.com/download"));
       }
       process.exit(1);
     }
@@ -1108,6 +1127,8 @@ async function runApp(
   // Readiness was already checked at the top of runApp().
   let tailscaleHttpsPort: number | undefined;
   let tailscaleUrl: string | undefined;
+  let ngrokUrl: string | undefined;
+  let ngrokProcess: Awaited<ReturnType<typeof startNgrok>> | undefined;
 
   if (wantsTailscale && tsBaseUrl) {
     const maxAttempts = 3;
@@ -1149,6 +1170,47 @@ async function runApp(
       });
     } catch {
       // Non-fatal: route display metadata only
+    }
+  }
+
+  if (wantsNgrok) {
+    try {
+      ngrokProcess = await startNgrok(port);
+      ngrokUrl = ngrokProcess.url;
+      console.log(chalk.green(`  ngrok -> ${ngrokUrl}`));
+      console.log(chalk.gray("  (accessible from the public internet via ngrok)\n"));
+
+      try {
+        store.updateRoute(hostname, {
+          ngrokUrl,
+          ngrokPid: ngrokProcess.pid,
+        });
+      } catch {
+        // Non-fatal: route display metadata only
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(colors.red(`Error: ${message}`));
+      if (message.includes("not found")) {
+        console.error(colors.blue("Install ngrok: https://ngrok.com/download"));
+      } else if (message.includes("authentication")) {
+        console.error(colors.blue("Configure ngrok authentication:"));
+        console.error(colors.cyan("  ngrok config add-authtoken <token>"));
+      }
+      try {
+        unregisterTailscale({
+          tailscaleHttpsPort,
+          tailscaleFunnel: wantsFunnel || undefined,
+        });
+      } catch {
+        // Best-effort cleanup; non-fatal
+      }
+      try {
+        store.removeRoute(hostname);
+      } catch {
+        // Best-effort cleanup; non-fatal
+      }
+      process.exit(1);
     }
   }
 
@@ -1208,9 +1270,11 @@ async function runApp(
       // own LAN discovery natively.
       ...(lanMode ? { PORTLESS_LAN: "1" } : {}),
       ...(tailscaleUrl ? { PORTLESS_TAILSCALE_URL: tailscaleUrl } : {}),
+      ...(ngrokUrl ? { PORTLESS_NGROK_URL: ngrokUrl } : {}),
       ...caEnv,
     },
     onCleanup: () => {
+      stopNgrokProcess(ngrokProcess?.child);
       try {
         unregisterTailscale({
           tailscaleHttpsPort,
@@ -1271,7 +1335,7 @@ function appPortFromEnv(): number | undefined {
   return port;
 }
 
-function applyTailscaleFlag(flag: string): boolean {
+function applySharingFlag(flag: string): boolean {
   if (flag === "--tailscale") {
     process.env.PORTLESS_TAILSCALE = "1";
     return true;
@@ -1279,6 +1343,10 @@ function applyTailscaleFlag(flag: string): boolean {
   if (flag === "--funnel") {
     process.env.PORTLESS_FUNNEL = "1";
     process.env.PORTLESS_TAILSCALE = "1";
+    return true;
+  }
+  if (flag === "--ngrok") {
+    process.env.PORTLESS_NGROK = "1";
     return true;
   }
   return false;
@@ -1315,6 +1383,9 @@ ${colors.bold("Options:")}
   --name <name>          Override the inferred base name (worktree prefix still applies)
   --force                Kill the existing process and take over its route
   --app-port <number>    Use a fixed port for the app (skip auto-assignment)
+  --tailscale            Share the app on your Tailscale network (tailnet)
+  --funnel               Share the app publicly via Tailscale Funnel
+  --ngrok                Share the app publicly via ngrok
   --help, -h             Show this help
 
 ${colors.bold("Name inference (in order):")}
@@ -1348,12 +1419,14 @@ ${colors.bold("Examples:")}
         process.exit(1);
       }
       name = args[i];
-    } else if (applyTailscaleFlag(args[i])) {
+    } else if (applySharingFlag(args[i])) {
       // handled
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
       console.error(
-        colors.blue("Known flags: --name, --force, --app-port, --tailscale, --funnel, --help")
+        colors.blue(
+          "Known flags: --name, --force, --app-port, --tailscale, --funnel, --ngrok, --help"
+        )
       );
       process.exit(1);
     }
@@ -1387,11 +1460,13 @@ function parseAppArgs(args: string[]): ParsedAppArgs {
     } else if (args[i] === "--app-port") {
       i++;
       appPort = parseAppPort(args[i]);
-    } else if (applyTailscaleFlag(args[i])) {
+    } else if (applySharingFlag(args[i])) {
       // handled
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
-      console.error(colors.blue("Known flags: --force, --app-port, --tailscale, --funnel"));
+      console.error(
+        colors.blue("Known flags: --force, --app-port, --tailscale, --funnel, --ngrok")
+      );
       process.exit(1);
     }
     i++;
@@ -1411,11 +1486,13 @@ function parseAppArgs(args: string[]): ParsedAppArgs {
     } else if (args[i] === "--app-port") {
       i++;
       appPort = parseAppPort(args[i]);
-    } else if (applyTailscaleFlag(args[i])) {
+    } else if (applySharingFlag(args[i])) {
       // handled
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
-      console.error(colors.blue("Known flags: --force, --app-port, --tailscale, --funnel"));
+      console.error(
+        colors.blue("Known flags: --force, --app-port, --tailscale, --funnel, --ngrok")
+      );
       process.exit(1);
     }
     i++;
@@ -1476,6 +1553,7 @@ ${colors.bold("Examples:")}
   portless get backend                # -> https://backend.localhost
   portless myapp --tailscale next dev # -> also https://<node>.ts.net (tailnet)
   portless myapp --funnel next dev    # -> also https://<node>.ts.net (public)
+  portless myapp --ngrok next dev     # -> also https://<random>.ngrok.app (public)
 
 ${colors.bold("Configuration (portless.json):")}
   Optional. Portless works out of the box by running the "dev" script
@@ -1537,6 +1615,11 @@ ${colors.bold("Tailscale sharing:")}
   ${colors.cyan("portless myapp --tailscale next dev")}
   ${colors.cyan("portless myapp --funnel next dev")}
 
+${colors.bold("ngrok sharing:")}
+  Use --ngrok to expose your dev server to the public internet with ngrok.
+  Requires the ngrok CLI to be installed and authenticated.
+  ${colors.cyan("portless myapp --ngrok next dev")}
+
 ${colors.bold("Options:")}
   run [--name <name>] <cmd>      Infer project name (or override with --name)
                                 Adds worktree prefix in git worktrees
@@ -1556,6 +1639,7 @@ ${colors.bold("Options:")}
   --app-port <number>           Use a fixed port for the app (skip auto-assignment)
   --tailscale                   Share the app on your Tailscale network (tailnet)
   --funnel                      Share the app publicly via Tailscale Funnel
+  --ngrok                       Share the app publicly via ngrok
   --force                       Kill the existing process and take over its route
   --name <name>                 Use <name> as the app name (bypasses subcommand dispatch)
   --                            Stop flag parsing; everything after is passed to the child
@@ -1571,6 +1655,7 @@ ${colors.bold("Environment variables:")}
   PORTLESS_SYNC_HOSTS=0         Disable auto-sync of ${HOSTS_DISPLAY} (on by default)
   PORTLESS_TAILSCALE=1          Share apps on your Tailscale network (same as --tailscale)
   PORTLESS_FUNNEL=1             Share apps publicly via Tailscale Funnel (same as --funnel)
+  PORTLESS_NGROK=1              Share apps publicly via ngrok (same as --ngrok)
   PORTLESS_STATE_DIR=<path>     Override the state directory
   PORTLESS=0                    Run command directly without proxy
 
@@ -1580,6 +1665,7 @@ ${colors.bold("Child process environment:")}
   PORTLESS_URL                  Public URL of the app (e.g. https://myapp.localhost)
   PORTLESS_LAN                  Set to 1 when proxy is in LAN mode
   PORTLESS_TAILSCALE_URL        Tailscale URL of the app (when --tailscale is active)
+  PORTLESS_NGROK_URL            ngrok URL of the app (when --ngrok is active)
   NODE_EXTRA_CA_CERTS           Path to the portless CA (set when HTTPS is active)
 
 ${colors.bold("Safari / DNS:")}
@@ -1722,6 +1808,10 @@ ${colors.bold("Options:")}
         // Tailscale may not be installed; non-fatal
       }
     }
+    if (route.ngrokPid) {
+      stopNgrok(route);
+      console.log(colors.green(`Stopped ngrok tunnel for ${route.hostname}.`));
+    }
   }
 
   const stateDirs = collectStateDirsForCleanup();
@@ -1810,6 +1900,10 @@ ${colors.bold("Options:")}
       } catch {
         // Tailscale CLI may not be installed; non-fatal during prune
       }
+    }
+    if (route.ngrokPid) {
+      stopNgrok(route);
+      console.log(`  ${route.hostname} - stopped ngrok tunnel`);
     }
   }
 
@@ -3449,6 +3543,9 @@ async function main() {
   if (stripGlobalFlag("--funnel", false)) {
     process.env.PORTLESS_FUNNEL = "1";
     process.env.PORTLESS_TAILSCALE = "1";
+  }
+  if (stripGlobalFlag("--ngrok", false)) {
+    process.env.PORTLESS_NGROK = "1";
   }
 
   // --script flag: override the default "dev" script for zero-arg mode.

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -410,6 +410,12 @@ function isEnabledEnv(value: string | undefined): boolean {
   return value === "1" || value === "true";
 }
 
+function formatProcessExitSuffix(code: number | null, signal: NodeJS.Signals | null): string {
+  if (signal) return ` (signal ${signal})`;
+  if (code !== null) return ` (exit ${code})`;
+  return "";
+}
+
 // ---------------------------------------------------------------------------
 // Proxy server lifecycle
 // ---------------------------------------------------------------------------
@@ -1129,6 +1135,36 @@ async function runApp(
   let tailscaleUrl: string | undefined;
   let ngrokUrl: string | undefined;
   let ngrokProcess: Awaited<ReturnType<typeof startNgrok>> | undefined;
+  let stoppingNgrok = false;
+  let ngrokRouteReady = false;
+  let ngrokExitHandled = false;
+  let pendingNgrokExit: { code: number | null; signal: NodeJS.Signals | null } | undefined;
+
+  const handleNgrokExit = (code: number | null, signal: NodeJS.Signals | null) => {
+    if (stoppingNgrok || ngrokExitHandled) return;
+    if (!ngrokRouteReady) {
+      pendingNgrokExit = { code, signal };
+      return;
+    }
+    ngrokExitHandled = true;
+    ngrokUrl = undefined;
+    console.warn(
+      colors.yellow(
+        `Warning: ngrok tunnel for ${hostname} stopped${formatProcessExitSuffix(
+          code,
+          signal
+        )}. Removing its public URL from the route list.`
+      )
+    );
+    try {
+      store.updateRoute(hostname, {
+        ngrokUrl: null,
+        ngrokPid: null,
+      });
+    } catch {
+      // Best-effort cleanup; non-fatal
+    }
+  };
 
   if (wantsTailscale && tsBaseUrl) {
     const maxAttempts = 3;
@@ -1175,7 +1211,10 @@ async function runApp(
 
   if (wantsNgrok) {
     try {
-      ngrokProcess = await startNgrok(port);
+      ngrokProcess = await startNgrok(port, {
+        hostHeader: hostname,
+        onExit: handleNgrokExit,
+      });
       ngrokUrl = ngrokProcess.url;
       console.log(chalk.green(`  ngrok -> ${ngrokUrl}`));
       console.log(chalk.gray("  (accessible from the public internet via ngrok)\n"));
@@ -1187,6 +1226,12 @@ async function runApp(
         });
       } catch {
         // Non-fatal: route display metadata only
+      } finally {
+        ngrokRouteReady = true;
+        if (pendingNgrokExit) {
+          handleNgrokExit(pendingNgrokExit.code, pendingNgrokExit.signal);
+          pendingNgrokExit = undefined;
+        }
       }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
@@ -1274,6 +1319,7 @@ async function runApp(
       ...caEnv,
     },
     onCleanup: () => {
+      stoppingNgrok = true;
       stopNgrokProcess(ngrokProcess?.child);
       try {
         unregisterTailscale({

--- a/packages/portless/src/ngrok.test.ts
+++ b/packages/portless/src/ngrok.test.ts
@@ -1,0 +1,160 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { describe, expect, it } from "vitest";
+import {
+  buildNgrokArgs,
+  ensureNgrokAvailable,
+  extractNgrokUrl,
+  startNgrok,
+  stopNgrokProcess,
+  type NgrokCommandRunner,
+  type NgrokChildProcess,
+  type NgrokSpawner,
+} from "./ngrok.js";
+
+class MockNgrokChild extends EventEmitter {
+  pid = 12345;
+  stdout = new PassThrough();
+  stderr = new PassThrough();
+  killedWith: NodeJS.Signals | undefined;
+
+  kill(signal?: NodeJS.Signals): boolean {
+    this.killedWith = signal;
+    return true;
+  }
+}
+
+function createSpawner(child: MockNgrokChild, calls: string[][] = []): NgrokSpawner {
+  return (args: string[]) => {
+    calls.push(args);
+    return child as unknown as NgrokChildProcess;
+  };
+}
+
+describe("ngrok", () => {
+  describe("ensureNgrokAvailable", () => {
+    it("checks the ngrok CLI version", () => {
+      const calls: string[][] = [];
+      const runner: NgrokCommandRunner = (args) => {
+        calls.push(args);
+        return { status: 0, stdout: "ngrok version 3.0.0", stderr: "" };
+      };
+
+      expect(() => ensureNgrokAvailable(runner)).not.toThrow();
+      expect(calls).toEqual([["version"]]);
+    });
+
+    it("throws an install hint when the ngrok CLI is missing", () => {
+      const error = Object.assign(new Error("spawn ngrok ENOENT"), { code: "ENOENT" });
+      const runner: NgrokCommandRunner = () => ({
+        status: null,
+        stdout: "",
+        stderr: "",
+        error,
+      });
+
+      expect(() => ensureNgrokAvailable(runner)).toThrow("ngrok CLI not found");
+    });
+
+    it("throws command output when the version check fails", () => {
+      const runner: NgrokCommandRunner = () => ({
+        status: 1,
+        stdout: "",
+        stderr: "permission denied",
+      });
+
+      expect(() => ensureNgrokAvailable(runner)).toThrow("permission denied");
+    });
+  });
+
+  describe("buildNgrokArgs", () => {
+    it("forwards HTTP traffic to the local app port", () => {
+      expect(buildNgrokArgs(4123)).toEqual([
+        "http",
+        "--log=stdout",
+        "--log-format=logfmt",
+        "http://127.0.0.1:4123",
+      ]);
+    });
+  });
+
+  describe("extractNgrokUrl", () => {
+    it("extracts the public URL from text output", () => {
+      const output = "Forwarding https://abc123.ngrok.app -> http://127.0.0.1:4123";
+      expect(extractNgrokUrl(output)).toBe("https://abc123.ngrok.app");
+    });
+
+    it("extracts the public URL from structured log output", () => {
+      const output =
+        't=2026-06-04 lvl=info msg="started tunnel" obj=tunnels url=https://abc123.ngrok-free.app';
+      expect(extractNgrokUrl(output)).toBe("https://abc123.ngrok-free.app");
+    });
+
+    it("ignores ngrok docs URLs from errors", () => {
+      const output = "ERROR see https://ngrok.com/docs/errors/err_ngrok_4018";
+      expect(extractNgrokUrl(output)).toBeNull();
+    });
+  });
+
+  describe("startNgrok", () => {
+    it("spawns ngrok and resolves with the public URL", async () => {
+      const child = new MockNgrokChild();
+      const calls: string[][] = [];
+      const promise = startNgrok(4123, {
+        spawner: createSpawner(child, calls),
+        timeoutMs: 1000,
+      });
+
+      child.stdout.write("Forwarding https://abc123.ngrok.app -> http://127.0.0.1:4123\n");
+
+      await expect(promise).resolves.toMatchObject({
+        url: "https://abc123.ngrok.app",
+        pid: 12345,
+      });
+      expect(calls).toEqual([
+        ["http", "--log=stdout", "--log-format=logfmt", "http://127.0.0.1:4123"],
+      ]);
+    });
+
+    it("throws an install hint when the ngrok CLI is missing", async () => {
+      const error = Object.assign(new Error("spawn ngrok ENOENT"), { code: "ENOENT" });
+      const spawner: NgrokSpawner = () => {
+        throw error;
+      };
+
+      await expect(startNgrok(4123, { spawner })).rejects.toThrow("ngrok CLI not found");
+    });
+
+    it("throws an auth hint when ngrok exits with auth output", async () => {
+      const child = new MockNgrokChild();
+      const promise = startNgrok(4123, {
+        spawner: createSpawner(child),
+        timeoutMs: 1000,
+      });
+
+      child.stderr.write("ERROR authtoken is required\n");
+      child.emit("exit", 1, null);
+
+      await expect(promise).rejects.toThrow("authentication is not configured");
+    });
+
+    it("kills ngrok when no public URL appears before the timeout", async () => {
+      const child = new MockNgrokChild();
+      const promise = startNgrok(4123, {
+        spawner: createSpawner(child),
+        timeoutMs: 1,
+      });
+
+      await expect(promise).rejects.toThrow("Timed out waiting for ngrok");
+      expect(child.killedWith).toBe("SIGTERM");
+    });
+  });
+
+  describe("stopNgrokProcess", () => {
+    it("terminates the child process", () => {
+      const child = new MockNgrokChild();
+      stopNgrokProcess(child as unknown as NgrokChildProcess);
+      expect(child.killedWith).toBe("SIGTERM");
+    });
+  });
+});

--- a/packages/portless/src/ngrok.test.ts
+++ b/packages/portless/src/ngrok.test.ts
@@ -68,11 +68,22 @@ describe("ngrok", () => {
   });
 
   describe("buildNgrokArgs", () => {
-    it("forwards HTTP traffic to the local app port", () => {
+    it("forwards HTTP traffic to the local app port with host rewriting", () => {
       expect(buildNgrokArgs(4123)).toEqual([
         "http",
         "--log=stdout",
         "--log-format=logfmt",
+        "--host-header=rewrite",
+        "http://127.0.0.1:4123",
+      ]);
+    });
+
+    it("uses the requested upstream host header", () => {
+      expect(buildNgrokArgs(4123, "myapp.localhost")).toEqual([
+        "http",
+        "--log=stdout",
+        "--log-format=logfmt",
+        "--host-header=myapp.localhost",
         "http://127.0.0.1:4123",
       ]);
     });
@@ -112,8 +123,32 @@ describe("ngrok", () => {
         pid: 12345,
       });
       expect(calls).toEqual([
-        ["http", "--log=stdout", "--log-format=logfmt", "http://127.0.0.1:4123"],
+        [
+          "http",
+          "--log=stdout",
+          "--log-format=logfmt",
+          "--host-header=rewrite",
+          "http://127.0.0.1:4123",
+        ],
       ]);
+    });
+
+    it("notifies when ngrok exits after startup", async () => {
+      const child = new MockNgrokChild();
+      const exits: Array<{ code: number | null; signal: NodeJS.Signals | null }> = [];
+      const promise = startNgrok(4123, {
+        onExit: (code, signal) => exits.push({ code, signal }),
+        spawner: createSpawner(child),
+        timeoutMs: 1000,
+      });
+
+      child.stdout.write("Forwarding https://abc123.ngrok.app -> http://127.0.0.1:4123\n");
+
+      await expect(promise).resolves.toMatchObject({
+        url: "https://abc123.ngrok.app",
+      });
+      child.emit("exit", 0, null);
+      expect(exits).toEqual([{ code: 0, signal: null }]);
     });
 
     it("throws an install hint when the ngrok CLI is missing", async () => {

--- a/packages/portless/src/ngrok.ts
+++ b/packages/portless/src/ngrok.ts
@@ -1,0 +1,221 @@
+import { spawn, spawnSync } from "node:child_process";
+
+const NGROK_BINARY = "ngrok";
+const NGROK_START_TIMEOUT_MS = 30_000;
+const NGROK_COMMAND_TIMEOUT_MS = 10_000;
+const OUTPUT_BUFFER_LIMIT = 16_384;
+
+export interface NgrokChildProcess {
+  pid?: number;
+  stdout: NodeJS.ReadableStream | null;
+  stderr: NodeJS.ReadableStream | null;
+  kill(signal?: NodeJS.Signals): boolean;
+  on(event: "error", listener: (err: Error) => void): this;
+  on(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
+}
+
+export type NgrokSpawner = (args: string[]) => NgrokChildProcess;
+
+interface NgrokCommandResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  error?: Error;
+}
+
+export type NgrokCommandRunner = (args: string[]) => NgrokCommandResult;
+
+export interface StartNgrokOptions {
+  spawner?: NgrokSpawner;
+  timeoutMs?: number;
+}
+
+export interface StartedNgrok {
+  url: string;
+  pid?: number;
+  child: NgrokChildProcess;
+}
+
+function defaultSpawner(args: string[]): NgrokChildProcess {
+  return spawn(NGROK_BINARY, args, {
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  }) as NgrokChildProcess;
+}
+
+function defaultRunner(args: string[]): NgrokCommandResult {
+  const result = spawnSync(NGROK_BINARY, args, {
+    encoding: "utf-8",
+    killSignal: "SIGKILL",
+    timeout: NGROK_COMMAND_TIMEOUT_MS,
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    ...(result.error ? { error: result.error } : {}),
+  };
+}
+
+function normalizeSpace(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+function formatSpawnError(error: Error): Error {
+  const errno = error as NodeJS.ErrnoException;
+  if (errno.code === "ENOENT") {
+    return new Error(
+      "ngrok CLI not found. Install ngrok (https://ngrok.com/download) and ensure `ngrok` is on PATH."
+    );
+  }
+  return new Error(`Failed to start ngrok: ${error.message}`);
+}
+
+function formatOutputError(output: string): Error {
+  const details = normalizeSpace(output);
+  const lower = details.toLowerCase();
+  if (
+    lower.includes("authtoken") ||
+    lower.includes("authentication") ||
+    lower.includes("not logged in")
+  ) {
+    return new Error(
+      "ngrok could not start because authentication is not configured. Run `ngrok config add-authtoken <token>`, then run portless again."
+    );
+  }
+  return new Error(
+    `Failed to start ngrok tunnel: ${details || "ngrok exited before printing a public URL"}`
+  );
+}
+
+export function ensureNgrokAvailable(runner: NgrokCommandRunner = defaultRunner): void {
+  const result = runner(["version"]);
+  if (result.error) {
+    throw formatSpawnError(result.error);
+  }
+  if (result.status !== 0) {
+    const details = normalizeSpace(result.stderr || result.stdout);
+    throw new Error(`Failed to check ngrok version: ${details || "unknown ngrok error"}`);
+  }
+}
+
+function cleanUrl(value: string): string {
+  return value.replace(/[),.]+$/g, "");
+}
+
+export function extractNgrokUrl(output: string): string | null {
+  const urlMatches = output.matchAll(/https:\/\/[^\s"'<>]+/g);
+  for (const match of urlMatches) {
+    const raw = match[0];
+    const matchIndex = match.index ?? 0;
+    const before = output.slice(Math.max(0, matchIndex - 80), matchIndex).toLowerCase();
+    const looksLikeTunnel =
+      before.includes("forwarding") ||
+      before.includes("url=") ||
+      before.includes('"url"') ||
+      before.includes("started tunnel");
+    if (!looksLikeTunnel) continue;
+
+    const candidate = cleanUrl(raw);
+    try {
+      const parsed = new URL(candidate);
+      if (parsed.hostname === "ngrok.com" || parsed.hostname.endsWith(".ngrok.com")) {
+        continue;
+      }
+      return parsed.toString().replace(/\/$/, "");
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+export function buildNgrokArgs(localPort: number): string[] {
+  return ["http", "--log=stdout", "--log-format=logfmt", `http://127.0.0.1:${localPort}`];
+}
+
+export function startNgrok(
+  localPort: number,
+  options: StartNgrokOptions = {}
+): Promise<StartedNgrok> {
+  const spawner = options.spawner ?? defaultSpawner;
+  const timeoutMs = options.timeoutMs ?? NGROK_START_TIMEOUT_MS;
+  const args = buildNgrokArgs(localPort);
+
+  let child: NgrokChildProcess;
+  try {
+    child = spawner(args);
+  } catch (err: unknown) {
+    return Promise.reject(formatSpawnError(err instanceof Error ? err : new Error(String(err))));
+  }
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let output = "";
+
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      fn();
+    };
+
+    const appendOutput = (chunk: Buffer | string) => {
+      if (settled) return;
+      output += chunk.toString();
+      if (output.length > OUTPUT_BUFFER_LIMIT) {
+        output = output.slice(-OUTPUT_BUFFER_LIMIT);
+      }
+      const url = extractNgrokUrl(output);
+      if (url) {
+        settle(() => resolve({ url, pid: child.pid, child }));
+      }
+    };
+
+    const timer = setTimeout(() => {
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        // non-fatal
+      }
+      settle(() =>
+        reject(
+          new Error(
+            "Timed out waiting for ngrok to print a public URL. Check that ngrok is authenticated and can connect."
+          )
+        )
+      );
+    }, timeoutMs);
+
+    child.stdout?.on("data", appendOutput);
+    child.stderr?.on("data", appendOutput);
+    child.on("error", (err) => {
+      settle(() => reject(formatSpawnError(err)));
+    });
+    child.on("exit", (code, signal) => {
+      settle(() => {
+        const suffix = signal ? ` (signal ${signal})` : code !== null ? ` (exit ${code})` : "";
+        const error = formatOutputError(output);
+        reject(new Error(`${error.message}${suffix}`));
+      });
+    });
+  });
+}
+
+export function stopNgrokProcess(child: NgrokChildProcess | undefined): void {
+  if (!child) return;
+  try {
+    child.kill("SIGTERM");
+  } catch {
+    // Best-effort cleanup.
+  }
+}
+
+export function stopNgrok(route: { ngrokPid?: number }): void {
+  if (!route.ngrokPid) return;
+  try {
+    process.kill(route.ngrokPid, "SIGTERM");
+  } catch {
+    // Process may already be gone, or may belong to another user.
+  }
+}

--- a/packages/portless/src/ngrok.ts
+++ b/packages/portless/src/ngrok.ts
@@ -26,6 +26,8 @@ interface NgrokCommandResult {
 export type NgrokCommandRunner = (args: string[]) => NgrokCommandResult;
 
 export interface StartNgrokOptions {
+  hostHeader?: string;
+  onExit?: (code: number | null, signal: NodeJS.Signals | null) => void;
   spawner?: NgrokSpawner;
   timeoutMs?: number;
 }
@@ -130,8 +132,14 @@ export function extractNgrokUrl(output: string): string | null {
   return null;
 }
 
-export function buildNgrokArgs(localPort: number): string[] {
-  return ["http", "--log=stdout", "--log-format=logfmt", `http://127.0.0.1:${localPort}`];
+export function buildNgrokArgs(localPort: number, hostHeader = "rewrite"): string[] {
+  return [
+    "http",
+    "--log=stdout",
+    "--log-format=logfmt",
+    `--host-header=${hostHeader}`,
+    `http://127.0.0.1:${localPort}`,
+  ];
 }
 
 export function startNgrok(
@@ -140,7 +148,7 @@ export function startNgrok(
 ): Promise<StartedNgrok> {
   const spawner = options.spawner ?? defaultSpawner;
   const timeoutMs = options.timeoutMs ?? NGROK_START_TIMEOUT_MS;
-  const args = buildNgrokArgs(localPort);
+  const args = buildNgrokArgs(localPort, options.hostHeader);
 
   let child: NgrokChildProcess;
   try {
@@ -151,6 +159,7 @@ export function startNgrok(
 
   return new Promise((resolve, reject) => {
     let settled = false;
+    let started = false;
     let output = "";
 
     const settle = (fn: () => void) => {
@@ -168,7 +177,10 @@ export function startNgrok(
       }
       const url = extractNgrokUrl(output);
       if (url) {
-        settle(() => resolve({ url, pid: child.pid, child }));
+        settle(() => {
+          started = true;
+          resolve({ url, pid: child.pid, child });
+        });
       }
     };
 
@@ -193,6 +205,10 @@ export function startNgrok(
       settle(() => reject(formatSpawnError(err)));
     });
     child.on("exit", (code, signal) => {
+      if (settled) {
+        if (started) options.onExit?.(code, signal);
+        return;
+      }
       settle(() => {
         const suffix = signal ? ` (signal ${signal})` : code !== null ? ` (exit ${code})` : "";
         const error = formatOutputError(output);

--- a/packages/portless/src/routes.test.ts
+++ b/packages/portless/src/routes.test.ts
@@ -444,4 +444,26 @@ describe("RouteStore", () => {
       expect(routes[0].tailscaleUrl).toBeUndefined();
     });
   });
+
+  describe("ngrok metadata", () => {
+    it("persists and loads ngrok fields via updateRoute", () => {
+      store.addRoute("myapp.localhost", 4123, process.pid);
+      store.updateRoute("myapp.localhost", {
+        ngrokUrl: "https://abc123.ngrok.app",
+        ngrokPid: 12345,
+      });
+      const routes = store.loadRoutes();
+      expect(routes).toHaveLength(1);
+      expect(routes[0].ngrokUrl).toBe("https://abc123.ngrok.app");
+      expect(routes[0].ngrokPid).toBe(12345);
+    });
+
+    it("loads routes without ngrok fields", () => {
+      store.addRoute("legacy.localhost", 4000, process.pid);
+      const routes = store.loadRoutes();
+      expect(routes).toHaveLength(1);
+      expect(routes[0].ngrokUrl).toBeUndefined();
+      expect(routes[0].ngrokPid).toBeUndefined();
+    });
+  });
 });

--- a/packages/portless/src/routes.test.ts
+++ b/packages/portless/src/routes.test.ts
@@ -458,6 +458,22 @@ describe("RouteStore", () => {
       expect(routes[0].ngrokPid).toBe(12345);
     });
 
+    it("clears ngrok fields via updateRoute", () => {
+      store.addRoute("myapp.localhost", 4123, process.pid);
+      store.updateRoute("myapp.localhost", {
+        ngrokUrl: "https://abc123.ngrok.app",
+        ngrokPid: 12345,
+      });
+      store.updateRoute("myapp.localhost", {
+        ngrokUrl: null,
+        ngrokPid: null,
+      });
+      const routes = store.loadRoutes();
+      expect(routes).toHaveLength(1);
+      expect(routes[0].ngrokUrl).toBeUndefined();
+      expect(routes[0].ngrokPid).toBeUndefined();
+    });
+
     it("loads routes without ngrok fields", () => {
       store.addRoute("legacy.localhost", 4000, process.pid);
       const routes = store.loadRoutes();

--- a/packages/portless/src/routes.ts
+++ b/packages/portless/src/routes.ts
@@ -26,6 +26,8 @@ export interface RouteMapping extends RouteInfo {
   tailscaleUrl?: string;
   tailscaleHttpsPort?: number;
   tailscaleFunnel?: boolean;
+  ngrokUrl?: string;
+  ngrokPid?: number;
 }
 
 /** Runtime check that a parsed JSON value is a valid RouteMapping. */
@@ -301,7 +303,12 @@ export class RouteStore {
    */
   updateRoute(
     hostname: string,
-    fields: Partial<Pick<RouteMapping, "tailscaleUrl" | "tailscaleHttpsPort" | "tailscaleFunnel">>
+    fields: Partial<
+      Pick<
+        RouteMapping,
+        "tailscaleUrl" | "tailscaleHttpsPort" | "tailscaleFunnel" | "ngrokUrl" | "ngrokPid"
+      >
+    >
   ): void {
     this.ensureDir();
     if (!this.acquireLock()) {
@@ -315,6 +322,8 @@ export class RouteStore {
       if (fields.tailscaleHttpsPort !== undefined)
         route.tailscaleHttpsPort = fields.tailscaleHttpsPort;
       if (fields.tailscaleFunnel !== undefined) route.tailscaleFunnel = fields.tailscaleFunnel;
+      if (fields.ngrokUrl !== undefined) route.ngrokUrl = fields.ngrokUrl;
+      if (fields.ngrokPid !== undefined) route.ngrokPid = fields.ngrokPid;
       this.saveRoutes(routes);
     } finally {
       this.releaseLock();

--- a/packages/portless/src/routes.ts
+++ b/packages/portless/src/routes.ts
@@ -30,6 +30,14 @@ export interface RouteMapping extends RouteInfo {
   ngrokPid?: number;
 }
 
+type RouteMetadataPatch = {
+  tailscaleUrl?: string | null;
+  tailscaleHttpsPort?: number | null;
+  tailscaleFunnel?: boolean | null;
+  ngrokUrl?: string | null;
+  ngrokPid?: number | null;
+};
+
 /** Runtime check that a parsed JSON value is a valid RouteMapping. */
 function isValidRoute(value: unknown): value is RouteMapping {
   return (
@@ -301,15 +309,7 @@ export class RouteStore {
    * Update metadata on an existing route entry. Only provided fields are
    * merged; the route must already exist (matched by hostname).
    */
-  updateRoute(
-    hostname: string,
-    fields: Partial<
-      Pick<
-        RouteMapping,
-        "tailscaleUrl" | "tailscaleHttpsPort" | "tailscaleFunnel" | "ngrokUrl" | "ngrokPid"
-      >
-    >
-  ): void {
+  updateRoute(hostname: string, fields: RouteMetadataPatch): void {
     this.ensureDir();
     if (!this.acquireLock()) {
       throw new Error("Failed to acquire route lock");
@@ -318,12 +318,28 @@ export class RouteStore {
       const routes = this.loadRoutes(true);
       const route = routes.find((r) => r.hostname === hostname);
       if (!route) return;
-      if (fields.tailscaleUrl !== undefined) route.tailscaleUrl = fields.tailscaleUrl;
-      if (fields.tailscaleHttpsPort !== undefined)
-        route.tailscaleHttpsPort = fields.tailscaleHttpsPort;
-      if (fields.tailscaleFunnel !== undefined) route.tailscaleFunnel = fields.tailscaleFunnel;
-      if (fields.ngrokUrl !== undefined) route.ngrokUrl = fields.ngrokUrl;
-      if (fields.ngrokPid !== undefined) route.ngrokPid = fields.ngrokPid;
+      if ("tailscaleUrl" in fields) {
+        if (fields.tailscaleUrl === null) delete route.tailscaleUrl;
+        else if (fields.tailscaleUrl !== undefined) route.tailscaleUrl = fields.tailscaleUrl;
+      }
+      if ("tailscaleHttpsPort" in fields) {
+        if (fields.tailscaleHttpsPort === null) delete route.tailscaleHttpsPort;
+        else if (fields.tailscaleHttpsPort !== undefined)
+          route.tailscaleHttpsPort = fields.tailscaleHttpsPort;
+      }
+      if ("tailscaleFunnel" in fields) {
+        if (fields.tailscaleFunnel === null) delete route.tailscaleFunnel;
+        else if (fields.tailscaleFunnel !== undefined)
+          route.tailscaleFunnel = fields.tailscaleFunnel;
+      }
+      if ("ngrokUrl" in fields) {
+        if (fields.ngrokUrl === null) delete route.ngrokUrl;
+        else if (fields.ngrokUrl !== undefined) route.ngrokUrl = fields.ngrokUrl;
+      }
+      if ("ngrokPid" in fields) {
+        if (fields.ngrokPid === null) delete route.ngrokPid;
+        else if (fields.ngrokPid !== undefined) route.ngrokPid = fields.ngrokPid;
+      }
       this.saveRoutes(routes);
     } finally {
       this.releaseLock();

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -183,6 +183,7 @@ Portless stores its state (routes, PID file, port file) in `~/.portless`. Overri
 | `PORTLESS_SYNC_HOSTS` | Set to `0` to disable auto-sync of /etc/hosts (on by default)               |
 | `PORTLESS_TAILSCALE`  | Set to `1` to share apps on your Tailscale network (same as `--tailscale`)  |
 | `PORTLESS_FUNNEL`     | Set to `1` to share apps publicly via Tailscale Funnel (same as `--funnel`) |
+| `PORTLESS_NGROK`      | Set to `1` to share apps publicly via ngrok (same as `--ngrok`)             |
 | `PORTLESS_STATE_DIR`  | Override the state directory                                                |
 | `PORTLESS=0`          | Bypass the proxy, run the command directly                                  |
 
@@ -241,6 +242,18 @@ Tailscale HTTPS certificates must be enabled before `--tailscale` or `--funnel` 
 
 Each `--tailscale` app is root-mounted on its own Tailscale HTTPS port (443, then 8443, 8444, etc.) so no framework `basePath` configuration is needed. Set `PORTLESS_TAILSCALE=1` to share every app by default. `portless list` shows both local and tailnet URLs. Tailscale serve registrations are cleaned up when the app exits. Requires `tailscale` CLI installed and connected, with Tailscale HTTPS certificates enabled.
 
+### ngrok sharing
+
+Expose a dev server to the public internet with ngrok using `--ngrok`:
+
+```bash
+portless myapp --ngrok next dev
+# -> https://myapp.localhost           (local)
+# -> https://abc123.ngrok.app          (public internet)
+```
+
+Set `PORTLESS_NGROK=1` to enable ngrok by default when portless runs an app. `portless list` shows both local and ngrok URLs. The ngrok tunnel is cleaned up when the app exits. Requires the `ngrok` CLI to be installed and authenticated with `ngrok config add-authtoken <token>`.
+
 ## OS startup service
 
 Use the service command when users want the proxy to start automatically after reboot:
@@ -296,6 +309,7 @@ The chosen service configuration is written into launchd, systemd, or Task Sched
 | `portless <name> --app-port <n> <cmd>` | Use a fixed port for the app instead of auto-assignment        |
 | `portless <name> --tailscale <cmd>`    | Share the app on your Tailscale network (tailnet)              |
 | `portless <name> --funnel <cmd>`       | Share the app publicly via Tailscale Funnel                    |
+| `portless <name> --ngrok <cmd>`        | Share the app publicly via ngrok                               |
 | `portless <name> --force <cmd>`        | Kill the existing process and take over its route              |
 | `portless --name <name> <cmd>`         | Force `<name>` as app name (bypasses subcommand dispatch)      |
 | `portless <name> -- <cmd> [args...]`   | Stop flag parsing; everything after `--` is passed to child    |
@@ -434,9 +448,21 @@ tailscale up         # Connect to your tailnet
 
 Requires the Tailscale CLI to be installed (https://tailscale.com/download) and on PATH.
 
+### ngrok not working
+
+If `--ngrok` fails:
+
+```bash
+ngrok version                         # Check if installed
+ngrok config add-authtoken <token>    # Configure authentication
+```
+
+Requires the ngrok CLI to be installed (https://ngrok.com/download) and on PATH.
+
 ### Requirements
 
 - Node.js 24+
 - macOS, Linux, or Windows
 - `openssl` (for `--https` cert generation; ships with macOS and most Linux distributions; on Windows, install via `winget install -e --id ShiningLight.OpenSSL.Dev` or use the copy bundled with Git for Windows)
 - `tailscale` CLI (optional, for `--tailscale` and `--funnel`)
+- `ngrok` CLI (optional, for `--ngrok`)


### PR DESCRIPTION
- Add an ngrok tunnel provider with CLI preflight, URL capture, and cleanup.
- Wire `--ngrok`, `PORTLESS_NGROK`, route metadata, and child URL env support.
- Document usage and cover behavior with provider, route, and CLI tests.