### PR TITLE
Support Laravel port injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ portless myapp next dev
 
 HTTPS with HTTP/2 is enabled by default. On first run, portless generates a local CA, trusts it, and binds port 443 (auto-elevates with sudo on macOS/Linux). Use `--no-tls` for plain HTTP.
 
-The proxy auto-starts when you run an app. A random port (4000 to 4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, VitePlus, Astro, React Router, Angular, Laravel (`php artisan serve`), Expo, React Native), portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag.
+The proxy auto-starts when you run an app. A random port (4000-4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, VitePlus, Astro, React Router, Angular, Laravel, Expo, React Native), portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag.
 
 When auto-starting, portless reuses the configuration (port, TLS, TLD) from the most recent proxy run, so a restart or reboot does not silently revert to defaults. Explicit env vars (`PORTLESS_PORT`, `PORTLESS_HTTPS`, etc.) always take priority.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ portless myapp next dev
 
 HTTPS with HTTP/2 is enabled by default. On first run, portless generates a local CA, trusts it, and binds port 443 (auto-elevates with sudo on macOS/Linux). Use `--no-tls` for plain HTTP.
 
-The proxy auto-starts when you run an app. A random port (4000-4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, VitePlus, Astro, React Router, Angular, Expo, React Native), portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag.
+The proxy auto-starts when you run an app. A random port (4000 to 4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, VitePlus, Astro, React Router, Angular, Laravel (`php artisan serve`), Expo, React Native), portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag.
 
 When auto-starting, portless reuses the configuration (port, TLS, TLD) from the most recent proxy run, so a restart or reboot does not silently revert to defaults. Explicit env vars (`PORTLESS_PORT`, `PORTLESS_HTTPS`, etc.) always take priority.
 

--- a/apps/docs/src/app/configuration/page.mdx
+++ b/apps/docs/src/app/configuration/page.mdx
@@ -261,4 +261,4 @@ Portless stores state (routes, PID file, port file, TLS marker) in `~/.portless`
 
 ## Port assignment
 
-Apps get a random port in the 4000--4999 range. Portless sets `PORT` and usually `HOST` before running your command. Most frameworks respect `PORT` automatically. For frameworks that ignore it (Vite, Astro, React Router, Angular, Expo, React Native), portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag.
+Apps get a random port in the 4000 to 4999 range. Portless sets `PORT` and usually `HOST` before running your command. Most frameworks respect `PORT` automatically. For frameworks that ignore it (Vite, Astro, React Router, Angular, Laravel (`php artisan serve`), Expo, React Native), portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag.

--- a/apps/docs/src/app/configuration/page.mdx
+++ b/apps/docs/src/app/configuration/page.mdx
@@ -261,4 +261,4 @@ Portless stores state (routes, PID file, port file, TLS marker) in `~/.portless`
 
 ## Port assignment
 
-Apps get a random port in the 4000 to 4999 range. Portless sets `PORT` and usually `HOST` before running your command. Most frameworks respect `PORT` automatically. For frameworks that ignore it (Vite, Astro, React Router, Angular, Laravel (`php artisan serve`), Expo, React Native), portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag.
+Apps get a random port in the 4000--4999 range. Portless sets `PORT` and usually `HOST` before running your command. Most frameworks respect `PORT` automatically. For frameworks that ignore it (Vite, Astro, React Router, Angular, Laravel, Expo, React Native), portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag.

--- a/apps/docs/src/app/page.mdx
+++ b/apps/docs/src/app/page.mdx
@@ -43,7 +43,7 @@ portless myapp next dev
 
 HTTPS with HTTP/2 is enabled by default. On first run, portless generates a local CA, trusts it, and binds port 443 (auto-elevates with sudo on macOS/Linux). Use `--no-tls` for plain HTTP.
 
-The proxy auto-starts when you run an app. A random port (4000 to 4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, Astro, React Router, Angular, Laravel (`php artisan serve`), Expo, React Native), portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag.
+The proxy auto-starts when you run an app. A random port (4000--4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, Astro, React Router, Angular, Laravel, Expo, React Native), portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag.
 
 ## Use in package.json
 

