### PR TITLE
Support for custom Ngrok URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Expose your dev server to the public internet with [ngrok](https://ngrok.com):
 ```bash
 portless myapp --ngrok next dev
 # -> https://myapp.localhost           (local)
-# -> https://random-name.ngrok.app     (public)
+# -> https://<random-name>.ngrok.app     (public)
 ```
 
 Pass a reserved URL to `--ngrok` to keep a stable address across restarts:
@@ -404,7 +404,7 @@ portless service uninstall       # Remove the startup service
 --app-port <number>              Use a fixed port for the app (skip auto-assignment)
 --tailscale                      Share the app on your Tailscale network (tailnet)
 --funnel                         Share the app publicly via Tailscale Funnel
---ngrok <url>                    Share publicly via ngrok (random URL, or a fixed one if given)
+--ngrok <url>                    Share the app publicly via ngrok (random URL, or a fixed one if given)
 --force                          Kill the existing process and take over its route
 --name <name>                    Use <name> as the app name
 ```

--- a/README.md
+++ b/README.md
@@ -330,10 +330,22 @@ Expose your dev server to the public internet with [ngrok](https://ngrok.com):
 ```bash
 portless myapp --ngrok next dev
 # -> https://myapp.localhost           (local)
-# -> https://abc123.ngrok.app          (public)
+# -> https://random-name.ngrok.app     (public)
 ```
 
-Set `PORTLESS_NGROK=1` in your shell profile or `.env` to enable ngrok by default when portless runs an app. `portless list` shows both local and ngrok URLs. The ngrok tunnel is cleaned up automatically when the app exits.
+Pass a reserved URL to `--ngrok` to keep a stable address across restarts:
+
+```bash
+portless myapp --ngrok=my-app.ngrok.dev next dev
+# -> https://myapp.localhost           (local)
+# -> https://my-app.ngrok.dev          (public, fixed)
+```
+
+The `--ngrok=<url>` form may omit the scheme (`my-app.ngrok.dev` becomes `https://my-app.ngrok.dev`). With a space-separated value, include the scheme: `--ngrok https://my-app.ngrok.dev`.
+
+The URL must be a domain you have reserved in your ngrok account.
+
+Set `PORTLESS_NGROK=1` in your shell profile or `.env` to enable ngrok by default when portless runs an app, or `PORTLESS_NGROK=my-app.ngrok.dev` to also pin the URL. `portless list` shows both local and ngrok URLs. The ngrok tunnel is cleaned up automatically when the app exits.
 
 Requires the ngrok CLI to be installed and authenticated. If ngrok reports an authentication error, run `ngrok config add-authtoken <token>` and try again.
 
@@ -392,7 +404,7 @@ portless service uninstall       # Remove the startup service
 --app-port <number>              Use a fixed port for the app (skip auto-assignment)
 --tailscale                      Share the app on your Tailscale network (tailnet)
 --funnel                         Share the app publicly via Tailscale Funnel
---ngrok                          Share the app publicly via ngrok
+--ngrok <url>                    Share publicly via ngrok (random URL, or a fixed one if given)
 --force                          Kill the existing process and take over its route
 --name <name>                    Use <name> as the app name
 ```
@@ -411,7 +423,7 @@ PORTLESS_WILDCARD=1              Allow unregistered subdomains to fall back to p
 PORTLESS_SYNC_HOSTS=0            Disable auto-sync of /etc/hosts (on by default)
 PORTLESS_TAILSCALE=1             Share apps on your Tailscale network (same as --tailscale)
 PORTLESS_FUNNEL=1                Share apps publicly via Tailscale Funnel (same as --funnel)
-PORTLESS_NGROK=1                 Share apps publicly via ngrok (same as --ngrok)
+PORTLESS_NGROK=1|<url>           Share apps publicly via ngrok; a URL pins a fixed tunnel (same as --ngrok)
 PORTLESS_STATE_DIR=<path>        Override the state directory
 
 # Injected into child processes

--- a/apps/docs/src/app/commands/page.mdx
+++ b/apps/docs/src/app/commands/page.mdx
@@ -72,6 +72,10 @@ portless docs.myapp next dev
       <td>`--ngrok`</td>
       <td>Share the app publicly via ngrok.</td>
     </tr>
+    <tr>
+      <td>`--ngrok=<url>`</td>
+      <td>Share via ngrok on a fixed URL (e.g. `my-app.ngrok.dev`).</td>
+    </tr>
   </tbody>
 </table>
 
@@ -79,6 +83,7 @@ portless docs.myapp next dev
 portless myapp --tailscale next dev
 portless myapp --funnel next dev
 portless myapp --ngrok next dev
+portless myapp --ngrok=my-app.ngrok.dev next dev
 ```
 
 ## Get a service URL

--- a/apps/docs/src/app/configuration/page.mdx
+++ b/apps/docs/src/app/configuration/page.mdx
@@ -207,7 +207,10 @@ For `appPort`: CLI `--app-port` flag > `PORTLESS_APP_PORT` env var > `package.js
     </tr>
     <tr>
       <td>`PORTLESS_NGROK`</td>
-      <td>Set to `1` to share apps publicly via ngrok</td>
+      <td>
+        Set to `1` to share apps publicly via ngrok, or to a URL to pin a fixed tunnel (e.g.
+        `my-app.ngrok.dev`)
+      </td>
       <td>off</td>
     </tr>
     <tr>

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -1472,5 +1472,65 @@ describe("CLI", () => {
         fs.rmSync(tmpDir, { recursive: true, force: true });
       }
     });
+
+    it("shows the optional ngrok URL in help output", () => {
+      const { status, stdout } = run(["--help"]);
+      expect(status).toBe(0);
+      expect(stdout).toContain("--ngrok <url>");
+    });
+
+    it("enables ngrok when --ngrok <url> is passed (space-separated)", () => {
+      const { status, stderr } = run(
+        ["myapp", "--ngrok", "https://my-app.ngrok.dev", "echo", "hello"],
+        { env: { PATH: "/tmp/portless-no-ngrok-path" } }
+      );
+      expect(status).toBe(1);
+      expect(stderr).toContain("ngrok CLI not found");
+    });
+
+    it("still accepts the --ngrok=<url> form", () => {
+      const { status, stderr } = run(
+        ["myapp", "--ngrok=https://my-app.ngrok.dev", "echo", "hello"],
+        { env: { PATH: "/tmp/portless-no-ngrok-path" } }
+      );
+      expect(status).toBe(1);
+      expect(stderr).toContain("ngrok CLI not found");
+    });
+
+    it("accepts a scheme-less URL via the --ngrok=<url> form", () => {
+      const { status, stderr } = run(["myapp", "--ngrok=my-app.ngrok.dev", "echo", "hello"], {
+        env: { PATH: "/tmp/portless-no-ngrok-path" },
+      });
+      expect(status).toBe(1);
+      expect(stderr).toContain("ngrok CLI not found");
+    });
+
+    it("treats a non-URL token after --ngrok as the command, not the URL", () => {
+      // `next` is not a URL, so --ngrok stays bare and `next dev` is the command.
+      const { status, stderr } = run(["myapp", "--ngrok", "next", "dev"], {
+        env: { PATH: "/tmp/portless-no-ngrok-path" },
+      });
+      expect(status).toBe(1);
+      expect(stderr).toContain("ngrok CLI not found");
+    });
+
+    it("enables ngrok when PORTLESS_NGROK is set to a URL", () => {
+      const { status, stderr } = run(["myapp", "echo", "hello"], {
+        env: {
+          PORTLESS_NGROK: "https://my-app.ngrok.dev",
+          PATH: "/tmp/portless-no-ngrok-path",
+        },
+      });
+      expect(status).toBe(1);
+      expect(stderr).toContain("ngrok CLI not found");
+    });
+
+    it("rejects --ngrok= with an empty URL", () => {
+      const { status, stderr } = run(["myapp", "--ngrok=", "echo", "hello"], {
+        env: { PATH: "/tmp/portless-no-ngrok-path" },
+      });
+      expect(status).toBe(1);
+      expect(stderr).toContain("--ngrok");
+    });
   });
 });

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -1476,7 +1476,7 @@ describe("CLI", () => {
     it("shows the optional ngrok URL in help output", () => {
       const { status, stdout } = run(["--help"]);
       expect(status).toBe(0);
-      expect(stdout).toContain("--ngrok <url>");
+      expect(stdout).toContain("--ngrok [<url>]");
     });
 
     it("enables ngrok when --ngrok <url> is passed (space-separated)", () => {

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -21,7 +21,13 @@ import {
   registerServe,
   unregisterTailscale,
 } from "./tailscale.js";
-import { ensureNgrokAvailable, startNgrok, stopNgrok, stopNgrokProcess } from "./ngrok.js";
+import {
+  ensureNgrokAvailable,
+  normalizeNgrokUrl,
+  startNgrok,
+  stopNgrok,
+  stopNgrokProcess,
+} from "./ngrok.js";
 import {
   inferProjectName,
   detectWorktreePrefix,
@@ -997,7 +1003,11 @@ async function runApp(
   // No point starting the proxy if tailscale will fail afterward.
   const wantsFunnel = isEnabledEnv(process.env.PORTLESS_FUNNEL);
   const wantsTailscale = wantsFunnel || isEnabledEnv(process.env.PORTLESS_TAILSCALE);
-  const wantsNgrok = isEnabledEnv(process.env.PORTLESS_NGROK);
+  // PORTLESS_NGROK is a boolean (0/1, true/false) or a fixed URL to pin the tunnel.
+  const ngrokValue = (process.env.PORTLESS_NGROK?.trim() ?? "").toLowerCase();
+  const wantsNgrok = ngrokValue !== "" && ngrokValue !== "0" && ngrokValue !== "false";
+  let ngrokUrl =
+    wantsNgrok && !isEnabledEnv(ngrokValue) ? normalizeNgrokUrl(ngrokValue) : undefined;
   let tsBaseUrl: string | undefined;
 
   if (wantsTailscale) {
@@ -1133,7 +1143,6 @@ async function runApp(
   // Readiness was already checked at the top of runApp().
   let tailscaleHttpsPort: number | undefined;
   let tailscaleUrl: string | undefined;
-  let ngrokUrl: string | undefined;
   let ngrokProcess: Awaited<ReturnType<typeof startNgrok>> | undefined;
   let stoppingNgrok = false;
   let ngrokRouteReady = false;
@@ -1213,6 +1222,7 @@ async function runApp(
     try {
       ngrokProcess = await startNgrok(port, {
         hostHeader: hostname,
+        url: ngrokUrl,
         onExit: handleNgrokExit,
       });
       ngrokUrl = ngrokProcess.url;
@@ -1431,7 +1441,7 @@ ${colors.bold("Options:")}
   --app-port <number>    Use a fixed port for the app (skip auto-assignment)
   --tailscale            Share the app on your Tailscale network (tailnet)
   --funnel               Share the app publicly via Tailscale Funnel
-  --ngrok                Share the app publicly via ngrok
+  --ngrok <url>          Share the app publicly via ngrok (random URL, or a fixed one if given)
   --help, -h             Show this help
 
 ${colors.bold("Name inference (in order):")}
@@ -1600,6 +1610,7 @@ ${colors.bold("Examples:")}
   portless myapp --tailscale next dev # -> also https://<node>.ts.net (tailnet)
   portless myapp --funnel next dev    # -> also https://<node>.ts.net (public)
   portless myapp --ngrok next dev     # -> also https://<random>.ngrok.app (public)
+  portless myapp --ngrok=my-app.ngrok.dev next dev # -> also https://my-app.ngrok.dev (public)
 
 ${colors.bold("Configuration (portless.json):")}
   Optional. Portless works out of the box by running the "dev" script
@@ -1665,6 +1676,10 @@ ${colors.bold("ngrok sharing:")}
   Use --ngrok to expose your dev server to the public internet with ngrok.
   Requires the ngrok CLI to be installed and authenticated.
   ${colors.cyan("portless myapp --ngrok next dev")}
+  Pass a URL to --ngrok to bind a fixed (reserved) ngrok URL instead of a random one.
+  The --ngrok=<url> form may omit the scheme; a space-separated URL must include it.
+  ${colors.cyan("portless myapp --ngrok=my-app.ngrok.dev next dev")}
+  ${colors.cyan("portless myapp --ngrok https://my-app.ngrok.dev next dev")}
 
 ${colors.bold("Options:")}
   run [--name <name>] <cmd>      Infer project name (or override with --name)
@@ -1685,7 +1700,7 @@ ${colors.bold("Options:")}
   --app-port <number>           Use a fixed port for the app (skip auto-assignment)
   --tailscale                   Share the app on your Tailscale network (tailnet)
   --funnel                      Share the app publicly via Tailscale Funnel
-  --ngrok                       Share the app publicly via ngrok
+  --ngrok <url>                 Share publicly via ngrok (random URL, or a fixed one if given)
   --force                       Kill the existing process and take over its route
   --name <name>                 Use <name> as the app name (bypasses subcommand dispatch)
   --                            Stop flag parsing; everything after is passed to the child
@@ -1701,7 +1716,7 @@ ${colors.bold("Environment variables:")}
   PORTLESS_SYNC_HOSTS=0         Disable auto-sync of ${HOSTS_DISPLAY} (on by default)
   PORTLESS_TAILSCALE=1          Share apps on your Tailscale network (same as --tailscale)
   PORTLESS_FUNNEL=1             Share apps publicly via Tailscale Funnel (same as --funnel)
-  PORTLESS_NGROK=1              Share apps publicly via ngrok (same as --ngrok)
+  PORTLESS_NGROK=1|<url>        Share apps publicly via ngrok; a URL pins a fixed tunnel (same as --ngrok)
   PORTLESS_STATE_DIR=<path>     Override the state directory
   PORTLESS=0                    Run command directly without proxy
 
@@ -3590,8 +3605,40 @@ async function main() {
     process.env.PORTLESS_FUNNEL = "1";
     process.env.PORTLESS_TAILSCALE = "1";
   }
-  if (stripGlobalFlag("--ngrok", false)) {
-    process.env.PORTLESS_NGROK = "1";
+  // --ngrok enables ngrok sharing; an optional URL pins the tunnel. It may be
+  // attached (--ngrok=<url>) or space-separated (--ngrok <url>); a space-separated
+  // value is only consumed when it is an http(s) URL, so `--ngrok next dev` keeps
+  // `next dev` as the child command.
+  {
+    const sep = args.indexOf("--");
+    const end = sep === -1 ? args.length : sep;
+    for (let i = 0; i < end; i++) {
+      const arg = args[i];
+      if (arg !== "--ngrok" && !arg.startsWith("--ngrok=")) continue;
+
+      let url: string | undefined;
+      if (arg.startsWith("--ngrok=")) {
+        url = arg.slice("--ngrok=".length);
+        args.splice(i, 1);
+      } else if (i + 1 < end && /^https?:\/\//i.test(args[i + 1])) {
+        url = args[i + 1];
+        args.splice(i, 2);
+      } else {
+        args.splice(i, 1);
+      }
+
+      if (url === undefined) {
+        process.env.PORTLESS_NGROK = "1";
+      } else if (url.trim() === "") {
+        console.error(
+          colors.red("Error: --ngrok requires a URL (e.g. --ngrok https://my-app.ngrok.dev).")
+        );
+        process.exit(1);
+      } else {
+        process.env.PORTLESS_NGROK = url.trim();
+      }
+      break;
+    }
   }
 
   // --script flag: override the default "dev" script for zero-arg mode.

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -3605,10 +3605,7 @@ async function main() {
     process.env.PORTLESS_FUNNEL = "1";
     process.env.PORTLESS_TAILSCALE = "1";
   }
-  // --ngrok enables ngrok sharing; an optional URL pins the tunnel. It may be
-  // attached (--ngrok=<url>) or space-separated (--ngrok <url>); a space-separated
-  // value is only consumed when it is an http(s) URL, so `--ngrok next dev` keeps
-  // `next dev` as the child command.
+
   {
     const sep = args.indexOf("--");
     const end = sep === -1 ? args.length : sep;

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1441,7 +1441,7 @@ ${colors.bold("Options:")}
   --app-port <number>    Use a fixed port for the app (skip auto-assignment)
   --tailscale            Share the app on your Tailscale network (tailnet)
   --funnel               Share the app publicly via Tailscale Funnel
-  --ngrok <url>          Share the app publicly via ngrok (random URL, or a fixed one if given)
+  --ngrok [<url>]        Share the app publicly via ngrok (random URL, or a fixed one if given)
   --help, -h             Show this help
 
 ${colors.bold("Name inference (in order):")}
@@ -1700,7 +1700,7 @@ ${colors.bold("Options:")}
   --app-port <number>           Use a fixed port for the app (skip auto-assignment)
   --tailscale                   Share the app on your Tailscale network (tailnet)
   --funnel                      Share the app publicly via Tailscale Funnel
-  --ngrok <url>                 Share publicly via ngrok (random URL, or a fixed one if given)
+  --ngrok [<url>]               Share publicly via ngrok (random URL, or a fixed one if given)
   --force                       Kill the existing process and take over its route
   --name <name>                 Use <name> as the app name (bypasses subcommand dispatch)
   --                            Stop flag parsing; everything after is passed to the child

--- a/packages/portless/src/ngrok.test.ts
+++ b/packages/portless/src/ngrok.test.ts
@@ -5,6 +5,7 @@ import {
   buildNgrokArgs,
   ensureNgrokAvailable,
   extractNgrokUrl,
+  normalizeNgrokUrl,
   startNgrok,
   stopNgrokProcess,
   type NgrokCommandRunner,
@@ -87,6 +88,36 @@ describe("ngrok", () => {
         "http://127.0.0.1:4123",
       ]);
     });
+
+    it("binds a fixed public URL when one is requested", () => {
+      expect(buildNgrokArgs(4123, "myapp.localhost", "https://my-app.ngrok.dev")).toEqual([
+        "http",
+        "--log=stdout",
+        "--log-format=logfmt",
+        "--host-header=myapp.localhost",
+        "--url=https://my-app.ngrok.dev",
+        "http://127.0.0.1:4123",
+      ]);
+    });
+
+    it("omits the --url flag when no URL is requested", () => {
+      expect(buildNgrokArgs(4123)).not.toContain("--url=");
+      expect(buildNgrokArgs(4123).some((arg) => arg.startsWith("--url"))).toBe(false);
+    });
+  });
+
+  describe("normalizeNgrokUrl", () => {
+    it("prefixes https:// when the value has no scheme", () => {
+      expect(normalizeNgrokUrl("my-app.ngrok.dev")).toBe("https://my-app.ngrok.dev");
+      // A port is not a scheme, so host:port is still promoted.
+      expect(normalizeNgrokUrl("my-app.ngrok.dev:8443")).toBe("https://my-app.ngrok.dev:8443");
+    });
+
+    it("keeps an existing scheme rather than double-prefixing https://", () => {
+      expect(normalizeNgrokUrl("https://my-app.ngrok.dev")).toBe("https://my-app.ngrok.dev");
+      // An explicit http:// is preserved, not forced to https.
+      expect(normalizeNgrokUrl("http://my-app.ngrok.dev")).toBe("http://my-app.ngrok.dev");
+    });
   });
 
   describe("extractNgrokUrl", () => {
@@ -131,6 +162,21 @@ describe("ngrok", () => {
           "http://127.0.0.1:4123",
         ],
       ]);
+    });
+
+    it("forwards a requested fixed URL to ngrok", async () => {
+      const child = new MockNgrokChild();
+      const calls: string[][] = [];
+      const promise = startNgrok(4123, {
+        url: "https://my-app.ngrok.dev",
+        spawner: createSpawner(child, calls),
+        timeoutMs: 1000,
+      });
+
+      child.stdout.write("Forwarding https://my-app.ngrok.dev -> http://127.0.0.1:4123\n");
+
+      await expect(promise).resolves.toMatchObject({ url: "https://my-app.ngrok.dev" });
+      expect(calls[0]).toContain("--url=https://my-app.ngrok.dev");
     });
 
     it("notifies when ngrok exits after startup", async () => {

--- a/packages/portless/src/ngrok.ts
+++ b/packages/portless/src/ngrok.ts
@@ -27,6 +27,7 @@ export type NgrokCommandRunner = (args: string[]) => NgrokCommandResult;
 
 export interface StartNgrokOptions {
   hostHeader?: string;
+  url?: string;
   onExit?: (code: number | null, signal: NodeJS.Signals | null) => void;
   spawner?: NgrokSpawner;
   timeoutMs?: number;
@@ -132,12 +133,17 @@ export function extractNgrokUrl(output: string): string | null {
   return null;
 }
 
-export function buildNgrokArgs(localPort: number, hostHeader = "rewrite"): string[] {
+export function normalizeNgrokUrl(url: string): string {
+  return /^[a-z][a-z0-9+.-]*:\/\//i.test(url) ? url : `https://${url}`;
+}
+
+export function buildNgrokArgs(localPort: number, hostHeader = "rewrite", url?: string): string[] {
   return [
     "http",
     "--log=stdout",
     "--log-format=logfmt",
     `--host-header=${hostHeader}`,
+    ...(url ? [`--url=${url}`] : []),
     `http://127.0.0.1:${localPort}`,
   ];
 }
