### PR TITLE
Prepare v0.14.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,23 @@
 # Changelog
 
-## 0.13.1
+## 0.14.0
 
 <!-- release:start -->
+
+### New Features
+
+- **ngrok sharing**: New `--ngrok` flag exposes portless apps publicly through ngrok while keeping the local `.localhost` URL. Also configurable with `PORTLESS_NGROK=1`; child processes receive `PORTLESS_NGROK_URL`, and `portless list` shows active ngrok URLs. (#323)
+
+### Improvements
+
+- **ngrok tunnel lifecycle**: Portless now checks for the ngrok CLI before starting an app, surfaces install and authentication guidance, removes stopped ngrok URLs from route state, and terminates tunnel processes during app cleanup. (#323)
+
+### Contributors
+
+- @ctate
+<!-- release:end -->
+
+## 0.13.1
 
 ### New Features
 
@@ -23,7 +38,6 @@
 - @skaldebane
 - @ItalianScallian
 - @neefrehman
-<!-- release:end -->
 
 ## 0.13.0
 

--- a/apps/docs/src/app/changelog/page.mdx
+++ b/apps/docs/src/app/changelog/page.mdx
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.14.0
+
+### New Features
+
+- **ngrok sharing**: New `--ngrok` flag exposes portless apps publicly through ngrok while keeping the local `.localhost` URL. Also configurable with `PORTLESS_NGROK=1`; child processes receive `PORTLESS_NGROK_URL`, and `portless list` shows active ngrok URLs
+
+### Improvements
+
+- **ngrok tunnel lifecycle**: Portless checks for the ngrok CLI before starting an app, surfaces install and authentication guidance, removes stopped ngrok URLs from route state, and terminates tunnel processes during app cleanup
+
 ## 0.13.1
 
 ### New Features

--- a/packages/portless/package.json
+++ b/packages/portless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portless",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Replace port numbers with stable, named .localhost URLs. For humans and agents.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
- Bump portless package version to 0.14.0
- Add release notes for ngrok sharing and tunnel lifecycle
- Add matching docs changelog entry