--- a/apps/docs/src/app/page.mdx
+++ b/apps/docs/src/app/page.mdx
@@ -43,7 +43,7 @@ portless myapp next dev
 
 HTTPS with HTTP/2 is enabled by default. On first run, portless generates a local CA, trusts it, and binds port 443 (auto-elevates with sudo on macOS/Linux). Use `--no-tls` for plain HTTP.
 
-The proxy auto-starts when you run an app. A random port (4000--4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, Astro, React Router, Angular, Expo, React Native), portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag.
+The proxy auto-starts when you run an app. A random port (4000 to 4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, Astro, React Router, Angular, Laravel (`php artisan serve`), Expo, React Native), portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag.
 
 ## Use in package.json
 

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -409,6 +409,12 @@ describe("injectFrameworkFlags", () => {
     expect(args).toEqual(["ng", "serve", "--port", "4567", "--host", "127.0.0.1"]);
   });
 
+  it("injects for laravel artisan serve without --strictPort", () => {
+    const args = ["php", "artisan", "serve"];
+    injectFrameworkFlags(args, 4567);
+    expect(args).toEqual(["php", "artisan", "serve", "--port", "4567", "--host", "127.0.0.1"]);
+  });
+
   it("injects for react-native without --strictPort", () => {
     const args = ["react-native", "start"];
     injectFrameworkFlags(args, 4567);

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -858,7 +858,7 @@ export function spawnCommand(
 // ---------------------------------------------------------------------------
 
 /**
- * Frameworks that ignore the `PORT` env var. Maps framework key to the
+ * Frameworks that ignore the `PORT` env var. Maps command basename to the
  * flags needed. `strictPort` indicates whether `--strictPort` is supported
  * (prevents the framework from silently picking a different port).
  *
@@ -887,10 +887,10 @@ const PACKAGE_RUNNERS: Record<string, string[]> = {
 };
 
 /**
- * Find the framework key inside `commandArgs`, looking
+ * Find the basename of the framework command inside `commandArgs`, looking
  * past known package runners (npx, bunx, yarn dlx, …) and their flags.
  */
-function findFrameworkKey(commandArgs: string[]): string | null {
+function findFrameworkBasename(commandArgs: string[]): string | null {
   if (commandArgs.length === 0) return null;
 
   const first = path.basename(commandArgs[0]);
@@ -947,10 +947,10 @@ function findFrameworkKey(commandArgs: string[]): string | null {
  * server local.
  */
 export function injectFrameworkFlags(commandArgs: string[], port: number): void {
-  const frameworkKey = findFrameworkKey(commandArgs);
-  if (!frameworkKey) return;
+  const basename = findFrameworkBasename(commandArgs);
+  if (!basename) return;
 
-  const framework = FRAMEWORKS_NEEDING_PORT[frameworkKey];
+  const framework = FRAMEWORKS_NEEDING_PORT[basename];
 
   if (!commandArgs.includes("--port")) {
     commandArgs.push("--port", port.toString());
@@ -962,9 +962,9 @@ export function injectFrameworkFlags(commandArgs: string[], port: number): void 
   if (!commandArgs.includes("--host")) {
     // In LAN mode, let Expo use its default (LAN) — injecting --host alongside
     // HOST=127.0.0.1 causes Metro's HMR WebSocket to break after a few reloads.
-    const isExpoLan = frameworkKey === "expo" && isLanEnvEnabled();
+    const isExpoLan = basename === "expo" && isLanEnvEnabled();
     if (isExpoLan) return;
-    const hostValue = frameworkKey === "expo" ? "localhost" : "127.0.0.1";
+    const hostValue = basename === "expo" ? "localhost" : "127.0.0.1";
     commandArgs.push("--host", hostValue);
   }
 }

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -858,7 +858,7 @@ export function spawnCommand(
 // ---------------------------------------------------------------------------
 
 /**
- * Frameworks that ignore the `PORT` env var. Maps command basename to the
+ * Frameworks that ignore the `PORT` env var. Maps framework key to the
  * flags needed. `strictPort` indicates whether `--strictPort` is supported
  * (prevents the framework from silently picking a different port).
  *
@@ -872,6 +872,7 @@ const FRAMEWORKS_NEEDING_PORT: Record<string, { strictPort: boolean }> = {
   rsbuild: { strictPort: false },
   astro: { strictPort: false },
   ng: { strictPort: false },
+  "laravel-artisan": { strictPort: false },
   "react-native": { strictPort: false },
   expo: { strictPort: false },
 };
@@ -886,13 +887,21 @@ const PACKAGE_RUNNERS: Record<string, string[]> = {
 };
 
 /**
- * Find the basename of the framework command inside `commandArgs`, looking
+ * Find the framework key inside `commandArgs`, looking
  * past known package runners (npx, bunx, yarn dlx, …) and their flags.
  */
-function findFrameworkBasename(commandArgs: string[]): string | null {
+function findFrameworkKey(commandArgs: string[]): string | null {
   if (commandArgs.length === 0) return null;
 
   const first = path.basename(commandArgs[0]);
+  if (
+    first === "php" &&
+    path.basename(commandArgs[1] ?? "") === "artisan" &&
+    commandArgs[2] === "serve"
+  ) {
+    return "laravel-artisan";
+  }
+
   if (FRAMEWORKS_NEEDING_PORT[first]) return first;
 
   const subcommands = PACKAGE_RUNNERS[first];
@@ -938,10 +947,10 @@ function findFrameworkBasename(commandArgs: string[]): string | null {
  * server local.
  */
 export function injectFrameworkFlags(commandArgs: string[], port: number): void {
-  const basename = findFrameworkBasename(commandArgs);
-  if (!basename) return;
+  const frameworkKey = findFrameworkKey(commandArgs);
+  if (!frameworkKey) return;
 
-  const framework = FRAMEWORKS_NEEDING_PORT[basename];
+  const framework = FRAMEWORKS_NEEDING_PORT[frameworkKey];
 
   if (!commandArgs.includes("--port")) {
     commandArgs.push("--port", port.toString());
@@ -953,9 +962,9 @@ export function injectFrameworkFlags(commandArgs: string[], port: number): void 
   if (!commandArgs.includes("--host")) {
     // In LAN mode, let Expo use its default (LAN) — injecting --host alongside
     // HOST=127.0.0.1 causes Metro's HMR WebSocket to break after a few reloads.
-    const isExpoLan = basename === "expo" && isLanEnvEnabled();
+    const isExpoLan = frameworkKey === "expo" && isLanEnvEnabled();
     if (isExpoLan) return;
-    const hostValue = basename === "expo" ? "localhost" : "127.0.0.1";
+    const hostValue = frameworkKey === "expo" ? "localhost" : "127.0.0.1";
     commandArgs.push("--host", hostValue);
   }
 }

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1626,7 +1626,7 @@ ${colors.bold("How it works:")}
   3. Access via https://<name>.localhost
   4. .localhost domains auto-resolve to 127.0.0.1
   5. Frameworks that ignore PORT (Vite, VitePlus, Astro, React Router, Angular,
-     Laravel artisan serve, Expo, React Native) get --port and, when needed, --host flags
+     Laravel, Expo, React Native) get --port and, when needed, --host flags
      injected automatically
 
 ${colors.bold("HTTP/2 + HTTPS (default):")}

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1626,7 +1626,7 @@ ${colors.bold("How it works:")}
   3. Access via https://<name>.localhost
   4. .localhost domains auto-resolve to 127.0.0.1
   5. Frameworks that ignore PORT (Vite, VitePlus, Astro, React Router, Angular,
-     Expo, React Native) get --port and, when needed, --host flags
+     Laravel artisan serve, Expo, React Native) get --port and, when needed, --host flags
      injected automatically
 
 ${colors.bold("HTTP/2 + HTTPS (default):")}

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -163,7 +163,7 @@ PORTLESS=0 pnpm dev   # Bypasses proxy, uses default port
 
 `.localhost` domains resolve to `127.0.0.1` natively in Chrome, Firefox, and Edge. Safari relies on the system DNS resolver, which may not handle `.localhost` subdomains on all configurations. Run `portless hosts sync` to add entries to `/etc/hosts` if needed.
 
-Most frameworks (Next.js, Express, Nuxt, etc.) respect the `PORT` env var automatically. For frameworks that ignore `PORT` (Vite, VitePlus, Astro, React Router, Angular, Expo, React Native), portless auto-injects the correct `--port` flag and, when needed, a matching `--host` CLI flag.
+Most frameworks (Next.js, Express, Nuxt, etc.) respect the `PORT` env var automatically. For frameworks that ignore `PORT` (Vite, VitePlus, Astro, React Router, Angular, Laravel (`php artisan serve`), Expo, React Native), portless auto-injects the correct `--port` flag and, when needed, a matching `--host` CLI flag.
 
 ### State directory
 
@@ -370,7 +370,7 @@ portless proxy start -p 8080
 
 ### Framework not respecting PORT
 
-Portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag for frameworks that ignore the `PORT` env var: **Vite**, **VitePlus** (`vp`), **Astro**, **React Router**, **Angular**, **Expo**, and **React Native**. SvelteKit uses Vite internally and is handled automatically.
+Portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag for frameworks that ignore the `PORT` env var: **Vite**, **VitePlus** (`vp`), **Astro**, **React Router**, **Angular**, **Laravel** (`php artisan serve`), **Expo**, and **React Native**. SvelteKit uses Vite internally and is handled automatically.
 
 For other frameworks that don't read `PORT`, pass the port manually:
 

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -163,7 +163,7 @@ PORTLESS=0 pnpm dev   # Bypasses proxy, uses default port
 
 `.localhost` domains resolve to `127.0.0.1` natively in Chrome, Firefox, and Edge. Safari relies on the system DNS resolver, which may not handle `.localhost` subdomains on all configurations. Run `portless hosts sync` to add entries to `/etc/hosts` if needed.
 
-Most frameworks (Next.js, Express, Nuxt, etc.) respect the `PORT` env var automatically. For frameworks that ignore `PORT` (Vite, VitePlus, Astro, React Router, Angular, Laravel (`php artisan serve`), Expo, React Native), portless auto-injects the correct `--port` flag and, when needed, a matching `--host` CLI flag.
+Most frameworks (Next.js, Express, Nuxt, etc.) respect the `PORT` env var automatically. For frameworks that ignore `PORT` (Vite, VitePlus, Astro, React Router, Angular, Laravel, Expo, React Native), portless auto-injects the correct `--port` flag and, when needed, a matching `--host` CLI flag.
 
 ### State directory
 
@@ -370,7 +370,7 @@ portless proxy start -p 8080
 
 ### Framework not respecting PORT
 
-Portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag for frameworks that ignore the `PORT` env var: **Vite**, **VitePlus** (`vp`), **Astro**, **React Router**, **Angular**, **Laravel** (`php artisan serve`), **Expo**, and **React Native**. SvelteKit uses Vite internally and is handled automatically.
+Portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag for frameworks that ignore the `PORT` env var: **Vite**, **VitePlus** (`vp`), **Astro**, **React Router**, **Angular**, **Laravel**, **Expo**, and **React Native**. SvelteKit uses Vite internally and is handled automatically.
 
 For other frameworks that don't read `PORT`, pass the port manually:
 


### PR DESCRIPTION
## Summary

- Detect Laravel as a framework that ignores `PORT`.
- Inject `--port <assigned-port>` and `--host 127.0.0.1` for Laravel dev server commands.
- Document Laravel support in README, docs pages, the portless skill, and CLI help output.

## Validation

- `pnpm exec vitest run src/cli-utils.test.ts -t injectFrameworkFlags`
- `pnpm type-check`
- `pnpm exec prettier --check ../../README.md ../../skills/portless/SKILL.md ../../apps/docs/src/app/configuration/page.mdx ../../apps/docs/src/app/page.mdx src/cli-utils.ts src/cli-utils.test.ts src/cli.ts`
- `pnpm build`
- `pnpm --filter @portless/docs build`
- `node packages/portless/dist/cli.js --help | rg -n 'Frameworks that ignore PORT|Laravel'`

## Note

`pnpm exec vitest run src/cli-utils.test.ts` still has one unrelated local failure in the LAN marker test because `127.0.0.1:1355` is listening in this environment, so `discoverState()` treats the marker as active and returns the LAN IP.
