### PR TITLE
Improve CLI ergonomics and error responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,8 @@ portless service status          # Show service and proxy status
 portless service uninstall       # Remove the startup service
 ```
 
+`portless url <name>` is a convenience alias for `portless get <name>`. If the single argument after `url` is an installed command, portless treats it as an app named `url` instead. Use `portless get <name>` when a service name also matches a command.
+
 ### Options
 
 ```

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ portless service uninstall       # Remove the startup service
 --key <path>                     Use a custom TLS private key
 --foreground                     Run proxy in foreground instead of daemon
 --tld <tld>                      Use a custom TLD instead of .localhost (e.g. test)
---wildcard                       Allow unregistered subdomains to fall back to parent route
+--wildcard                       Allow unregistered subdomains to fall back to parent route (proxy start / service install only)
 --state-dir <path>               Use a custom state directory with service install
 --script <name>                  Run a specific package.json script (default: dev)
 --app-port <number>              Use a fixed port for the app (skip auto-assignment)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ HTTPS with HTTP/2 is enabled by default. On first run, portless generates a loca
 
 The proxy auto-starts when you run an app. A random port (4000-4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, VitePlus, Astro, React Router, Angular, Expo, React Native), portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag.
 
-When auto-starting, portless reuses the configuration (port, TLS, TLD, wildcard mode) from the most recent proxy run, so a restart or reboot does not silently revert to defaults. Explicit env vars (`PORTLESS_PORT`, `PORTLESS_HTTPS`, etc.) always take priority.
+When auto-starting, portless reuses the configuration (port, TLS, TLD) from the most recent proxy run, so a restart or reboot does not silently revert to defaults. Explicit env vars (`PORTLESS_PORT`, `PORTLESS_HTTPS`, etc.) always take priority.
 
 In non-interactive environments (no TTY, or `CI=1`), portless exits with a descriptive error instead of prompting, so task runners like turborepo and CI scripts fail early with a clear message.
 
@@ -276,7 +276,7 @@ portless proxy start --lan --ip 192.168.1.42
 
 `--lan` switches the proxy to mDNS discovery: services are advertised as `<name>.local` and reachable from any device on the same network. Portless auto-detects your LAN IP and follows Wi-Fi/IP changes automatically, but you can pin another address with `--ip <address>` or by exporting `PORTLESS_LAN_IP`. Set `PORTLESS_LAN=1` in your shell (0/1 boolean) to make LAN mode the default whenever the proxy starts.
 
-Portless remembers LAN mode via `proxy.lan`, so if you stop a LAN proxy and start it again, it stays in LAN mode. All proxy settings (port, TLS, TLD, LAN, wildcard mode) are persisted and reused on auto-start unless overridden by explicit flags or env vars. Use `PORTLESS_LAN=0` for one start to switch back to `.localhost` mode. If a proxy is already running with different explicit LAN, TLS, TLD, or wildcard settings, portless warns and asks you to stop it first.
+Portless remembers LAN mode via `proxy.lan`, so if you stop a LAN proxy and start it again, it stays in LAN mode. All proxy settings (port, TLS, TLD, LAN) are persisted and reused on auto-start unless overridden by explicit flags or env vars. Use `PORTLESS_LAN=0` for one start to switch back to `.localhost` mode. If a proxy is already running with different explicit LAN, TLS, TLD, or wildcard settings, portless warns and asks you to stop it first.
 
 LAN mode depends on the system mDNS tools that portless already spawns: macOS ships with `dns-sd`, while Linux uses `avahi-publish-address` from `avahi-utils` (install via `sudo apt install avahi-utils` or your distro’s equivalent). If the command is missing or your network isn’t reachable, `portless proxy start --lan` prints the relevant error and exits.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ HTTPS with HTTP/2 is enabled by default. On first run, portless generates a loca
 
 The proxy auto-starts when you run an app. A random port (4000-4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, VitePlus, Astro, React Router, Angular, Expo, React Native), portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag.
 
-When auto-starting, portless reuses the configuration (port, TLS, TLD) from the most recent proxy run, so a restart or reboot does not silently revert to defaults. Explicit env vars (`PORTLESS_PORT`, `PORTLESS_HTTPS`, etc.) always take priority.
+When auto-starting, portless reuses the configuration (port, TLS, TLD, wildcard mode) from the most recent proxy run, so a restart or reboot does not silently revert to defaults. Explicit env vars (`PORTLESS_PORT`, `PORTLESS_HTTPS`, etc.) always take priority.
 
 In non-interactive environments (no TTY, or `CI=1`), portless exits with a descriptive error instead of prompting, so task runners like turborepo and CI scripts fail early with a clear message.
 
@@ -276,7 +276,7 @@ portless proxy start --lan --ip 192.168.1.42
 
 `--lan` switches the proxy to mDNS discovery: services are advertised as `<name>.local` and reachable from any device on the same network. Portless auto-detects your LAN IP and follows Wi-Fi/IP changes automatically, but you can pin another address with `--ip <address>` or by exporting `PORTLESS_LAN_IP`. Set `PORTLESS_LAN=1` in your shell (0/1 boolean) to make LAN mode the default whenever the proxy starts.
 
-Portless remembers LAN mode via `proxy.lan`, so if you stop a LAN proxy and start it again, it stays in LAN mode. All proxy settings (port, TLS, TLD, LAN) are persisted and reused on auto-start unless overridden by explicit flags or env vars. Use `PORTLESS_LAN=0` for one start to switch back to `.localhost` mode. If a proxy is already running with different explicit LAN/TLS/TLD settings, portless warns and asks you to stop it first.
+Portless remembers LAN mode via `proxy.lan`, so if you stop a LAN proxy and start it again, it stays in LAN mode. All proxy settings (port, TLS, TLD, LAN, wildcard mode) are persisted and reused on auto-start unless overridden by explicit flags or env vars. Use `PORTLESS_LAN=0` for one start to switch back to `.localhost` mode. If a proxy is already running with different explicit LAN, TLS, TLD, or wildcard settings, portless warns and asks you to stop it first.
 
 LAN mode depends on the system mDNS tools that portless already spawns: macOS ships with `dns-sd`, while Linux uses `avahi-publish-address` from `avahi-utils` (install via `sudo apt install avahi-utils` or your distro’s equivalent). If the command is missing or your network isn’t reachable, `portless proxy start --lan` prints the relevant error and exits.
 
@@ -344,10 +344,15 @@ portless                        # Run dev script through proxy
 portless                        # From monorepo root: run all workspace packages
 portless run [--name <name>] [cmd] [args...]  # Infer name, run through proxy
 portless <name> <cmd> [args...]  # Run app at https://<name>.localhost
+portless <name> VAR=val <cmd>    # Apply env assignments to the child command
+portless get <name>              # Print URL for a service
+portless url <name>              # Alias for portless get
 portless alias <name> <port>     # Register a static route (e.g. for Docker)
 portless alias <name> <port> --force  # Overwrite an existing route
 portless alias --remove <name>   # Remove a static route
 portless list                    # Show active routes
+portless ls                      # Alias for portless list
+portless status                  # Alias for portless list
 portless trust                   # Add local CA to system trust store
 portless clean                   # Remove state, CA trust entry, and hosts block
 portless prune                   # Kill orphaned dev servers from crashed sessions

--- a/packages/portless/src/clean-utils.test.ts
+++ b/packages/portless/src/clean-utils.test.ts
@@ -36,6 +36,7 @@ describe("removePortlessStateFiles", () => {
     fs.writeFileSync(path.join(tmpDir, "routes.json"), "[]");
     fs.writeFileSync(path.join(tmpDir, "ca.pem"), "pem");
     fs.writeFileSync(path.join(tmpDir, "proxy.port"), "443");
+    fs.writeFileSync(path.join(tmpDir, "proxy.wildcard"), "1");
     fs.mkdirSync(path.join(tmpDir, "host-certs"));
     fs.writeFileSync(path.join(tmpDir, "host-certs", "x.pem"), "x");
 
@@ -45,6 +46,7 @@ describe("removePortlessStateFiles", () => {
 
     expect(fs.existsSync(path.join(tmpDir, "routes.json"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, "ca.pem"))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, "proxy.wildcard"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, "host-certs"))).toBe(false);
     expect(fs.readFileSync(path.join(tmpDir, "user-notes.txt"), "utf-8")).toBe("keep me");
   });

