### PR TITLE
Fix HTTP/2 Host forwarding and --force takeover race

### DIFF
--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1251,7 +1251,7 @@ async function runApp(
         // Best-effort cleanup; non-fatal
       }
       try {
-        store.removeRoute(hostname);
+        store.removeRoute(hostname, process.pid);
       } catch {
         // Best-effort cleanup; non-fatal
       }
@@ -1330,7 +1330,7 @@ async function runApp(
         // Best-effort cleanup; non-fatal
       }
       try {
-        store.removeRoute(hostname);
+        store.removeRoute(hostname, process.pid);
       } catch {
         // Lock acquisition may fail during cleanup; non-fatal
       }
@@ -1573,7 +1573,7 @@ ${colors.bold("Usage:")}
   ${colors.cyan("portless run")}                     Same as above
   ${colors.cyan("portless run <cmd>")}               Run a command through the proxy
   ${colors.cyan("portless <name> <cmd>")}            Run with an explicit app name
-  ${colors.cyan("portless proxy start")}             Start the proxy (HTTPS on port 443, daemon)
+  ${colors.cyan("portless proxy start")}             Start the proxy (HTTPS on port 443, daemon); rarely needed since it auto-starts on first run
   ${colors.cyan("portless proxy stop")}              Stop the proxy
   ${colors.cyan("portless service install")}         Start proxy automatically when the OS starts
   ${colors.cyan("portless get <name>")}              Print URL for a service (for cross-service refs)