@@ -148,7 +154,7 @@ export function startNgrok(
 ): Promise<StartedNgrok> {
   const spawner = options.spawner ?? defaultSpawner;
   const timeoutMs = options.timeoutMs ?? NGROK_START_TIMEOUT_MS;
-  const args = buildNgrokArgs(localPort, options.hostHeader);
+  const args = buildNgrokArgs(localPort, options.hostHeader, options.url);
 
   let child: NgrokChildProcess;
   try {

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -183,7 +183,7 @@ Portless stores its state (routes, PID file, port file) in `~/.portless`. Overri
 | `PORTLESS_SYNC_HOSTS` | Set to `0` to disable auto-sync of /etc/hosts (on by default)               |
 | `PORTLESS_TAILSCALE`  | Set to `1` to share apps on your Tailscale network (same as `--tailscale`)  |
 | `PORTLESS_FUNNEL`     | Set to `1` to share apps publicly via Tailscale Funnel (same as `--funnel`) |
-| `PORTLESS_NGROK`      | Set to `1` to share apps publicly via ngrok (same as `--ngrok`)             |
+| `PORTLESS_NGROK`      | Set to `1` to share apps via ngrok, or a URL to pin it (same as `--ngrok`)  |
 | `PORTLESS_STATE_DIR`  | Override the state directory                                                |
 | `PORTLESS=0`          | Bypass the proxy, run the command directly                                  |
 
@@ -252,7 +252,16 @@ portless myapp --ngrok next dev
 # -> https://abc123.ngrok.app          (public internet)
 ```
 
-Set `PORTLESS_NGROK=1` to enable ngrok by default when portless runs an app. `portless list` shows both local and ngrok URLs. The ngrok tunnel is cleaned up when the app exits. Requires the `ngrok` CLI to be installed and authenticated with `ngrok config add-authtoken <token>`.
+Pass a reserved URL to `--ngrok` to bind a fixed address instead of a random one (the URL must be a domain reserved in your ngrok account):
+
+```bash
+portless myapp --ngrok=my-app.ngrok.dev next dev
+# -> https://my-app.ngrok.dev          (public internet, fixed)
+```
+
+The `--ngrok=<url>` form may omit the scheme (`my-app.ngrok.dev` becomes `https://my-app.ngrok.dev`). With a space-separated value, include the scheme: `--ngrok https://my-app.ngrok.dev`.
+
+Set `PORTLESS_NGROK=1` to enable ngrok by default when portless runs an app, or `PORTLESS_NGROK=my-app.ngrok.dev` to also pin the URL. `portless list` shows both local and ngrok URLs. The ngrok tunnel is cleaned up when the app exits. Requires the `ngrok` CLI to be installed and authenticated with `ngrok config add-authtoken <token>`.
 
 ## OS startup service
 
@@ -310,6 +319,7 @@ The chosen service configuration is written into launchd, systemd, or Task Sched
 | `portless <name> --tailscale <cmd>`    | Share the app on your Tailscale network (tailnet)              |
 | `portless <name> --funnel <cmd>`       | Share the app publicly via Tailscale Funnel                    |
 | `portless <name> --ngrok <cmd>`        | Share the app publicly via ngrok                               |
+| `portless <name> --ngrok=<url> <cmd>`  | Share via ngrok on a fixed URL (e.g. my-app.ngrok.dev)         |
 | `portless <name> --force <cmd>`        | Kill the existing process and take over its route              |
 | `portless --name <name> <cmd>`         | Force `<name>` as app name (bypasses subcommand dispatch)      |
 | `portless <name> -- <cmd> [args...]`   | Stop flag parsing; everything after `--` is passed to child    |


### PR DESCRIPTION
`--ngrok` now accepts an optional reserved URL to pin a stable public address. Handy for OAuth callbacks, webhooks, and anything that needs the same URL across restarts.

## Usage
```bash
portless myapp --ngrok=my-app.ngrok.dev next dev   # -> https://my-app.ngrok.dev   (custom)
portless myapp --ngrok next dev                    # -> https://<random>.ngrok.app (unchanged)
```
Also settable via `PORTLESS_NGROK=my-app.ngrok.dev`

## Notes
The `--ngrok=<url>` form may omit the scheme (_my-app.ngrok.dev → https://my-app.ngrok.dev_). The space-separated `--ngrok <url>` form requires a scheme, so a non-URL string stays the child command (`--ngrok next dev` still runs `next dev`).
Fully backward compatible — bare `--ngrok` and `PORTLESS_NGROK=1` still allocate a random URL.
The URL must be a domain reserved in your ngrok account.
Docs (README, SKILL.md, docs site, --help) and CLI/unit tests updated.