--- a/packages/portless/src/clean-utils.ts
+++ b/packages/portless/src/clean-utils.ts
@@ -12,6 +12,7 @@ const PORTLESS_STATE_FILES = [
   "proxy.tls",
   "proxy.tld",
   "proxy.lan",
+  "proxy.wildcard",
   "ca-key.pem",
   "ca.pem",
   "server-key.pem",

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -26,11 +26,13 @@ import {
   readLanMarker,
   readPersistedProxyState,
   readTldFromDir,
+  readWildcardMarker,
   resolveStateDir,
   validateTld,
   writeLanMarker,
   writeTldFile,
   writeTlsMarker,
+  writeWildcardMarker,
 } from "./cli-utils.js";
 
 describe("findFreePort", () => {
@@ -871,6 +873,32 @@ describe("readLanMarker / writeLanMarker", () => {
   });
 });
 
+describe("readWildcardMarker / writeWildcardMarker", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-wildcard-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes and reads wildcard mode", () => {
+    writeWildcardMarker(tmpDir, true);
+    expect(readWildcardMarker(tmpDir)).toBe(true);
+  });
+
+  it("removes the file when disabled", () => {
+    writeWildcardMarker(tmpDir, true);
+    expect(fs.existsSync(path.join(tmpDir, "proxy.wildcard"))).toBe(true);
+
+    writeWildcardMarker(tmpDir, false);
+    expect(fs.existsSync(path.join(tmpDir, "proxy.wildcard"))).toBe(false);
+    expect(readWildcardMarker(tmpDir)).toBe(false);
+  });
+});
+
 describe("readTldFromDir / writeTldFile", () => {
   let tmpDir: string;
 
@@ -993,17 +1021,27 @@ describe("readPersistedProxyState", () => {
     expect(state!.lanMode).toBe(true);
   });
 
+  it("reads wildcard mode from persisted state", () => {
+    fs.writeFileSync(path.join(tmpDir, "proxy.port"), "1355");
+    writeWildcardMarker(tmpDir, true);
+    const state = readPersistedProxyState();
+    expect(state).not.toBeNull();
+    expect(state!.useWildcard).toBe(true);
+  });
+
   it("returns full previous config for a custom proxy setup", () => {
     fs.writeFileSync(path.join(tmpDir, "proxy.port"), "1355");
     writeTlsMarker(tmpDir, true);
     writeTldFile(tmpDir, "local");
     writeLanMarker(tmpDir, "192.168.1.42");
+    writeWildcardMarker(tmpDir, true);
     const state = readPersistedProxyState();
     expect(state).toEqual({
       port: 1355,
       tls: true,
       tld: "local",
       lanMode: true,
+      useWildcard: true,
     });
   });
 });

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -756,30 +756,6 @@ function shellEscape(arg: string): string {
   return `'${arg.replace(/'/g, "'\\''")}'`;
 }
 