@@ -2983,7 +2983,7 @@ async function spawnProxiedApp(
     }
     if (capturedStore && capturedHostname) {
       try {
-        capturedStore.removeRoute(capturedHostname);
+        capturedStore.removeRoute(capturedHostname, process.pid);
       } catch {
         // non-fatal
       }
@@ -3270,7 +3270,7 @@ async function runWithTurbo(
 
     for (const { hostname } of routes) {
       try {
-        store.removeRoute(hostname);
+        store.removeRoute(hostname, process.pid);
       } catch {
         // non-fatal
       }
@@ -3357,7 +3357,7 @@ async function runWithDirectSpawn(
 
     for (const { store, hostname } of routeEntries) {
       try {
-        store.removeRoute(hostname);
+        store.removeRoute(hostname, process.pid);
       } catch {
         // non-fatal
       }

--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -1122,6 +1122,59 @@ describe("createProxyServer with TLS (HTTP/2)", () => {
     expect(result.protocol).toBe("h2");
   });
 
+  it("forwards the :authority hostname as Host to the backend (h2 -> HTTP/1.1)", async () => {
+    let receivedHost = "";
+    const backend = trackServer(
+      http.createServer((req, res) => {
+        receivedHost = req.headers.host || "";
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.end("ok");
+      })
+    );
+    await listen(backend);
+    const backendAddr = backend.address();
+    if (!backendAddr || typeof backendAddr === "string") throw new Error("no addr");
+
+    const routes: RouteInfo[] = [{ hostname: "myapp.localhost", port: backendAddr.port }];
+    const server = trackServer(
+      createProxyServer({
+        getRoutes: () => routes,
+        proxyPort: TEST_PROXY_PORT,
+        tls: { cert: tlsCert, key: tlsKey },
+      })
+    );
+    await listen(server);
+
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("no addr");
+
+    const status = await new Promise<number>((resolve, reject) => {
+      const client = http2.connect(`https://127.0.0.1:${addr.port}`, {
+        rejectUnauthorized: false,
+      });
+      client.on("error", reject);
+      // Real h2 clients (browsers, curl) send only :authority — no Host header.
+      const req = client.request({
+        ":method": "GET",
+        ":path": "/",
+        ":authority": "myapp.localhost",
+      });
+      req.on("response", (headers) => {
+        const s = headers[":status"] as number;
+        req.resume();
+        req.on("end", () => {
+          client.close();
+          resolve(s);
+        });
+      });
+      req.on("error", reject);
+      req.end();
+    });
+
+    expect(status).toBe(200);
+    expect(receivedHost).toBe("myapp.localhost");
+  });
+
   it("still accepts HTTP/1.1 connections over TLS (allowHTTP1)", async () => {
     const routes: RouteInfo[] = [];
     const server = trackServer(

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -189,6 +189,12 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
         delete proxyReqHeaders[key];
       }
     }
+    // HTTP/2 carries the hostname only in :authority (stripped above); restore
+    // it as Host so Host-dependent backends (multi-tenant vhosts, framework
+    // host allow-lists) see the original hostname instead of 127.0.0.1.
+    if (!proxyReqHeaders.host) {
+      proxyReqHeaders.host = getRequestHost(req);
+    }
 
     const proxyReq = http.request(
       {
@@ -296,6 +302,12 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
       if (key.startsWith(":")) {
         delete proxyReqHeaders[key];
       }
+    }
+    // HTTP/2 carries the hostname only in :authority (stripped above); restore
+    // it as Host so Host-dependent backends (multi-tenant vhosts, framework
+    // host allow-lists) see the original hostname instead of 127.0.0.1.
+    if (!proxyReqHeaders.host) {
+      proxyReqHeaders.host = getRequestHost(req);
     }
 
     const proxyReq = http.request({

--- a/packages/portless/src/routes.test.ts
+++ b/packages/portless/src/routes.test.ts
@@ -287,6 +287,24 @@ describe("RouteStore", () => {
       expect(routes).toHaveLength(1);
       expect(routes[0].hostname).toBe("app2.localhost");
     });
+
+    it("removes the route when the caller still owns it", () => {
+      store.addRoute("myapp.localhost", 4001, process.pid);
+      store.removeRoute("myapp.localhost", process.pid);
+      expect(store.loadRoutes()).toHaveLength(0);
+    });
+
+    it("does not remove a route the caller no longer owns (post --force takeover)", () => {
+      // Simulate the state right after a --force takeover: the route is owned
+      // by another live process. The killed process's exit cleanup (passing
+      // its own pid) must not deregister the new owner's route.
+      const newOwnerPid = process.ppid;
+      store.addRoute("myapp.localhost", 4002, newOwnerPid);
+      store.removeRoute("myapp.localhost", process.pid);
+      const routes = store.loadRoutes();
+      expect(routes).toHaveLength(1);
+      expect(routes[0].pid).toBe(newOwnerPid);
+    });
   });
 
   describe("locking (via concurrent addRoute)", () => {

--- a/packages/portless/src/routes.ts
+++ b/packages/portless/src/routes.ts
@@ -346,13 +346,21 @@ export class RouteStore {
     }
   }
 
-  removeRoute(hostname: string): void {
+  /**
+   * Remove a route by hostname. When `ownerPid` is provided, the entry is
+   * only removed while it is still owned by that pid. Exit cleanups must
+   * pass their own pid: after a `--force` takeover the killed process would
+   * otherwise deregister the route the new owner just registered.
+   */
+  removeRoute(hostname: string, ownerPid?: number): void {
     this.ensureDir();
     if (!this.acquireLock()) {
       throw new Error("Failed to acquire route lock");
     }
     try {
-      const routes = this.loadRoutes(true).filter((r) => r.hostname !== hostname);
+      const routes = this.loadRoutes(true).filter(
+        (r) => r.hostname !== hostname || (ownerPid !== undefined && r.pid !== ownerPid)
+      );
       this.saveRoutes(routes);
     } finally {
       this.releaseLock();


### PR DESCRIPTION
- Backends now receive the original hostname in the Host header for HTTP/2 requests; previously the :authority pseudo-header was stripped without being mapped to Host, so Host-dependent apps (multi-tenant subdomain routing, framework host allow-lists, absolute URL generation) saw 127.0.0.1 for all browser traffic
- Taking over a route with --force no longer leaves a dead URL: route removal during exit cleanup is now ownership-checked by pid, so the killed process can't deregister the route the new owner just registered
- portless --help now notes the proxy auto-starts on first run, so portless proxy start is rarely needed
- Regression tests for both fixes