-/** Quote an argument for cmd.exe while preserving Windows argv parsing. */
-function cmdEscape(arg: string): string {
-  let escaped = '"';
-  let backslashes = 0;
-
-  for (const char of arg) {
-    if (char === "\\") {
-      backslashes++;
-      continue;
-    }
-
-    if (char === '"') {
-      escaped += "\\".repeat(backslashes * 2 + 1) + '"';
-      backslashes = 0;
-      continue;
-    }
-
-    escaped += "\\".repeat(backslashes) + char;
-    backslashes = 0;
-  }
-
-  return escaped + "\\".repeat(backslashes * 2) + '"';
-}
-
 /**
  * Walk up from `cwd` to the filesystem root, collecting all
  * `node_modules/.bin` directories that exist. Returns them in
@@ -850,9 +826,8 @@ export function spawnCommand(
   // On Unix, spawn detached so the child gets its own process group. This
   // lets us kill the entire tree (shell + grandchild dev server) with a
   // single process.kill(-pid, signal) instead of only the immediate child.
-  const windowsCommand = commandArgs.map(cmdEscape).join(" ");
   const child = isWindows
-    ? spawn("cmd.exe", ["/d", "/s", "/c", `"${windowsCommand}"`], {
+    ? spawn("cmd.exe", ["/d", "/s", "/c", commandArgs.join(" ")], {
         stdio: "inherit",
         env,
       })

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -756,6 +756,30 @@ function shellEscape(arg: string): string {
   return `'${arg.replace(/'/g, "'\\''")}'`;
 }
 
+/** Quote an argument for cmd.exe while preserving Windows argv parsing. */
+function cmdEscape(arg: string): string {
+  let escaped = '"';
+  let backslashes = 0;
+
+  for (const char of arg) {
+    if (char === "\\") {
+      backslashes++;
+      continue;
+    }
+
+    if (char === '"') {
+      escaped += "\\".repeat(backslashes * 2 + 1) + '"';
+      backslashes = 0;
+      continue;
+    }
+
+    escaped += "\\".repeat(backslashes) + char;
+    backslashes = 0;
+  }
+
+  return escaped + "\\".repeat(backslashes * 2) + '"';
+}
+
 /**
  * Walk up from `cwd` to the filesystem root, collecting all
  * `node_modules/.bin` directories that exist. Returns them in
@@ -827,7 +851,7 @@ export function spawnCommand(
   // lets us kill the entire tree (shell + grandchild dev server) with a
   // single process.kill(-pid, signal) instead of only the immediate child.
   const child = isWindows
-    ? spawn("cmd.exe", ["/d", "/s", "/c", commandArgs.join(" ")], {
+    ? spawn("cmd.exe", ["/d", "/s", "/c", commandArgs.map(cmdEscape).join(" ")], {
         stdio: "inherit",
         env,
       })

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -197,6 +197,32 @@ export function writeTlsMarker(dir: string, enabled: boolean): void {
   }
 }
 
+/** Name of the marker file that indicates wildcard subdomain fallback is enabled. */
+const WILDCARD_MARKER_FILE = "proxy.wildcard";
+
+/** Read the wildcard marker from a state directory. */
+export function readWildcardMarker(dir: string): boolean {
+  try {
+    return fs.existsSync(path.join(dir, WILDCARD_MARKER_FILE));
+  } catch {
+    return false;
+  }
+}
+
+/** Write or remove the wildcard marker in the state directory. */
+export function writeWildcardMarker(dir: string, enabled: boolean): void {
+  const markerPath = path.join(dir, WILDCARD_MARKER_FILE);
+  if (enabled) {
+    fs.writeFileSync(markerPath, "1", { mode: 0o644 });
+  } else {
+    try {
+      fs.unlinkSync(markerPath);
+    } catch {
+      // Marker may already be absent; non-fatal
+    }
+  }
+}
+
 /**
  * Name of the marker file that remembers LAN mode across proxy restarts.
  * While the proxy is running, the file stores the last known LAN IP.
@@ -344,6 +370,7 @@ export function readPersistedProxyState(): {
   tls: boolean;
   tld: string;
   lanMode: boolean;
+  useWildcard: boolean;
 } | null {
   const dir = process.env.PORTLESS_STATE_DIR || USER_STATE_DIR;
   const port = readPortFromDir(dir);
@@ -351,7 +378,8 @@ export function readPersistedProxyState(): {
     const tls = readTlsMarker(dir);
     const tld = readTldFromDir(dir);
     const lanIp = readLanMarker(dir);
-    return { port, tls, tld, lanMode: lanIp !== null || tld === "local" };
+    const useWildcard = readWildcardMarker(dir);
+    return { port, tls, tld, lanMode: lanIp !== null || tld === "local", useWildcard };
   }
 
   return null;

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -850,8 +850,9 @@ export function spawnCommand(
   // On Unix, spawn detached so the child gets its own process group. This
   // lets us kill the entire tree (shell + grandchild dev server) with a
   // single process.kill(-pid, signal) instead of only the immediate child.
+  const windowsCommand = commandArgs.map(cmdEscape).join(" ");
   const child = isWindows
-    ? spawn("cmd.exe", ["/d", "/s", "/c", commandArgs.map(cmdEscape).join(" ")], {
+    ? spawn("cmd.exe", ["/d", "/s", "/c", `"${windowsCommand}"`], {
         stdio: "inherit",
         env,
       })

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -664,6 +664,39 @@ describe("CLI", () => {
         fs.rmSync(tmpDir, { recursive: true, force: true });
       }
     });
+
+    it("does not warn when a running proxy is already using wildcard mode", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-cli-wildcard-proxy-"));
+      const server = http.createServer((_req, res) => {
+        res.setHeader("X-Portless", "1");
+        res.end("ok");
+      });
+
+      try {
+        const proxyPort = await new Promise<number>((resolve) => {
+          server.listen(0, "127.0.0.1", () => {
+            const addr = server.address();
+            if (addr && typeof addr !== "string") {
+              resolve(addr.port);
+            }
+          });
+        });
+
+        fs.writeFileSync(path.join(tmpDir, "proxy.port"), proxyPort.toString());
+        fs.writeFileSync(path.join(tmpDir, "proxy.wildcard"), "1");
+
+        const { status, stdout, stderr } = run(["proxy", "start", "--wildcard"], {
+          env: { PORTLESS_STATE_DIR: tmpDir, PORTLESS_HTTPS: "0" },
+        });
+
+        expect(status).toBe(0);
+        expect(stdout).toContain("Proxy is already running on port");
+        expect(stderr).not.toContain("requested wildcard subdomain routing");
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe("persisted LAN marker", () => {

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -361,7 +361,7 @@ describe("CLI", () => {
             "PORTLESS_TAILSCALE=1",
             "node",
             "-e",
-            "process.stdout.write(process.env.PORTLESS_TAILSCALE || '')",
+            "process.stdout.write(process.env.PORTLESS_TAILSCALE)",
           ],
           { env }
         );

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -41,6 +41,13 @@ function run(args: string[], options?: { env?: Record<string, string | undefined
   if (env.npm_command === "exec") {
     delete env.npm_command;
   }
+  if (process.platform === "win32" && "PATH" in env) {
+    for (const key of Object.keys(env)) {
+      if (key !== "PATH" && key.toUpperCase() === "PATH") {
+        delete env[key];
+      }
+    }
+  }
   const result = spawnSync(process.execPath, [CLI_PATH, ...args], {
     encoding: "utf-8",
     timeout: 10_000,
@@ -52,6 +59,14 @@ function run(args: string[], options?: { env?: Record<string, string | undefined
     stdout: result.stdout,
     stderr: result.stderr,
   };
+}
+
+function inheritedPath(): string {
+  return process.env.PATH ?? process.env.Path ?? "";
+}
+
+function prependPath(dir: string): string {
+  return `${dir}${path.delimiter}${inheritedPath()}`;
 }
 
 function writeExpoShim(dir: string): void {
@@ -325,7 +340,7 @@ describe("CLI", () => {
         PORTLESS_STATE_DIR: tmpDir,
         PORTLESS_PORT: String(proxyPort),
         PORTLESS_HTTPS: "0",
-        PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        PATH: prependPath(fakeBinDir),
       };
 
       try {
@@ -400,6 +415,54 @@ describe("CLI", () => {
       });
       expect(status).toBe(0);
       expect(stdout.trim()).toBe("app-named-url");
+    });
+
+    it("still runs an app named url with a one token command when that command exists", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-url-alias-state-"));
+      const shimDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-url-alias-bin-"));
+      const server = http.createServer((_req, res) => {
+        res.setHeader("X-Portless", "1");
+        res.end("ok");
+      });
+      const commandName = "portless-url-command";
+
+      try {
+        const proxyPort = await new Promise<number>((resolve) => {
+          server.listen(0, "127.0.0.1", () => {
+            const addr = server.address();
+            if (addr && typeof addr !== "string") {
+              resolve(addr.port);
+            }
+          });
+        });
+
+        fs.writeFileSync(path.join(tmpDir, "proxy.port"), proxyPort.toString());
+        if (process.platform === "win32") {
+          fs.writeFileSync(
+            path.join(shimDir, `${commandName}.cmd`),
+            "@echo off\r\necho app-named-url-single\r\n"
+          );
+        } else {
+          const shimPath = path.join(shimDir, commandName);
+          fs.writeFileSync(shimPath, "#!/bin/sh\necho app-named-url-single\n");
+          fs.chmodSync(shimPath, 0o755);
+        }
+
+        const { status, stdout } = run(["url", commandName], {
+          env: {
+            PATH: prependPath(shimDir),
+            PORTLESS_STATE_DIR: tmpDir,
+            PORTLESS_HTTPS: "0",
+          },
+        });
+
+        expect(status).toBe(0);
+        expect(stdout).toContain("app-named-url-single");
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        fs.rmSync(shimDir, { recursive: true, force: true });
+      }
     });
   });
 
@@ -890,7 +953,7 @@ describe("CLI", () => {
 
         const { status } = run(["run", "--name", "mobile", "--app-port", "4567", "expo", "start"], {
           env: {
-            PATH: `${shimDir}${path.delimiter}${process.env.PATH ?? ""}`,
+            PATH: prependPath(shimDir),
             PORTLESS_STATE_DIR: tmpDir,
             PORTLESS_TEST_CAPTURE_FILE: capturePath,
             PORTLESS_HTTPS: "0",
@@ -987,7 +1050,7 @@ describe("CLI", () => {
 
         const { status } = run(["run", "--name", "myapp", "--app-port", "4567", "rsbuild", "dev"], {
           env: {
-            PATH: `${shimDir}${path.delimiter}${process.env.PATH ?? ""}`,
+            PATH: prependPath(shimDir),
             PORTLESS_STATE_DIR: tmpDir,
             PORTLESS_TEST_CAPTURE_FILE: capturePath,
             PORTLESS_HTTPS: "0",
@@ -1378,7 +1441,7 @@ describe("CLI", () => {
           PORTLESS_PORT: String(testPort),
           PORTLESS_STATE_DIR: tmpDir,
           // Put fake security first in PATH; real openssl is still reachable
-          PATH: `${fakeBinDir}:${process.env.PATH}`,
+          PATH: prependPath(fakeBinDir),
         };
 
         // HTTPS is on by default (no PORTLESS_HTTPS=0), so this exercises

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -316,6 +316,51 @@ describe("CLI", () => {
       expect(stdout.trim()).toBe("12");
     });
 
+    it("does not apply PORTLESS_* child assignments to portless itself", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-env-scope-"));
+      const fakeBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-fake-tailscale-"));
+      const proxyPort = await getFreePort();
+      const fakeMessage = "fake tailscale should not run";
+      const env = {
+        PORTLESS_STATE_DIR: tmpDir,
+        PORTLESS_PORT: String(proxyPort),
+        PORTLESS_HTTPS: "0",
+        PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      };
+
+      try {
+        if (process.platform === "win32") {
+          fs.writeFileSync(
+            path.join(fakeBinDir, "tailscale.cmd"),
+            `@echo off\r\necho ${fakeMessage} 1>&2\r\nexit /b 42\r\n`
+          );
+        } else {
+          const shimPath = path.join(fakeBinDir, "tailscale");
+          fs.writeFileSync(shimPath, `#!/bin/sh\necho "${fakeMessage}" >&2\nexit 42\n`);
+          fs.chmodSync(shimPath, 0o755);
+        }
+
+        const { status, stdout, stderr } = run(
+          [
+            "myapp",
+            "PORTLESS_TAILSCALE=1",
+            "node",
+            "-e",
+            "process.stdout.write(process.env.PORTLESS_TAILSCALE || '')",
+          ],
+          { env }
+        );
+
+        expect(status).toBe(0);
+        expect(stdout).toContain("1");
+        expect(stderr).not.toContain(fakeMessage);
+      } finally {
+        run(["proxy", "stop"], { env });
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        fs.rmSync(fakeBinDir, { recursive: true, force: true });
+      }
+    });
+
     it("does not hoist after an explicit -- separator", () => {
       const { stdout } = run(["myapp", "--", "C=3", "echo", "untouched"], {
         env: { PORTLESS: "0" },

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -1256,6 +1256,18 @@ describe("CLI", () => {
       expect(start2.stdout).toContain("already running");
     });
 
+    it("clears wildcard mode marker when the proxy stops", () => {
+      const markerPath = path.join(tmpDir, "proxy.wildcard");
+      const start = run(["proxy", "start", "--wildcard"], { env: proxyEnv() });
+      expect(start.status).toBe(0);
+      expect(fs.existsSync(markerPath)).toBe(true);
+
+      const stop = run(["proxy", "stop"], { env: proxyEnv() });
+      expect(stop.status).toBe(0);
+      expect(stop.stdout).toContain("Proxy stopped");
+      expect(fs.existsSync(markerPath)).toBe(false);
+    });
+
     it("stops proxy using explicit -p flag instead of env var", () => {
       const start = run(["proxy", "start"], { env: proxyEnv() });
       expect(start.status).toBe(0);

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -288,6 +288,90 @@ describe("CLI", () => {
     });
   });
 
+  describe("env assignments before the child command", () => {
+    it("hoists VAR=val tokens into the child environment (named mode)", () => {
+      const { status, stdout } = run(
+        ["myapp", "GREETING=hi", "node", "-e", "console.log(process.env.GREETING)"],
+        { env: { PORTLESS: "0" } }
+      );
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe("hi");
+    });
+
+    it("hoists VAR=val tokens in run mode", () => {
+      const { status, stdout } = run(
+        ["run", "GREETING=hello", "node", "-e", "console.log(process.env.GREETING)"],
+        { env: { PORTLESS: "0" } }
+      );
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe("hello");
+    });
+
+    it("hoists multiple assignments and keeps the rest of the command intact", () => {
+      const { status, stdout } = run(
+        ["myapp", "A=1", "B=2", "node", "-e", "console.log(process.env.A + process.env.B)"],
+        { env: { PORTLESS: "0" } }
+      );
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe("12");
+    });
+
+    it("does not hoist after an explicit -- separator", () => {
+      const { stdout } = run(["myapp", "--", "C=3", "echo", "untouched"], {
+        env: { PORTLESS: "0" },
+      });
+      // The command after -- is passed through literally, so the first token
+      // is executed as a (nonexistent) program instead of being hoisted.
+      expect(stdout.trim()).not.toBe("untouched");
+    });
+  });
+
+  describe("command aliases", () => {
+    it("treats ls as list", () => {
+      expect(run(["ls"]).status).toBe(0);
+    });
+
+    it("treats status as list", () => {
+      expect(run(["status"]).status).toBe(0);
+    });
+
+    it("treats url as get", () => {
+      const { status, stdout } = run(["url", "--help"]);
+      expect(status).toBe(0);
+      expect(stdout).toContain("portless get");
+    });
+
+    it("still runs an app named ls when a command follows", () => {
+      const { status, stdout } = run(["ls", "echo", "app-named-ls"], {
+        env: { PORTLESS: "0" },
+      });
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe("app-named-ls");
+    });
+
+    it("still runs an app named url when a command follows", () => {
+      const { status, stdout } = run(["url", "echo", "app-named-url"], {
+        env: { PORTLESS: "0" },
+      });
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe("app-named-url");
+    });
+  });
+
+  describe("--wildcard misplacement hint", () => {
+    it("redirects --wildcard to proxy start in named mode", () => {
+      const { status, stderr } = run(["myapp", "--wildcard", "echo", "x"]);
+      expect(status).toBe(1);
+      expect(stderr).toContain("proxy start --wildcard");
+    });
+
+    it("redirects --wildcard to proxy start in run mode", () => {
+      const { status, stderr } = run(["run", "--wildcard", "echo", "x"]);
+      expect(status).toBe(1);
+      expect(stderr).toContain("proxy start --wildcard");
+    });
+  });
+
   describe("--force positioning", () => {
     it("accepts --force before name (PORTLESS=0)", () => {
       const { status, stdout } = run(["--force", "myapp", "echo", "ok"], {

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -1170,6 +1170,24 @@ describe("CLI", () => {
       expect(stdout.trim()).toMatch(/^https?:\/\/backend\.localhost(:\d+)?$/);
     });
 
+    it("accepts --no-worktree before the name through the url alias", () => {
+      const { status, stdout } = run(["url", "--no-worktree", "backend"], { env: getEnv() });
+      expect(status).toBe(0);
+      expect(stdout.trim()).toMatch(/^https?:\/\/backend\.localhost(:\d+)?$/);
+    });
+
+    it("accepts --no-worktree after the name through the url alias", () => {
+      const { status, stdout } = run(["url", "backend", "--no-worktree"], { env: getEnv() });
+      expect(status).toBe(0);
+      expect(stdout.trim()).toMatch(/^https?:\/\/backend\.localhost(:\d+)?$/);
+    });
+
+    it("reports missing service name through the url alias", () => {
+      const { status, stderr } = run(["url", "--no-worktree"], { env: getEnv() });
+      expect(status).toBe(1);
+      expect(stderr).toContain("Missing service name");
+    });
+
     it("exits 1 for invalid hostname", () => {
       const { status, stderr } = run(["get", "my@app"]);
       expect(status).toBe(1);

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -309,7 +309,7 @@ describe("CLI", () => {
 
     it("hoists multiple assignments and keeps the rest of the command intact", () => {
       const { status, stdout } = run(
-        ["myapp", "A=1", "B=2", "node", "-e", "console.log(process.env.A + process.env.B)"],
+        ["myapp", "A=1", "B=2", "node", "-e", "process.stdout.write(process.env.A+process.env.B)"],
         { env: { PORTLESS: "0" } }
       );
       expect(status).toBe(0);

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1429,6 +1429,23 @@ function applySharingFlag(flag: string): boolean {
   return false;
 }
 
+function isUrlGetAliasShape(args: string[]): boolean {
+  if (args[0] !== "url") return false;
+
+  const rest = args.slice(1);
+  if (rest.length === 0) return true;
+  if (rest.includes("--help") || rest.includes("-h")) return true;
+
+  let positionals = 0;
+  for (const arg of rest) {
+    if (arg === "--no-worktree") continue;
+    if (arg.startsWith("-")) return false;
+    positionals++;
+  }
+
+  return positionals <= 1;
+}
+
 /**
  * Parse `run` subcommand arguments: `[--name <name>] [--force] [--] <command...>`
  *
@@ -3782,7 +3799,7 @@ async function main() {
       await handleList();
       return;
     }
-    if (args[0] === "get" || (args[0] === "url" && args.slice(2).every((a) => a.startsWith("-")))) {
+    if (args[0] === "get" || isUrlGetAliasShape(args)) {
       await handleGet(args);
       return;
     }

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -280,6 +280,14 @@ function getProxyConfigMismatchMessages(
     );
   }
 
+  if (explicit.useWildcard && desiredConfig.useWildcard !== actualConfig.useWildcard) {
+    messages.push(
+      desiredConfig.useWildcard
+        ? "requested wildcard subdomain routing, but the running proxy is using strict matching"
+        : "requested strict subdomain matching, but the running proxy is using wildcard routing"
+    );
+  }
+
   return messages;
 }
 
@@ -1381,6 +1389,22 @@ function appPortFromEnv(): number | undefined {
   return port;
 }
 
+/**
+ * Hoist leading `VAR=val` tokens from a child command into the environment,
+ * matching shell semantics: `portless myapp API_URL=x node server.js` behaves
+ * like `API_URL=x portless myapp node server.js`. Without this the first
+ * token would be executed as a program literally named `API_URL=x`.
+ */
+function hoistEnvAssignments(commandArgs: string[]): string[] {
+  let i = 0;
+  while (i < commandArgs.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(commandArgs[i])) {
+    const eq = commandArgs[i].indexOf("=");
+    process.env[commandArgs[i].slice(0, eq)] = commandArgs[i].slice(eq + 1);
+    i++;
+  }
+  return commandArgs.slice(i);
+}
+
 function applySharingFlag(flag: string): boolean {
   if (flag === "--tailscale") {
     process.env.PORTLESS_TAILSCALE = "1";
@@ -1409,10 +1433,12 @@ function parseRunArgs(args: string[]): ParsedRunArgs {
   let force = false;
   let appPort: number | undefined;
   let name: string | undefined;
+  let passthrough = false;
   let i = 0;
 
   while (i < args.length && args[i].startsWith("-")) {
     if (args[i] === "--") {
+      passthrough = true;
       i++;
       break;
     } else if (args[i] === "--help" || args[i] === "-h") {
@@ -1467,6 +1493,14 @@ ${colors.bold("Examples:")}
       name = args[i];
     } else if (applySharingFlag(args[i])) {
       // handled
+    } else if (args[i] === "--wildcard") {
+      console.error(colors.red(`Error: "--wildcard" is a proxy-level option, not a per-app flag.`));
+      console.error(
+        colors.blue(
+          "Enable it on the proxy: portless proxy stop && portless proxy start --wildcard"
+        )
+      );
+      process.exit(1);
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
       console.error(
@@ -1481,7 +1515,10 @@ ${colors.bold("Examples:")}
 
   if (!appPort) appPort = appPortFromEnv();
 
-  return { force, appPort, name, commandArgs: args.slice(i) };
+  // An explicit `--` means "pass everything through untouched" — skip env
+  // assignment hoisting so the documented escape hatch stays literal.
+  const commandArgs = passthrough ? args.slice(i) : hoistEnvAssignments(args.slice(i));
+  return { force, appPort, name, commandArgs };
 }
 
 /**
@@ -1494,11 +1531,13 @@ ${colors.bold("Examples:")}
 function parseAppArgs(args: string[]): ParsedAppArgs {
   let force = false;
   let appPort: number | undefined;
+  let passthrough = false;
   let i = 0;
 
   // Consume leading flags before name
   while (i < args.length && args[i].startsWith("-")) {
     if (args[i] === "--") {
+      passthrough = true;
       i++;
       break;
     } else if (args[i] === "--force") {
@@ -1508,6 +1547,14 @@ function parseAppArgs(args: string[]): ParsedAppArgs {
       appPort = parseAppPort(args[i]);
     } else if (applySharingFlag(args[i])) {
       // handled
+    } else if (args[i] === "--wildcard") {
+      console.error(colors.red(`Error: "--wildcard" is a proxy-level option, not a per-app flag.`));
+      console.error(
+        colors.blue(
+          "Enable it on the proxy: portless proxy stop && portless proxy start --wildcard"
+        )
+      );
+      process.exit(1);
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
       console.error(
@@ -1525,6 +1572,7 @@ function parseAppArgs(args: string[]): ParsedAppArgs {
   // Allow flags immediately after name (e.g. `portless myapp --force next dev`)
   while (i < args.length && args[i].startsWith("--")) {
     if (args[i] === "--") {
+      passthrough = true;
       i++;
       break;
     } else if (args[i] === "--force") {
@@ -1534,6 +1582,14 @@ function parseAppArgs(args: string[]): ParsedAppArgs {
       appPort = parseAppPort(args[i]);
     } else if (applySharingFlag(args[i])) {
       // handled
+    } else if (args[i] === "--wildcard") {
+      console.error(colors.red(`Error: "--wildcard" is a proxy-level option, not a per-app flag.`));
+      console.error(
+        colors.blue(
+          "Enable it on the proxy: portless proxy stop && portless proxy start --wildcard"
+        )
+      );
+      process.exit(1);
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
       console.error(
@@ -1546,7 +1602,10 @@ function parseAppArgs(args: string[]): ParsedAppArgs {
 
   if (!appPort) appPort = appPortFromEnv();
 
-  return { force, appPort, name, commandArgs: args.slice(i) };
+  // An explicit `--` means "pass everything through untouched" — skip env
+  // assignment hoisting so the documented escape hatch stays literal.
+  const commandArgs = passthrough ? args.slice(i) : hoistEnvAssignments(args.slice(i));
+  return { force, appPort, name, commandArgs };
 }
 
 // ---------------------------------------------------------------------------
@@ -1680,7 +1739,7 @@ ${colors.bold("Options:")}
   --key <path>                  Use a custom TLS private key
   --foreground                  Run proxy in foreground (for debugging)
   --tld <tld>                   Use a custom TLD instead of .localhost (e.g. test, dev)
-  --wildcard                    Allow unregistered subdomains to fall back to parent route
+  --wildcard                    Allow unregistered subdomains to fall back to parent route (proxy start / service install only)
   --state-dir <path>            Use a custom state directory with service install
   --app-port <number>           Use a fixed port for the app (skip auto-assignment)
   --tailscale                   Share the app on your Tailscale network (tailnet)
@@ -3693,11 +3752,18 @@ async function main() {
       await handlePrune(args);
       return;
     }
-    if (args[0] === "list") {
+    // `ls`, `status`, and `url` are aliases for `list` and `get`, but only
+    // when the argument shape matches the subcommand — `portless ls next dev`
+    // is an app named "ls" running a command, and existing workflows built on
+    // those names keep working.
+    if (
+      args[0] === "list" ||
+      ((args[0] === "ls" || args[0] === "status") && args.slice(1).every((a) => a.startsWith("-")))
+    ) {
       await handleList();
       return;
     }
-    if (args[0] === "get") {
+    if (args[0] === "get" || (args[0] === "url" && args.slice(2).every((a) => a.startsWith("-")))) {
       await handleGet(args);
       return;
     }

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -56,6 +56,7 @@ import {
   readPersistedProxyState,
   readTldFromDir,
   readTlsMarker,
+  readWildcardMarker,
   resolveStateDir,
   spawnCommand,
   augmentedPath,
@@ -64,6 +65,7 @@ import {
   writeLanMarker,
   writeTldFile,
   writeTlsMarker,
+  writeWildcardMarker,
 } from "./cli-utils.js";
 import { collectStateDirsForCleanup, removePortlessStateFiles } from "./clean-utils.js";
 import {
@@ -241,7 +243,7 @@ function readCurrentProxyConfig(dir: string): ProxyConfig {
     lanIp,
     lanIpExplicit: false,
     tld,
-    useWildcard: false,
+    useWildcard: readWildcardMarker(dir),
   };
 }
 
@@ -596,6 +598,7 @@ function startProxyServer(
     writeTlsMarker(store.dir, isTls);
     writeTldFile(store.dir, tld);
     writeLanMarker(store.dir, activeLanIp);
+    writeWildcardMarker(store.dir, strict === false);
     fixOwnership(store.dir, store.pidPath, store.portFilePath);
     const proto = isTls ? "HTTPS/2" : "HTTP";
     const tldLabel = tld !== DEFAULT_TLD ? ` (TLD: .${tld})` : "";
@@ -909,6 +912,9 @@ async function ensureProxyRunning(
     }
     if (!explicit.lanMode && persisted.lanMode !== desiredConfig.lanMode) {
       startConfig.lanMode = persisted.lanMode;
+    }
+    if (!explicit.useWildcard && persisted.useWildcard !== desiredConfig.useWildcard) {
+      startConfig.useWildcard = persisted.useWildcard;
     }
     const envPort = getDefaultPort(startConfig.useHttps);
     if (persisted.port !== envPort) {
@@ -1632,13 +1638,14 @@ ${colors.bold("Usage:")}
   ${colors.cyan("portless run")}                     Same as above
   ${colors.cyan("portless run <cmd>")}               Run a command through the proxy
   ${colors.cyan("portless <name> <cmd>")}            Run with an explicit app name
+  ${colors.cyan("portless <name> VAR=val <cmd>")}    Apply env assignments to the child command
   ${colors.cyan("portless proxy start")}             Start the proxy (HTTPS on port 443, daemon); rarely needed since it auto-starts on first run
   ${colors.cyan("portless proxy stop")}              Stop the proxy
   ${colors.cyan("portless service install")}         Start proxy automatically when the OS starts
-  ${colors.cyan("portless get <name>")}              Print URL for a service (for cross-service refs)
+  ${colors.cyan("portless get <name>")}              Print URL for a service; alias: url
   ${colors.cyan("portless alias <name> <port>")}     Register a static route (e.g. for Docker)
   ${colors.cyan("portless alias --remove <name>")}   Remove a static route
-  ${colors.cyan("portless list")}                    Show active routes
+  ${colors.cyan("portless list")}                    Show active routes; aliases: ls, status
   ${colors.cyan("portless trust")}                   Add local CA to system trust store
   ${colors.cyan("portless clean")}                   Remove portless state, trust entry, and hosts block
   ${colors.cyan("portless prune")}                   Kill orphaned dev servers from crashed sessions
@@ -1650,12 +1657,14 @@ ${colors.bold("Examples:")}
   portless                            # From monorepo root: start all apps
   portless --script start             # Run "start" script instead of "dev"
   portless myapp next dev             # -> https://myapp.localhost
+  portless myapp API_URL=x next dev   # API_URL is set for the child command
   portless run next dev               # -> https://<project>.localhost
   portless run next dev               # in worktree -> https://<worktree>.<project>.localhost
   portless service install            # Start HTTPS proxy on OS startup
   portless service install --lan      # Persist LAN mode in the startup service
   portless service install --wildcard # Persist wildcard routing in the startup service
   portless get backend                # -> https://backend.localhost
+  portless url backend                # Alias for "portless get backend"
   portless myapp --tailscale next dev # -> also https://<node>.ts.net (tailnet)
   portless myapp --funnel next dev    # -> also https://<node>.ts.net (public)
   portless myapp --ngrok next dev     # -> also https://<random>.ngrok.app (public)
@@ -2463,6 +2472,9 @@ ${colors.bold("LAN mode (--lan):")}
     tld,
     useWildcard,
   });
+  if (!explicit.useWildcard) {
+    desiredConfig.useWildcard = readWildcardMarker(stateDir);
+  }
   const lanMode = desiredConfig.lanMode;
   useHttps = desiredConfig.useHttps;
   customCertPath = desiredConfig.customCertPath;

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1429,6 +1429,41 @@ function applySharingFlag(flag: string): boolean {
   return false;
 }
 
+function isExecutableFile(filePath: string): boolean {
+  try {
+    const stat = fs.statSync(filePath);
+    if (!stat.isFile()) return false;
+    if (isWindows) return true;
+    fs.accessSync(filePath, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function commandExists(command: string): boolean {
+  if (!command || command.includes("/") || command.includes("\\")) {
+    return isExecutableFile(path.resolve(command));
+  }
+
+  const pathValue = augmentedPath(process.env);
+  const extensions = isWindows
+    ? ["", ...(process.env.PATHEXT || ".COM;.EXE;.BAT;.CMD").split(";").filter(Boolean)].map(
+        (ext) => ext.toLowerCase()
+      )
+    : [""];
+
+  for (const dir of pathValue.split(path.delimiter)) {
+    if (!dir) continue;
+    for (const ext of extensions) {
+      const candidate = path.join(dir, isWindows ? command + ext : command);
+      if (isExecutableFile(candidate)) return true;
+    }
+  }
+
+  return false;
+}
+
 function isUrlGetAliasShape(args: string[]): boolean {
   if (args[0] !== "url") return false;
 
@@ -1437,13 +1472,23 @@ function isUrlGetAliasShape(args: string[]): boolean {
   if (rest.includes("--help") || rest.includes("-h")) return true;
 
   let positionals = 0;
+  let serviceName: string | undefined;
+  let hasGetFlag = false;
   for (const arg of rest) {
-    if (arg === "--no-worktree") continue;
+    if (arg === "--no-worktree") {
+      hasGetFlag = true;
+      continue;
+    }
     if (arg.startsWith("-")) return false;
+    serviceName = arg;
     positionals++;
   }
 
-  return positionals <= 1;
+  if (positionals === 0) return true;
+  if (positionals > 1) return false;
+  if (hasGetFlag) return true;
+
+  return serviceName === undefined || !commandExists(serviceName);
 }
 
 /**
@@ -2101,6 +2146,11 @@ ${colors.bold("Examples:")}
   portless get backend                  # -> https://backend.localhost
   portless get backend                  # in worktree -> https://auth.backend.localhost
   portless get backend --no-worktree    # -> https://backend.localhost (skip worktree)
+
+${colors.bold("Alias note:")}
+  "url" is a convenience alias for "get". If the single argument is an
+  installed command, portless treats it as an app named "url" instead.
+  Use "portless get <name>" when a service name also matches a command.
 `);
     process.exit(0);
   }

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -654,9 +654,7 @@ function startProxyServer(
     } catch {
       // Port file may already be removed; non-fatal
     }
-    writeTlsMarker(store.dir, false);
-    writeTldFile(store.dir, DEFAULT_TLD);
-    writeLanMarker(store.dir, null);
+    resetProxyRuntimeMarkers(store.dir);
     if (autoSyncHosts) cleanHostsFile();
     server.close(() => process.exit(0));
     // Force exit after a short timeout in case connections don't drain
@@ -688,6 +686,13 @@ function sudoStopOrHint(port: number): void {
   }
 }
 
+function resetProxyRuntimeMarkers(dir: string): void {
+  writeTlsMarker(dir, false);
+  writeTldFile(dir, DEFAULT_TLD);
+  writeLanMarker(dir, null);
+  writeWildcardMarker(dir, false);
+}
+
 async function stopProxy(store: RouteStore, proxyPort: number, _tls: boolean): Promise<void> {
   const pidPath = store.pidPath;
 
@@ -706,9 +711,7 @@ async function stopProxy(store: RouteStore, proxyPort: number, _tls: boolean): P
           } catch {
             // Port file may already be absent; non-fatal
           }
-          writeTlsMarker(store.dir, false);
-          writeTldFile(store.dir, DEFAULT_TLD);
-          writeLanMarker(store.dir, null);
+          resetProxyRuntimeMarkers(store.dir);
           console.log(colors.green(`Killed process ${pid}. Proxy stopped.`));
         } catch (err: unknown) {
           if (isErrnoException(err) && err.code === "EPERM") {
@@ -746,9 +749,7 @@ async function stopProxy(store: RouteStore, proxyPort: number, _tls: boolean): P
     if (isNaN(pid)) {
       console.error(colors.red("Corrupted PID file. Removing it."));
       fs.unlinkSync(pidPath);
-      writeTlsMarker(store.dir, false);
-      writeTldFile(store.dir, DEFAULT_TLD);
-      writeLanMarker(store.dir, null);
+      resetProxyRuntimeMarkers(store.dir);
       return;
     }
 
@@ -767,9 +768,7 @@ async function stopProxy(store: RouteStore, proxyPort: number, _tls: boolean): P
       } catch {
         // Port file may already be absent; non-fatal
       }
-      writeTlsMarker(store.dir, false);
-      writeTldFile(store.dir, DEFAULT_TLD);
-      writeLanMarker(store.dir, null);
+      resetProxyRuntimeMarkers(store.dir);
       return;
     }
 
@@ -784,9 +783,7 @@ async function stopProxy(store: RouteStore, proxyPort: number, _tls: boolean): P
       );
       console.log(colors.yellow("Removing stale PID file."));
       fs.unlinkSync(pidPath);
-      writeTlsMarker(store.dir, false);
-      writeTldFile(store.dir, DEFAULT_TLD);
-      writeLanMarker(store.dir, null);
+      resetProxyRuntimeMarkers(store.dir);
       return;
     }
 
@@ -797,9 +794,7 @@ async function stopProxy(store: RouteStore, proxyPort: number, _tls: boolean): P
     } catch {
       // Port file may already be removed; non-fatal
     }
-    writeTlsMarker(store.dir, false);
-    writeTldFile(store.dir, DEFAULT_TLD);
-    writeLanMarker(store.dir, null);
+    resetProxyRuntimeMarkers(store.dir);
     console.log(colors.green("Proxy stopped."));
   } catch (err: unknown) {
     if (isErrnoException(err) && err.code === "EPERM") {

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -997,7 +997,8 @@ async function runApp(
   autoInfo?: { nameSource: string; prefix?: string; prefixSource?: string },
   desiredPort?: number,
   lanMode = false,
-  lanIp?: string | null
+  lanIp?: string | null,
+  childEnv: Record<string, string> = {}
 ) {
   let store = initialStore;
   console.log(chalk.blue.bold(`\nportless\n`));
@@ -1290,12 +1291,10 @@ async function runApp(
   // Server Components) trust portless-proxied HTTPS services. Node.js does
   // not use the system trust store, so without this env var it rejects the
   // portless CA as "self-signed certificate in certificate chain".
-  // Respect any value the user already set. Note: we check process.env here
-  // rather than the constructed child env because the child env inherits from
-  // process.env via spread. If a future code path injects NODE_EXTRA_CA_CERTS
-  // into the child env independently, this guard would need updating.
+  // Respect any value the user already set, including child scoped assignments.
   const caEnv: Record<string, string> = {};
-  if (tls && !process.env.NODE_EXTRA_CA_CERTS) {
+  const childBaseEnv = { ...process.env, ...childEnv };
+  if (tls && !childBaseEnv.NODE_EXTRA_CA_CERTS) {
     const caPath = path.join(stateDir, "ca.pem");
     if (fs.existsSync(caPath)) {
       caEnv.NODE_EXTRA_CA_CERTS = caPath;
@@ -1315,6 +1314,7 @@ async function runApp(
   spawnCommand(commandArgs, {
     env: {
       ...process.env,
+      ...childEnv,
       PORT: port.toString(),
       ...(hostBind ? { HOST: hostBind } : {}),
       PORTLESS_URL: finalUrl,
@@ -1357,6 +1357,8 @@ interface ParsedRunArgs {
   appPort?: number;
   /** Override the inferred base name (from --name flag). */
   name?: string;
+  /** Environment assignments applied only to the child process. */
+  childEnv: Record<string, string>;
   /** The child command and its arguments, passed through untouched. */
   commandArgs: string[];
 }
@@ -1391,19 +1393,23 @@ function appPortFromEnv(): number | undefined {
 }
 
 /**
- * Hoist leading `VAR=val` tokens from a child command into the environment,
- * matching shell semantics: `portless myapp API_URL=x node server.js` behaves
- * like `API_URL=x portless myapp node server.js`. Without this the first
- * token would be executed as a program literally named `API_URL=x`.
+ * Pull leading `VAR=val` tokens out of a child command.
+ * Without this the first token would be executed as a program literally named
+ * `API_URL=x`. The assignments are kept out of process.env so they cannot
+ * configure portless itself before the child process starts.
  */
-function hoistEnvAssignments(commandArgs: string[]): string[] {
+function hoistEnvAssignments(commandArgs: string[]): {
+  commandArgs: string[];
+  childEnv: Record<string, string>;
+} {
   let i = 0;
+  const childEnv: Record<string, string> = {};
   while (i < commandArgs.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(commandArgs[i])) {
     const eq = commandArgs[i].indexOf("=");
-    process.env[commandArgs[i].slice(0, eq)] = commandArgs[i].slice(eq + 1);
+    childEnv[commandArgs[i].slice(0, eq)] = commandArgs[i].slice(eq + 1);
     i++;
   }
-  return commandArgs.slice(i);
+  return { commandArgs: commandArgs.slice(i), childEnv };
 }
 
 function applySharingFlag(flag: string): boolean {
@@ -1518,8 +1524,10 @@ ${colors.bold("Examples:")}
 
   // An explicit `--` means "pass everything through untouched" — skip env
   // assignment hoisting so the documented escape hatch stays literal.
-  const commandArgs = passthrough ? args.slice(i) : hoistEnvAssignments(args.slice(i));
-  return { force, appPort, name, commandArgs };
+  const parsedCommand = passthrough
+    ? { commandArgs: args.slice(i), childEnv: {} }
+    : hoistEnvAssignments(args.slice(i));
+  return { force, appPort, name, ...parsedCommand };
 }
 
 /**
@@ -1605,8 +1613,10 @@ function parseAppArgs(args: string[]): ParsedAppArgs {
 
   // An explicit `--` means "pass everything through untouched" — skip env
   // assignment hoisting so the documented escape hatch stays literal.
-  const commandArgs = passthrough ? args.slice(i) : hoistEnvAssignments(args.slice(i));
-  return { force, appPort, name, commandArgs };
+  const parsedCommand = passthrough
+    ? { commandArgs: args.slice(i), childEnv: {} }
+    : hoistEnvAssignments(args.slice(i));
+  return { force, appPort, name, ...parsedCommand };
 }
 
 // ---------------------------------------------------------------------------
@@ -3521,7 +3531,8 @@ async function handleRunMode(args: string[], globalScript?: string): Promise<voi
     { nameSource, prefix: worktree?.prefix, prefixSource: worktree?.source },
     parsed.appPort,
     lanMode,
-    lanIp
+    lanIp,
+    parsed.childEnv
   );
 }
 
@@ -3567,7 +3578,8 @@ async function handleNamedMode(args: string[]): Promise<void> {
     undefined,
     parsed.appPort,
     lanMode,
-    lanIp
+    lanIp,
+    parsed.childEnv
   );
 }
 
@@ -3684,12 +3696,12 @@ async function main() {
       process.env.PORTLESS === "false" ||
       process.env.PORTLESS === "skip";
     if (skipPortless) {
-      const { commandArgs } = parseAppArgs(args);
-      if (commandArgs.length === 0) {
+      const parsed = parseAppArgs(args);
+      if (parsed.commandArgs.length === 0) {
         console.error(colors.red("Error: No command provided."));
         process.exit(1);
       }
-      spawnCommand(commandArgs);
+      spawnCommand(parsed.commandArgs, { env: { ...process.env, ...parsed.childEnv } });
       return;
     }
     await handleNamedMode(args);
@@ -3724,7 +3736,7 @@ async function main() {
       console.error(colors.red("Error: No command provided."));
       process.exit(1);
     }
-    spawnCommand(commandArgs);
+    spawnCommand(commandArgs, { env: { ...process.env, ...parsed.childEnv } });
     return;
   }
 

--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -18,20 +18,23 @@ type AnyServer = http.Server | ProxyServer;
 
 function request(
   server: AnyServer,
-  options: { host?: string; path?: string; method?: string }
+  options: { host?: string; path?: string; method?: string; accept?: string | null }
 ): Promise<{ status: number; headers: http.IncomingHttpHeaders; body: string }> {
   return new Promise((resolve, reject) => {
     const addr = server.address();
     if (!addr || typeof addr === "string") {
       return reject(new Error("Server not listening"));
     }
+    // Default to a browser-style Accept header; pass accept: null for a
+    // non-browser client (curl, fetch) to exercise plain-text error responses.
+    const accept = options.accept === undefined ? "text/html" : options.accept;
     const req = http.request(
       {
         hostname: "127.0.0.1",
         port: addr.port,
         path: options.path || "/",
         method: options.method || "GET",
-        headers: { host: options.host || "" },
+        headers: { host: options.host || "", ...(accept === null ? {} : { accept }) },
       },
       (res) => {
         let body = "";
@@ -386,6 +389,57 @@ describe("createProxyServer", () => {
       expect(res.body).toContain("Bad Gateway");
       expect(errors.length).toBeGreaterThan(0);
       expect(errors[0]).toContain("dead.localhost");
+    });
+
+    it("returns plain-text 502 with the target port for non-browser clients", async () => {
+      const routes: RouteInfo[] = [{ hostname: "dead.localhost", port: 59999 }];
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => routes,
+          proxyPort: TEST_PROXY_PORT,
+          onError: () => {},
+        })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "dead.localhost", accept: null });
+      expect(res.status).toBe(502);
+      expect(res.headers["content-type"]).toContain("text/plain");
+      expect(res.body).toContain("127.0.0.1:59999");
+      expect(res.body).toContain("portless list");
+    });
+  });
+
+  describe("plain-text error pages for non-browser clients", () => {
+    it("returns plain-text 404 with routes and registration hint", async () => {
+      const routes: RouteInfo[] = [{ hostname: "myapp.localhost", port: 4001 }];
+      const server = trackServer(
+        createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "unknown.localhost", accept: null });
+      expect(res.status).toBe(404);
+      expect(res.headers["content-type"]).toContain("text/plain");
+      expect(res.body).toContain("no app registered for unknown.localhost");
+      expect(res.body).toContain("127.0.0.1:4001");
+      expect(res.body).toContain("portless unknown <command>");
+    });
+
+    it("still returns the HTML 404 page when the client accepts text/html", async () => {
+      const routes: RouteInfo[] = [];
+      const server = trackServer(
+        createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+      );
+      await listen(server);
+
+      const res = await request(server, {
+        host: "unknown.localhost",
+        accept: "text/html,application/xhtml+xml",
+      });
+      expect(res.status).toBe(404);
+      expect(res.headers["content-type"]).toContain("text/html");
+      expect(res.body).toContain("<!DOCTYPE html>");
     });
   });
 
@@ -742,6 +796,7 @@ describe("createProxyServer", () => {
             method: "GET",
             headers: {
               host: "app.test",
+              accept: "text/html",
               "x-portless-hops": "5",
             },
           },
@@ -997,20 +1052,21 @@ describe("createProxyServer with TLS (HTTP/2)", () => {
 
   function httpsRequest(
     server: AnyServer,
-    options: { host?: string; path?: string; method?: string }
+    options: { host?: string; path?: string; method?: string; accept?: string | null }
   ): Promise<{ status: number; headers: http.IncomingHttpHeaders; body: string }> {
     return new Promise((resolve, reject) => {
       const addr = server.address();
       if (!addr || typeof addr === "string") {
         return reject(new Error("Server not listening"));
       }
+      const accept = options.accept === undefined ? "text/html" : options.accept;
       const req = https.request(
         {
           hostname: "127.0.0.1",
           port: addr.port,
           path: options.path || "/",
           method: options.method || "GET",
-          headers: { host: options.host || "" },
+          headers: { host: options.host || "", ...(accept === null ? {} : { accept }) },
           rejectUnauthorized: false,
         },
         (res) => {

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -33,6 +33,18 @@ function getRequestHost(req: http.IncomingMessage): string {
 }
 
 /**
+ * Whether the client expects an HTML error page. Browsers send
+ * `Accept: text/html` on navigation; non-browser clients (curl, fetch,
+ * coding agents) do not and get a compact plain-text response instead of
+ * the styled HTML pages, which inline fonts and run to hundreds of
+ * kilobytes.
+ */
+function wantsHtml(req: http.IncomingMessage): boolean {
+  const accept = req.headers.accept;
+  return typeof accept === "string" && accept.includes("text/html");
+}
+
+/**
  * Detect whether a request arrived over an encrypted (TLS) connection.
  * Works for both native TLS sockets and HTTP/2 streams.
  */
@@ -140,6 +152,13 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
           `This usually means a backend is proxying back through portless without rewriting ` +
           `the Host header. If you use Vite/webpack proxy, set changeOrigin: true.`
       );
+      if (!wantsHtml(req)) {
+        res.writeHead(508, { "Content-Type": "text/plain" });
+        res.end(
+          `508 Loop Detected: this request has passed through portless ${hops} times. A dev server (Vite, webpack, etc.) is likely proxying back through portless without rewriting the Host header. Fix: set changeOrigin: true in your dev server proxy config.\n`
+        );
+        return;
+      }
       res.writeHead(508, { "Content-Type": "text/html" });
       res.end(
         renderPage(
@@ -159,9 +178,20 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
     const route = findRoute(routes, host, strict);
 
     if (!route) {
+      const strippedHostPlain = host.endsWith(tldSuffix) ? host.slice(0, -tldSuffix.length) : host;
+      if (!wantsHtml(req)) {
+        const routeLines =
+          routes.length > 0
+            ? `Active apps:\n${routes.map((r) => `  ${formatUrl(r.hostname, proxyPort, reqTls)} -> 127.0.0.1:${r.port}`).join("\n")}`
+            : "No apps running.";
+        res.writeHead(404, { "Content-Type": "text/plain" });
+        res.end(
+          `404 Not Found: no app registered for ${host}\n\n${routeLines}\n\nRegister this app: portless ${strippedHostPlain} <command>\n`
+        );
+        return;
+      }
       const safeHost = escapeHtml(host);
-      const strippedHost = host.endsWith(tldSuffix) ? host.slice(0, -tldSuffix.length) : host;
-      const safeSuggestion = escapeHtml(strippedHost);
+      const safeSuggestion = escapeHtml(strippedHostPlain);
       const routesList =
         routes.length > 0
           ? `<div class="section"><p class="label">Active apps</p><ul class="card">${routes.map((r) => `<li><a href="${escapeHtml(formatUrl(r.hostname, proxyPort, reqTls))}" class="card-link"><span class="name">${escapeHtml(r.hostname)}</span><span class="meta"><code class="port">127.0.0.1:${escapeHtml(String(r.port))}</code><span class="arrow">${ARROW_SVG}</span></span></a></li>`).join("")}</ul></div>`
@@ -235,6 +265,13 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
           errWithCode.code === "ECONNREFUSED"
             ? "The target app is not responding. It may have crashed."
             : "The target app may not be running.";
+        if (!wantsHtml(req)) {
+          res.writeHead(502, { "Content-Type": "text/plain" });
+          res.end(
+            `502 Bad Gateway: ${host} is routed to 127.0.0.1:${route.port}, but ${detail.charAt(0).toLowerCase()}${detail.slice(1)}\nInspect routes with: portless list\n`
+          );
+          return;
+        }
         res.writeHead(502, { "Content-Type": "text/html" });
         res.end(
           renderPage(

--- a/packages/portless/src/routes.ts
+++ b/packages/portless/src/routes.ts
@@ -38,6 +38,11 @@ type RouteMetadataPatch = {
   ngrokPid?: number | null;
 };
 
+function isRetryableLockError(err: unknown): boolean {
+  if (!isErrnoException(err)) return false;
+  return err.code === "EEXIST" || err.code === "EPERM" || err.code === "EACCES";
+}
+
 /** Runtime check that a parsed JSON value is a valid RouteMapping. */
 function isValidRoute(value: unknown): value is RouteMapping {
   return (
@@ -124,12 +129,14 @@ export class RouteStore {
         fs.mkdirSync(this.lockPath);
         return true;
       } catch (err: unknown) {
-        if (isErrnoException(err) && err.code === "EEXIST") {
+        if (isRetryableLockError(err)) {
           try {
-            const stat = fs.statSync(this.lockPath);
-            if (Date.now() - stat.mtimeMs > STALE_LOCK_THRESHOLD_MS) {
-              fs.rmSync(this.lockPath, { recursive: true });
-              continue;
+            if (fs.existsSync(this.lockPath)) {
+              const stat = fs.statSync(this.lockPath);
+              if (Date.now() - stat.mtimeMs > STALE_LOCK_THRESHOLD_MS) {
+                fs.rmSync(this.lockPath, { recursive: true, force: true });
+                continue;
+              }
             }
           } catch {
             continue;
@@ -147,7 +154,7 @@ export class RouteStore {
 
   private releaseLock(): void {
     try {
-      fs.rmSync(this.lockPath, { recursive: true });
+      fs.rmSync(this.lockPath, { recursive: true, force: true });
     } catch {
       // Lock may already be removed; non-fatal
     }

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -48,7 +48,7 @@ portless myapp next dev
 # -> https://myapp.localhost
 ```
 
-The proxy auto-starts when you run an app. You can also start it explicitly with `portless proxy start`. Auto-start reuses the configuration (port, TLS, TLD, wildcard mode) from the most recent proxy run, so a restart or reboot does not silently revert to defaults. Explicit env vars always take priority.
+The proxy auto-starts when you run an app. You can also start it explicitly with `portless proxy start`. Auto-start reuses the configuration (port, TLS, TLD) from the most recent proxy run, so a restart or reboot does not silently revert to defaults. Explicit env vars always take priority.
 
 In non-interactive environments (no TTY, or `CI=1`), portless exits with a descriptive error instead of prompting. Task runners like turborepo should pre-start the proxy.
 
@@ -209,7 +209,7 @@ portless proxy start --lan --ip 192.168.1.42
 
 `--lan` advertises `<name>.local` hostnames over mDNS so any device on the same Wi-Fi can reach your apps. Portless auto-detects your LAN IP and follows network changes automatically, but you can pin a specific address with `--ip <address>` or the `PORTLESS_LAN_IP` environment variable. Set `PORTLESS_LAN=1` to default to LAN mode every time the proxy starts.
 
-Portless remembers LAN mode via `proxy.lan`, so if you stop a LAN proxy and start again, it stays in LAN mode. All proxy settings (port, TLS, TLD, LAN, wildcard mode) are persisted and reused on auto-start unless overridden by explicit flags or env vars. Use `PORTLESS_LAN=0` for one start to switch back to `.localhost` mode. If a proxy is already running with different explicit LAN, TLS, TLD, or wildcard settings, portless warns and asks you to stop it first.
+Portless remembers LAN mode via `proxy.lan`, so if you stop a LAN proxy and start again, it stays in LAN mode. All proxy settings (port, TLS, TLD, LAN) are persisted and reused on auto-start unless overridden by explicit flags or env vars. Use `PORTLESS_LAN=0` for one start to switch back to `.localhost` mode. If a proxy is already running with different explicit LAN, TLS, TLD, or wildcard settings, portless warns and asks you to stop it first.
 
 LAN mode depends on the system mDNS helpers that portless launches: macOS includes `dns-sd`, while Linux uses `avahi-publish-address` from `avahi-utils` (install via `sudo apt install avahi-utils` or your distro’s tooling).
 

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -273,49 +273,50 @@ The chosen service configuration is written into launchd, systemd, or Task Sched
 
 ## CLI Reference
 
-| Command                                | Description                                                    |
-| -------------------------------------- | -------------------------------------------------------------- |
-| `portless`                             | Run dev script through proxy                                   |
-| `portless`                             | From monorepo root: run all workspace packages                 |
-| `portless --script <name>`             | Run a specific package.json script (default: dev)              |
-| `portless run [cmd] [args...]`         | Infer name from project, run through proxy (auto-starts)       |
-| `portless run --name <name> <cmd>`     | Override inferred base name (worktree prefix still applies)    |
-| `portless <name> <cmd> [args...]`      | Run app at `https://<name>.localhost` (auto-starts proxy)      |
-| `portless get <name>`                  | Print URL for a service (for cross-service wiring)             |
-| `portless get <name> --no-worktree`    | Print URL without worktree prefix                              |
-| `portless list`                        | Show active routes                                             |
-| `portless trust`                       | Add local CA to system trust store (for HTTPS)                 |
-| `portless clean`                       | Remove state, CA trust entry, and /etc/hosts block             |
-| `portless prune`                       | Kill orphaned dev servers from crashed sessions                |
-| `portless prune --force`               | Kill orphans with SIGKILL instead of SIGTERM                   |
-| `portless proxy start`                 | Start HTTPS proxy as a daemon (port 443, auto-elevates)        |
-| `portless proxy start --no-tls`        | Start without HTTPS (plain HTTP on port 80)                    |
-| `portless proxy start --lan`           | Start in LAN mode (mDNS `.local`, auto-follows LAN IP changes) |
-| `portless proxy start -p <number>`     | Start the proxy on a custom port                               |
-| `portless proxy start --tld test`      | Use .test instead of .localhost                                |
-| `portless proxy start --foreground`    | Start the proxy in foreground (for debugging)                  |
-| `portless proxy start --wildcard`      | Allow unregistered subdomains to fall back to parent route     |
-| `portless proxy stop`                  | Stop the proxy                                                 |
-| `portless service install`             | Start the HTTPS proxy when the OS starts                       |
-| `portless service install --lan`       | Start the service in LAN mode                                  |
-| `portless service install --wildcard`  | Persist wildcard routing in the startup service                |
-| `portless service status`              | Show service and proxy status                                  |
-| `portless service uninstall`           | Remove the startup service                                     |
-| `portless alias <name> <port>`         | Register a static route (e.g. for Docker containers)           |
-| `portless alias <name> <port> --force` | Overwrite an existing route                                    |
-| `portless alias --remove <name>`       | Remove a static route                                          |
-| `portless hosts sync`                  | Add routes to /etc/hosts (fixes Safari)                        |
-| `portless hosts clean`                 | Remove portless entries from /etc/hosts                        |
-| `portless <name> --app-port <n> <cmd>` | Use a fixed port for the app instead of auto-assignment        |
-| `portless <name> --tailscale <cmd>`    | Share the app on your Tailscale network (tailnet)              |
-| `portless <name> --funnel <cmd>`       | Share the app publicly via Tailscale Funnel                    |
-| `portless <name> --ngrok <cmd>`        | Share the app publicly via ngrok                               |
-| `portless <name> --force <cmd>`        | Kill the existing process and take over its route              |
-| `portless --name <name> <cmd>`         | Force `<name>` as app name (bypasses subcommand dispatch)      |
-| `portless <name> -- <cmd> [args...]`   | Stop flag parsing; everything after `--` is passed to child    |
-| `portless --help` / `-h`               | Show help                                                      |
-| `portless run --help`                  | Show help for a subcommand (also: alias, hosts, clean)         |
-| `portless --version` / `-v`            | Show version                                                   |
+| Command                                | Description                                                                 |
+| -------------------------------------- | --------------------------------------------------------------------------- |
+| `portless`                             | Run dev script through proxy                                                |
+| `portless`                             | From monorepo root: run all workspace packages                              |
+| `portless --script <name>`             | Run a specific package.json script (default: dev)                           |
+| `portless run [cmd] [args...]`         | Infer name from project, run through proxy (auto-starts)                    |
+| `portless run --name <name> <cmd>`     | Override inferred base name (worktree prefix still applies)                 |
+| `portless <name> <cmd> [args...]`      | Run app at `https://<name>.localhost` (auto-starts proxy)                   |
+| `portless <name> VAR=val <cmd>`        | Env assignments before the command are applied to the child                 |
+| `portless get <name>`                  | Print URL for a service (for cross-service wiring); `url` works as an alias |
+| `portless get <name> --no-worktree`    | Print URL without worktree prefix                                           |
+| `portless list`                        | Show active routes; `ls` and `status` work as aliases                       |
+| `portless trust`                       | Add local CA to system trust store (for HTTPS)                              |
+| `portless clean`                       | Remove state, CA trust entry, and /etc/hosts block                          |
+| `portless prune`                       | Kill orphaned dev servers from crashed sessions                             |
+| `portless prune --force`               | Kill orphans with SIGKILL instead of SIGTERM                                |
+| `portless proxy start`                 | Start HTTPS proxy as a daemon (port 443, auto-elevates)                     |
+| `portless proxy start --no-tls`        | Start without HTTPS (plain HTTP on port 80)                                 |
+| `portless proxy start --lan`           | Start in LAN mode (mDNS `.local`, auto-follows LAN IP changes)              |
+| `portless proxy start -p <number>`     | Start the proxy on a custom port                                            |
+| `portless proxy start --tld test`      | Use .test instead of .localhost                                             |
+| `portless proxy start --foreground`    | Start the proxy in foreground (for debugging)                               |
+| `portless proxy start --wildcard`      | Allow unregistered subdomains to fall back to parent route                  |
+| `portless proxy stop`                  | Stop the proxy                                                              |
+| `portless service install`             | Start the HTTPS proxy when the OS starts                                    |
+| `portless service install --lan`       | Start the service in LAN mode                                               |
+| `portless service install --wildcard`  | Persist wildcard routing in the startup service                             |
+| `portless service status`              | Show service and proxy status                                               |
+| `portless service uninstall`           | Remove the startup service                                                  |
+| `portless alias <name> <port>`         | Register a static route (e.g. for Docker containers)                        |
+| `portless alias <name> <port> --force` | Overwrite an existing route                                                 |
+| `portless alias --remove <name>`       | Remove a static route                                                       |
+| `portless hosts sync`                  | Add routes to /etc/hosts (fixes Safari)                                     |
+| `portless hosts clean`                 | Remove portless entries from /etc/hosts                                     |
+| `portless <name> --app-port <n> <cmd>` | Use a fixed port for the app instead of auto-assignment                     |
+| `portless <name> --tailscale <cmd>`    | Share the app on your Tailscale network (tailnet)                           |
+| `portless <name> --funnel <cmd>`       | Share the app publicly via Tailscale Funnel                                 |
+| `portless <name> --ngrok <cmd>`        | Share the app publicly via ngrok                                            |
+| `portless <name> --force <cmd>`        | Kill the existing process and take over its route                           |
+| `portless --name <name> <cmd>`         | Force `<name>` as app name (bypasses subcommand dispatch)                   |
+| `portless <name> -- <cmd> [args...]`   | Stop flag parsing; everything after `--` is passed to child                 |
+| `portless --help` / `-h`               | Show help                                                                   |
+| `portless run --help`                  | Show help for a subcommand (also: alias, hosts, clean)                      |
+| `portless --version` / `-v`            | Show version                                                                |
 
 **Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `trust`, `clean`, `prune`, `proxy`, and `service` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name, or `portless --name <name> <cmd>` to force any name including reserved ones.
 

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -48,7 +48,7 @@ portless myapp next dev
 # -> https://myapp.localhost
 ```
 
-The proxy auto-starts when you run an app. You can also start it explicitly with `portless proxy start`. Auto-start reuses the configuration (port, TLS, TLD) from the most recent proxy run, so a restart or reboot does not silently revert to defaults. Explicit env vars always take priority.
+The proxy auto-starts when you run an app. You can also start it explicitly with `portless proxy start`. Auto-start reuses the configuration (port, TLS, TLD, wildcard mode) from the most recent proxy run, so a restart or reboot does not silently revert to defaults. Explicit env vars always take priority.
 
 In non-interactive environments (no TTY, or `CI=1`), portless exits with a descriptive error instead of prompting. Task runners like turborepo should pre-start the proxy.
 
@@ -209,7 +209,7 @@ portless proxy start --lan --ip 192.168.1.42
 
 `--lan` advertises `<name>.local` hostnames over mDNS so any device on the same Wi-Fi can reach your apps. Portless auto-detects your LAN IP and follows network changes automatically, but you can pin a specific address with `--ip <address>` or the `PORTLESS_LAN_IP` environment variable. Set `PORTLESS_LAN=1` to default to LAN mode every time the proxy starts.
 
-Portless remembers LAN mode via `proxy.lan`, so if you stop a LAN proxy and start again, it stays in LAN mode. All proxy settings (port, TLS, TLD, LAN) are persisted and reused on auto-start unless overridden by explicit flags or env vars. Use `PORTLESS_LAN=0` for one start to switch back to `.localhost` mode. If a proxy is already running with different explicit LAN/TLS/TLD settings, portless warns and asks you to stop it first.
+Portless remembers LAN mode via `proxy.lan`, so if you stop a LAN proxy and start again, it stays in LAN mode. All proxy settings (port, TLS, TLD, LAN, wildcard mode) are persisted and reused on auto-start unless overridden by explicit flags or env vars. Use `PORTLESS_LAN=0` for one start to switch back to `.localhost` mode. If a proxy is already running with different explicit LAN, TLS, TLD, or wildcard settings, portless warns and asks you to stop it first.
 
 LAN mode depends on the system mDNS helpers that portless launches: macOS includes `dns-sd`, while Linux uses `avahi-publish-address` from `avahi-utils` (install via `sudo apt install avahi-utils` or your distro’s tooling).
 

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -318,6 +318,8 @@ The chosen service configuration is written into launchd, systemd, or Task Sched
 | `portless run --help`                  | Show help for a subcommand (also: alias, hosts, clean)                      |
 | `portless --version` / `-v`            | Show version                                                                |
 
+`portless url <name>` is a convenience alias for `portless get <name>`. If the single argument after `url` is an installed command, portless treats it as an app named `url` instead. Use `portless get <name>` when a service name also matches a command.
+
 **Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `trust`, `clean`, `prune`, `proxy`, and `service` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name, or `portless --name <name> <cmd>` to force any name including reserved ones.
 
 ## portless.json


### PR DESCRIPTION
- Serve compact plain-text 404/502/508 responses to non-browser clients (Accept negotiation); the 502 now names the routed port and the 404 lists active routes and the registration command
- Apply leading VAR=val tokens in a wrapped command to the child environment, matching shell semantics
- Accept url as an alias for get, and ls/status as aliases for list
- Detect a running proxy whose wildcard mode differs from the requested one and point --wildcard misuse on app commands at portless proxy start --wildcard