### PR TITLE
feat: add portless doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ portless alias <name> <port>     # Register a static route (e.g. for Docker)
 portless alias <name> <port> --force  # Overwrite an existing route
 portless alias --remove <name>   # Remove a static route
 portless list                    # Show active routes
+portless doctor                  # Check proxy, routes, DNS, and CA trust
 portless trust                   # Add local CA to system trust store
 portless clean                   # Remove state, CA trust entry, and hosts block
 portless prune                   # Kill orphaned dev servers from crashed sessions
@@ -423,7 +424,7 @@ PORTLESS_NGROK_URL               ngrok URL of the app (when --ngrok is active)
 NODE_EXTRA_CA_CERTS              Path to the portless CA (when HTTPS is active)
 ```
 
-> **Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `trust`, `clean`, `prune`, `proxy`, and `service` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name from your project, or `portless --name <name> <cmd>` to force any name including reserved ones.
+> **Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `doctor`, `trust`, `clean`, `prune`, `proxy`, and `service` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name from your project, or `portless --name <name> <cmd>` to force any name including reserved ones.
 
 ## Uninstall / reset
 
@@ -447,6 +448,10 @@ portless hosts clean   # Clean up later
 ```
 
 Auto-syncs `/etc/hosts` for route hostnames by default (`.localhost`, custom TLDs, LAN `.local`). Set `PORTLESS_SYNC_HOSTS=0` to disable.
+
+## Troubleshooting
+
+Run `portless doctor` to inspect local health without changing state. It checks Node.js, the state directory, proxy liveness, route entries, HTTPS CA trust, hostname resolution, and LAN mode prerequisites, then prints suggested fixes.
 
 ## Proxying Between Portless Apps
 

--- a/apps/docs/src/app/commands/page.mdx
+++ b/apps/docs/src/app/commands/page.mdx
@@ -119,6 +119,14 @@ portless list
 
 Shows active routes and their assigned ports.
 
+## Doctor
+
+```bash
+portless doctor
+```
+
+Checks local portless health without changing state. It reports Node.js compatibility, state directory permissions, proxy liveness, route entries, HTTPS CA trust, hostname resolution, and LAN mode prerequisites, then prints suggested fixes.
+
 ## Trust the CA
 
 ```bash

--- a/packages/portless/src/clean-utils.test.ts
+++ b/packages/portless/src/clean-utils.test.ts
@@ -36,6 +36,7 @@ describe("removePortlessStateFiles", () => {
     fs.writeFileSync(path.join(tmpDir, "routes.json"), "[]");
     fs.writeFileSync(path.join(tmpDir, "ca.pem"), "pem");
     fs.writeFileSync(path.join(tmpDir, "proxy.port"), "443");
+    fs.writeFileSync(path.join(tmpDir, "proxy.custom-cert"), "1");
     fs.mkdirSync(path.join(tmpDir, "host-certs"));
     fs.writeFileSync(path.join(tmpDir, "host-certs", "x.pem"), "x");
 
@@ -45,6 +46,7 @@ describe("removePortlessStateFiles", () => {
 
     expect(fs.existsSync(path.join(tmpDir, "routes.json"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, "ca.pem"))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, "proxy.custom-cert"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, "host-certs"))).toBe(false);
     expect(fs.readFileSync(path.join(tmpDir, "user-notes.txt"), "utf-8")).toBe("keep me");
   });

--- a/packages/portless/src/clean-utils.ts
+++ b/packages/portless/src/clean-utils.ts
@@ -10,6 +10,7 @@ const PORTLESS_STATE_FILES = [
   "proxy.port",
   "proxy.log",
   "proxy.tls",
+  "proxy.custom-cert",
   "proxy.tld",
   "proxy.lan",
   "ca-key.pem",

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -173,6 +173,7 @@ export function readPortFromDir(dir: string): number | null {
 
 /** Name of the marker file that indicates the proxy is running with TLS. */
 const TLS_MARKER_FILE = "proxy.tls";
+const CUSTOM_CERT_MARKER_FILE = "proxy.custom-cert";
 
 /** Read the TLS marker from a state directory. */
 export function readTlsMarker(dir: string): boolean {
@@ -186,6 +187,27 @@ export function readTlsMarker(dir: string): boolean {
 /** Write or remove the TLS marker in the state directory. */
 export function writeTlsMarker(dir: string, enabled: boolean): void {
   const markerPath = path.join(dir, TLS_MARKER_FILE);
+  if (enabled) {
+    fs.writeFileSync(markerPath, "1", { mode: 0o644 });
+  } else {
+    try {
+      fs.unlinkSync(markerPath);
+    } catch {
+      // Marker may already be absent; non-fatal
+    }
+  }
+}
+
+export function readCustomCertMarker(dir: string): boolean {
+  try {
+    return fs.existsSync(path.join(dir, CUSTOM_CERT_MARKER_FILE));
+  } catch {
+    return false;
+  }
+}
+
+export function writeCustomCertMarker(dir: string, enabled: boolean): void {
+  const markerPath = path.join(dir, CUSTOM_CERT_MARKER_FILE);
   if (enabled) {
     fs.writeFileSync(markerPath, "1", { mode: 0o644 });
   } else {

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -354,6 +354,32 @@ describe("CLI", () => {
       }
     });
 
+    it("warns when a route has an invalid port instead of crashing", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-doctor-bad-port-"));
+      const proxyPort = await getFreePort();
+      try {
+        fs.writeFileSync(
+          path.join(tmpDir, "routes.json"),
+          JSON.stringify([{ hostname: "bad.localhost", port: 99999, pid: 0 }])
+        );
+
+        const { status, stdout, stderr } = run(["doctor"], {
+          env: {
+            PORTLESS_STATE_DIR: tmpDir,
+            PORTLESS_PORT: proxyPort.toString(),
+            PORTLESS_HTTPS: "0",
+          },
+        });
+
+        expect(status).toBe(0);
+        expect(stdout).toContain("Route bad.localhost has invalid port 99999.");
+        expect(stdout).toContain("Summary: 0 failures");
+        expect(stderr).not.toContain("Port should be");
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
     it("does not report an alive stale PID file as healthy", async () => {
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-doctor-pid-"));
       const proxyPort = await getFreePort();

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as http from "node:http";
 import * as os from "node:os";
@@ -104,6 +104,50 @@ async function getFreePort(): Promise<number> {
   }
 }
 
+async function waitForHttpHeader(
+  port: number,
+  headerName: string,
+  expectedValue: string
+): Promise<void> {
+  for (let i = 0; i < 50; i++) {
+    const matched = await new Promise<boolean>((resolve) => {
+      const req = http.request(
+        {
+          hostname: "127.0.0.1",
+          port,
+          method: "HEAD",
+          timeout: 200,
+        },
+        (res) => {
+          res.resume();
+          resolve(res.headers[headerName.toLowerCase()] === expectedValue);
+        }
+      );
+      req.on("error", () => resolve(false));
+      req.on("timeout", () => {
+        req.destroy();
+        resolve(false);
+      });
+      req.end();
+    });
+    if (matched) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Timed out waiting for ${headerName} on port ${port}`);
+}
+
+async function stopChild(child: ReturnType<typeof spawn>): Promise<void> {
+  if (child.exitCode !== null) return;
+  child.kill("SIGTERM");
+  await new Promise<void>((resolve) => {
+    const timeout = setTimeout(resolve, 1000);
+    child.once("exit", () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+  });
+}
+
 describe("CLI", () => {
   beforeAll(() => {
     if (!fs.existsSync(CLI_PATH)) {
@@ -123,6 +167,7 @@ describe("CLI", () => {
       expect(stdout).toContain("portless run");
       expect(stdout).toContain("portless get");
       expect(stdout).toContain("run [--name <name>]");
+      expect(stdout).toContain("portless doctor");
       expect(stdout).toContain("--port");
       expect(stdout).toContain("-p");
       expect(stdout).toContain("--foreground");
@@ -174,6 +219,139 @@ describe("CLI", () => {
       // it doesn't crash and returns 0.
       const { status } = run(["list"]);
       expect(status).toBe(0);
+    });
+  });
+
+  describe("doctor", () => {
+    it("prints help with --help", () => {
+      const { status, stdout } = run(["doctor", "--help"]);
+      expect(status).toBe(0);
+      expect(stdout).toContain("portless doctor");
+      expect(stdout).toContain("state");
+      expect(stdout).toContain("does not start");
+    });
+
+    it("reports a stopped proxy as a warning and exits 0", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-doctor-stopped-"));
+      const proxyPort = await getFreePort();
+      try {
+        const { status, stdout } = run(["doctor"], {
+          env: {
+            PORTLESS_STATE_DIR: tmpDir,
+            PORTLESS_PORT: proxyPort.toString(),
+            PORTLESS_HTTPS: "0",
+          },
+        });
+
+        expect(status).toBe(0);
+        expect(stdout).toContain("portless doctor");
+        expect(stdout).toContain(`Proxy is not running on port ${proxyPort}`);
+        expect(stdout).toContain("Summary: 0 failures");
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("exits 1 when the proxy port is occupied by a non-portless process", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-doctor-conflict-"));
+      const server = http.createServer((_req, res) => {
+        res.end("not portless");
+      });
+
+      try {
+        const proxyPort = await new Promise<number>((resolve) => {
+          server.listen(0, "127.0.0.1", () => {
+            const addr = server.address();
+            if (addr && typeof addr !== "string") {
+              resolve(addr.port);
+            }
+          });
+        });
+
+        const { status, stdout } = run(["doctor"], {
+          env: {
+            PORTLESS_STATE_DIR: tmpDir,
+            PORTLESS_PORT: proxyPort.toString(),
+            PORTLESS_HTTPS: "0",
+          },
+        });
+
+        expect(status).toBe(1);
+        expect(stdout).toContain(`Port ${proxyPort} is in use, but it is not a portless proxy`);
+        expect(stdout).toContain("Summary: 1 failure");
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("reports a responding proxy and registered route", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-doctor-healthy-"));
+      const appServer = http.createServer((_req, res) => {
+        res.end("app");
+      });
+      let proxyChild: ReturnType<typeof spawn> | undefined;
+
+      try {
+        const proxyPort = await getFreePort();
+        const proxyScriptPath = path.join(tmpDir, "proxy-server.cjs");
+        fs.writeFileSync(
+          proxyScriptPath,
+          [
+            'const http = require("node:http");',
+            "const server = http.createServer((_req, res) => {",
+            '  res.setHeader("X-Portless", "1");',
+            '  res.end("ok");',
+            "});",
+            `server.listen(${proxyPort}, "127.0.0.1");`,
+            'process.on("SIGTERM", () => server.close(() => process.exit(0)));',
+          ].join("\n") + "\n"
+        );
+        proxyChild = spawn(process.execPath, [proxyScriptPath], {
+          stdio: "ignore",
+        });
+        await waitForHttpHeader(proxyPort, "X-Portless", "1");
+
+        const appPort = await new Promise<number>((resolve) => {
+          appServer.listen(0, "127.0.0.1", () => {
+            const addr = appServer.address();
+            if (addr && typeof addr !== "string") {
+              resolve(addr.port);
+            }
+          });
+        });
+
+        fs.writeFileSync(path.join(tmpDir, "proxy.port"), proxyPort.toString());
+        fs.writeFileSync(
+          path.join(tmpDir, "routes.json"),
+          JSON.stringify([{ hostname: "myapp.localhost", port: appPort, pid: 0 }])
+        );
+
+        const { status, stdout } = run(["doctor"], {
+          env: {
+            PORTLESS_STATE_DIR: tmpDir,
+            PORTLESS_HTTPS: "0",
+          },
+        });
+
+        expect(status).toBe(0);
+        expect(stdout).toContain(`Proxy is responding on port ${proxyPort}`);
+        expect(stdout).toContain("Routes: 1 active route");
+        expect(stdout).toContain("Summary: 0 failures");
+      } finally {
+        if (proxyChild) await stopChild(proxyChild);
+        await new Promise<void>((resolve) => appServer.close(() => resolve()));
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("does not bypass doctor when PORTLESS=0 is set", () => {
+      const { status, stderr } = run(["doctor", "typo"], {
+        env: { PORTLESS: "0" },
+      });
+      expect(status).toBe(1);
+      expect(stderr).toContain("Unknown argument");
+      expect(stderr).not.toContain("ENOENT");
     });
   });
 

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -252,6 +252,27 @@ describe("CLI", () => {
       }
     });
 
+    it("does not fail for a missing nested state directory with a writable ancestor", async () => {
+      const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "portless-doctor-nested-"));
+      const proxyPort = await getFreePort();
+      const stateDir = path.join(tmpRoot, "missing", "state");
+      try {
+        const { status, stdout } = run(["doctor"], {
+          env: {
+            PORTLESS_STATE_DIR: stateDir,
+            PORTLESS_PORT: proxyPort.toString(),
+            PORTLESS_HTTPS: "0",
+          },
+        });
+
+        expect(status).toBe(0);
+        expect(stdout).toContain(`State directory has not been created yet: ${stateDir}`);
+        expect(stdout).toContain("Summary: 0 failures");
+      } finally {
+        fs.rmSync(tmpRoot, { recursive: true, force: true });
+      }
+    });
+
     it("does not require OpenSSL when persisted proxy state is HTTP", async () => {
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-doctor-http-"));
       const proxyPort = await getFreePort();

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -252,6 +252,27 @@ describe("CLI", () => {
       }
     });
 
+    it("does not require OpenSSL when persisted proxy state is HTTP", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-doctor-http-"));
+      const proxyPort = await getFreePort();
+      try {
+        fs.writeFileSync(path.join(tmpDir, "proxy.port"), proxyPort.toString());
+
+        const { status, stdout } = run(["doctor"], {
+          env: {
+            PORTLESS_STATE_DIR: tmpDir,
+            PATH: tmpDir,
+          },
+        });
+
+        expect(status).toBe(0);
+        expect(stdout).toContain("HTTPS is disabled for the current proxy state.");
+        expect(stdout).not.toContain("OpenSSL is not available");
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
     it("exits 1 when the proxy port is occupied by a non-portless process", async () => {
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-doctor-conflict-"));
       const server = http.createServer((_req, res) => {
@@ -281,6 +302,53 @@ describe("CLI", () => {
         expect(stdout).toContain("Summary: 1 failure");
       } finally {
         await new Promise<void>((resolve) => server.close(() => resolve()));
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("warns when routes.json is corrupted", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-doctor-routes-"));
+      const proxyPort = await getFreePort();
+      try {
+        fs.writeFileSync(path.join(tmpDir, "routes.json"), "{");
+
+        const { status, stdout } = run(["doctor"], {
+          env: {
+            PORTLESS_STATE_DIR: tmpDir,
+            PORTLESS_PORT: proxyPort.toString(),
+            PORTLESS_HTTPS: "0",
+          },
+        });
+
+        expect(status).toBe(0);
+        expect(stdout).toContain("Corrupted routes file (invalid JSON)");
+        expect(stdout).toContain("Summary: 0 failures");
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("does not report an alive stale PID file as healthy", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-doctor-pid-"));
+      const proxyPort = await getFreePort();
+      try {
+        fs.writeFileSync(path.join(tmpDir, "proxy.port"), proxyPort.toString());
+        fs.writeFileSync(path.join(tmpDir, "proxy.pid"), process.pid.toString());
+
+        const { status, stdout } = run(["doctor"], {
+          env: {
+            PORTLESS_STATE_DIR: tmpDir,
+            PORTLESS_HTTPS: "0",
+          },
+        });
+
+        expect(status).toBe(0);
+        expect(stdout).toContain(
+          `Proxy PID file points to PID ${process.pid}, but no portless proxy is responding on port ${proxyPort}.`
+        );
+        expect(stdout).not.toContain("Proxy PID file points to a running process");
+        expect(stdout).not.toContain("Proxy PID file points to the responding proxy process");
+      } finally {
         fs.rmSync(tmpDir, { recursive: true, force: true });
       }
     });

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -273,6 +273,32 @@ describe("CLI", () => {
       }
     });
 
+    it("does not require generated CA checks when proxy state uses a custom certificate", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-doctor-custom-cert-"));
+      const proxyPort = await getFreePort();
+      try {
+        fs.writeFileSync(path.join(tmpDir, "proxy.port"), proxyPort.toString());
+        fs.writeFileSync(path.join(tmpDir, "proxy.tls"), "1");
+        fs.writeFileSync(path.join(tmpDir, "proxy.custom-cert"), "1");
+
+        const { status, stdout } = run(["doctor"], {
+          env: {
+            PORTLESS_STATE_DIR: tmpDir,
+            PATH: tmpDir,
+          },
+        });
+
+        expect(status).toBe(0);
+        expect(stdout).toContain("Proxy is configured with a custom TLS certificate.");
+        expect(stdout).toContain("Generated local CA is not required for custom TLS certificates.");
+        expect(stdout).not.toContain("OpenSSL is not available");
+        expect(stdout).not.toContain("Generated CA file is missing");
+        expect(stdout).not.toContain("Local CA has not been generated");
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
     it("exits 1 when the proxy port is occupied by a non-portless process", async () => {
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-doctor-conflict-"));
       const server = http.createServer((_req, res) => {

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -10,7 +10,13 @@ import { StringDecoder } from "node:string_decoder";
 import { createSNICallback, ensureCerts, isCATrusted, trustCA, untrustCA } from "./certs.js";
 import { createHttpRedirectServer, createProxyServer } from "./proxy.js";
 import { fixOwnership, formatUrl, isErrnoException, parseHostname } from "./utils.js";
-import { syncHostsFile, cleanHostsFile, shouldAutoSyncHosts } from "./hosts.js";
+import {
+  checkHostResolution,
+  getManagedHostnames,
+  syncHostsFile,
+  cleanHostsFile,
+  shouldAutoSyncHosts,
+} from "./hosts.js";
 import { FILE_MODE, RouteConflictError, RouteStore } from "./routes.js";
 import {
   ensureTailscaleReady,
@@ -1580,6 +1586,7 @@ ${colors.bold("Usage:")}
   ${colors.cyan("portless alias <name> <port>")}     Register a static route (e.g. for Docker)
   ${colors.cyan("portless alias --remove <name>")}   Remove a static route
   ${colors.cyan("portless list")}                    Show active routes
+  ${colors.cyan("portless doctor")}                  Check local portless health
   ${colors.cyan("portless trust")}                   Add local CA to system trust store
   ${colors.cyan("portless clean")}                   Remove portless state, trust entry, and hosts block
   ${colors.cyan("portless prune")}                   Kill orphaned dev servers from crashed sessions
@@ -1597,6 +1604,7 @@ ${colors.bold("Examples:")}
   portless service install --lan      # Persist LAN mode in the startup service
   portless service install --wildcard # Persist wildcard routing in the startup service
   portless get backend                # -> https://backend.localhost
+  portless doctor                     # Check proxy, routes, DNS, and CA trust
   portless myapp --tailscale next dev # -> also https://<node>.ts.net (tailnet)
   portless myapp --funnel next dev    # -> also https://<node>.ts.net (public)
   portless myapp --ngrok next dev     # -> also https://<random>.ngrok.app (public)
@@ -1727,7 +1735,7 @@ ${colors.bold("Skip portless:")}
   PORTLESS=0 pnpm dev           # Runs command directly without proxy
 
 ${colors.bold("Reserved names:")}
-  run, get, alias, hosts, list, trust, clean, prune, proxy, service are subcommands and
+  run, get, alias, hosts, list, doctor, trust, clean, prune, proxy, service are subcommands and
   cannot be used as app names directly. Use "portless run" to infer the name,
   or "portless --name <name>" to force any name including reserved ones.
 `);
@@ -2221,6 +2229,344 @@ ${colors.bold("Usage: portless hosts <command>")}
     colors.red(`Failed to update ${HOSTS_DISPLAY}${isWindows ? " (run as Administrator)." : "."}`)
   );
   process.exit(1);
+}
+
+type DoctorStatus = "ok" | "warn" | "fail" | "info";
+
+type DoctorFinding = {
+  status: DoctorStatus;
+  message: string;
+  hint?: string;
+};
+
+function colorDoctorStatus(status: DoctorStatus): (value: string) => string {
+  if (status === "fail") return colors.red;
+  if (status === "warn") return colors.yellow;
+  if (status === "ok") return colors.green;
+  return colors.gray;
+}
+
+function printDoctorFinding(finding: DoctorFinding): void {
+  const status = finding.status.padEnd(5);
+  console.log(`${colorDoctorStatus(finding.status)(status)} ${finding.message}`);
+  if (finding.hint) {
+    console.log(colors.gray(`      ${finding.hint}`));
+  }
+}
+
+function isProcessAliveForDoctor(pid: number): boolean {
+  if (pid <= 0) return true;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function checkPathWritable(targetPath: string): boolean {
+  try {
+    fs.accessSync(targetPath, fs.constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function checkCommandAvailable(command: string, args: string[]): boolean {
+  const result = spawnSync(command, args, {
+    stdio: "ignore",
+    timeout: 3000,
+    windowsHide: true,
+  });
+  return !result.error && (result.status === 0 || result.status === null);
+}
+
+function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function doctorProxyStartHint(proxyPort: number, tls: boolean): string {
+  const defaultPort = getDefaultPort(tls);
+  const portArgs = proxyPort === defaultPort ? "" : ` -p ${proxyPort}`;
+  const tlsArgs = tls ? "" : " --no-tls";
+  return `Run: portless proxy start${portArgs}${tlsArgs}`;
+}
+
+async function handleDoctor(args: string[]): Promise<void> {
+  if (args[1] === "--help" || args[1] === "-h") {
+    console.log(`
+${colors.bold("portless doctor")} - Check local portless health and print suggested fixes.
+
+${colors.bold("Usage:")}
+  ${colors.cyan("portless doctor")}
+
+Checks Node.js, the state directory, proxy liveness, route entries, HTTPS CA
+trust, hostname resolution, and LAN mode prerequisites. It does not start,
+stop, clean, prune, trust, or modify portless state.
+
+${colors.bold("Options:")}
+  --help, -h             Show this help
+`);
+    process.exit(0);
+  }
+
+  if (args.length > 1) {
+    console.error(colors.red(`Error: Unknown argument "${args[1]}".`));
+    console.error(colors.cyan("  portless doctor --help"));
+    process.exit(1);
+  }
+
+  const findings: DoctorFinding[] = [];
+  const add = (status: DoctorStatus, message: string, hint?: string) => {
+    findings.push({ status, message, hint });
+  };
+
+  let state: Awaited<ReturnType<typeof discoverState>>;
+  try {
+    state = await discoverState();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    add("fail", `Could not discover portless state: ${message}`);
+    state = {
+      dir: resolveStateDir(),
+      port: getDefaultPort(!isHttpsEnvDisabled()),
+      tls: !isHttpsEnvDisabled(),
+      tld: DEFAULT_TLD,
+      lanMode: isLanEnvEnabled(),
+      lanIp: null,
+    };
+  }
+
+  const store = new RouteStore(state.dir, {
+    onWarning: (msg) => add("warn", msg),
+  });
+  const hasPortFile = fs.existsSync(store.portFilePath);
+  const configuredTls = hasPortFile ? state.tls : !isHttpsEnvDisabled();
+  const configuredPort = hasPortFile ? state.port : getDefaultPort(configuredTls);
+  const initialProxyRunning = await isProxyRunning(state.port, state.tls);
+  const probePort = initialProxyRunning || hasPortFile ? state.port : configuredPort;
+  const probeTls = initialProxyRunning || hasPortFile ? state.tls : configuredTls;
+  const proxyRunning =
+    initialProxyRunning && probePort === state.port
+      ? true
+      : await isProxyRunning(probePort, probeTls);
+  const portListening = proxyRunning ? true : await isPortListening(probePort);
+  const proxyPort = proxyRunning || portListening || hasPortFile ? probePort : configuredPort;
+  const proxyTls = proxyRunning || portListening || hasPortFile ? probeTls : configuredTls;
+  const stateExists = fs.existsSync(state.dir);
+
+  console.log(colors.blue.bold("\nportless doctor\n"));
+  console.log(`Version: ${__VERSION__}`);
+  console.log(`Node.js: ${process.versions.node}`);
+  console.log(`Platform: ${process.platform} ${process.arch}`);
+  console.log(`State dir: ${state.dir}`);
+  console.log(`Proxy target: ${formatUrl("127.0.0.1", proxyPort, proxyTls)}`);
+  console.log(`Mode: ${proxyTls ? "HTTPS" : "HTTP"}, .${state.tld}${state.lanMode ? ", LAN" : ""}`);
+  console.log("");
+
+  const nodeMajor = parseInt(process.versions.node.split(".")[0], 10);
+  if (nodeMajor >= 24) {
+    add("ok", `Node.js ${process.versions.node} satisfies portless requirements.`);
+  } else {
+    add("fail", `Node.js ${process.versions.node} is unsupported.`, "Install Node.js 24 or newer.");
+  }
+
+  if (stateExists) {
+    try {
+      const stat = fs.statSync(state.dir);
+      if (!stat.isDirectory()) {
+        add("fail", `State path exists but is not a directory: ${state.dir}`);
+      } else if (checkPathWritable(state.dir)) {
+        add("ok", `State directory is writable: ${state.dir}`);
+      } else {
+        add("fail", `State directory is not writable: ${state.dir}`);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      add("fail", `Could not inspect state directory: ${message}`);
+    }
+  } else {
+    const parentDir = path.dirname(state.dir);
+    if (checkPathWritable(parentDir)) {
+      add("info", `State directory has not been created yet: ${state.dir}`);
+    } else {
+      add("fail", `State directory does not exist and parent is not writable: ${parentDir}`);
+    }
+  }
+
+  if (proxyRunning) {
+    add("ok", `Proxy is responding on port ${proxyPort}.`);
+  } else if (portListening) {
+    const pid = findPidOnPort(proxyPort);
+    add(
+      "fail",
+      `Port ${proxyPort} is in use, but it is not a portless proxy.`,
+      pid ? `Process on port: PID ${pid}` : "Could not identify the process holding the port."
+    );
+  } else {
+    add(
+      "warn",
+      `Proxy is not running on port ${proxyPort}.`,
+      doctorProxyStartHint(proxyPort, proxyTls)
+    );
+  }
+
+  if (fs.existsSync(store.pidPath)) {
+    try {
+      const rawPid = fs.readFileSync(store.pidPath, "utf-8").trim();
+      const pid = parseInt(rawPid, 10);
+      if (isNaN(pid) || pid <= 0) {
+        add("fail", `Proxy PID file is invalid: ${store.pidPath}`);
+      } else if (isProcessAliveForDoctor(pid)) {
+        add("ok", `Proxy PID file points to a running process: ${pid}`);
+      } else {
+        add("warn", `Proxy PID file is stale: ${pid}`, "Run: portless proxy stop");
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      add("fail", `Could not read proxy PID file: ${message}`);
+    }
+  } else if (proxyRunning) {
+    add("warn", `Proxy is running but the PID file is missing: ${store.pidPath}`);
+  }
+
+  if (proxyTls || !isHttpsEnvDisabled()) {
+    if (checkCommandAvailable("openssl", ["version"])) {
+      add("ok", "OpenSSL is available for certificate generation.");
+    } else {
+      add(
+        "fail",
+        "OpenSSL is not available on PATH.",
+        isWindows
+          ? "Install OpenSSL or add Git for Windows OpenSSL to PATH."
+          : "Install OpenSSL with your system package manager."
+      );
+    }
+  } else {
+    add("info", "HTTPS is disabled, so OpenSSL is not required for this run.");
+  }
+
+  if (proxyTls) {
+    const caPath = path.join(state.dir, "ca.pem");
+    if (fs.existsSync(caPath)) {
+      if (isCATrusted(state.dir)) {
+        add("ok", "Local CA is trusted by the OS trust store.");
+      } else {
+        add(
+          "warn",
+          "Local CA exists but is not trusted by the OS trust store.",
+          "Run: portless trust"
+        );
+      }
+    } else if (proxyRunning) {
+      add("warn", `Generated CA file is missing: ${caPath}`);
+    } else {
+      add("info", "Local CA has not been generated yet.");
+    }
+  } else {
+    add("info", "HTTPS is disabled for the current proxy state.");
+  }
+
+  let rawRoutes: ReturnType<RouteStore["loadRoutesRaw"]> = [];
+  try {
+    rawRoutes = store.loadRoutesRaw();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    add("fail", `Could not read routes: ${message}`);
+  }
+
+  const liveRoutes = rawRoutes.filter(
+    (route) => route.pid === 0 || isProcessAliveForDoctor(route.pid)
+  );
+  const staleRoutes = rawRoutes.filter(
+    (route) => route.pid !== 0 && !isProcessAliveForDoctor(route.pid)
+  );
+  if (rawRoutes.length === 0) {
+    add("info", "No routes are registered.");
+  } else if (staleRoutes.length === 0) {
+    add("ok", `Routes: ${pluralize(liveRoutes.length, "active route")}.`);
+  } else {
+    add(
+      "warn",
+      `Routes: ${pluralize(liveRoutes.length, "active route")}, ${pluralize(staleRoutes.length, "stale route")}.`,
+      "Run: portless prune"
+    );
+  }
+
+  for (const route of staleRoutes.slice(0, 5)) {
+    add("warn", `Stale route ${route.hostname} is owned by exited PID ${route.pid}.`);
+  }
+  if (staleRoutes.length > 5) {
+    add("warn", `${staleRoutes.length - 5} additional stale routes hidden.`);
+  }
+
+  const routePortChecks = await Promise.all(
+    liveRoutes.map(async (route) => ({
+      route,
+      listening: await isPortListening(route.port),
+    }))
+  );
+  for (const { route, listening } of routePortChecks) {
+    if (listening) continue;
+    add(
+      "warn",
+      `Route ${route.hostname} points to port ${route.port}, but nothing is listening there.`,
+      route.pid === 0 ? "Remove the alias or start that service." : "The app may still be starting."
+    );
+  }
+
+  if (state.lanMode || isLanEnvEnabled()) {
+    const mdns = isMdnsSupported();
+    if (mdns.supported) {
+      add("ok", "mDNS publishing support is available for LAN mode.");
+    } else {
+      add("fail", `LAN mode is enabled but mDNS publishing is unavailable: ${mdns.reason}`);
+    }
+    if (state.lanIp) {
+      add("ok", `LAN IP is recorded: ${state.lanIp}`);
+    } else {
+      add("warn", "LAN mode is enabled but no LAN IP is recorded.");
+    }
+  } else if (liveRoutes.length > 0) {
+    const managedHosts = new Set(getManagedHostnames());
+    const resolutionChecks = await Promise.all(
+      liveRoutes.map(async (route) => ({
+        hostname: route.hostname,
+        resolves: await checkHostResolution(route.hostname),
+        managed: managedHosts.has(route.hostname),
+      }))
+    );
+    const unresolved = resolutionChecks.filter((result) => !result.resolves);
+    if (unresolved.length === 0) {
+      add("ok", "Registered hostnames resolve through the system resolver.");
+    } else {
+      add(
+        "warn",
+        `${pluralize(unresolved.length, "hostname")} did not resolve through the system resolver.`,
+        "Run: portless hosts sync"
+      );
+      for (const result of unresolved.slice(0, 5)) {
+        const hostState = result.managed ? "present in hosts block" : "missing from hosts block";
+        add("warn", `${result.hostname} is ${hostState}.`);
+      }
+    }
+  }
+
+  for (const finding of findings) {
+    printDoctorFinding(finding);
+  }
+
+  const failures = findings.filter((finding) => finding.status === "fail").length;
+  const warnings = findings.filter((finding) => finding.status === "warn").length;
+  console.log("");
+  if (failures > 0) {
+    console.log(
+      colors.red(`Summary: ${pluralize(failures, "failure")}, ${pluralize(warnings, "warning")}.`)
+    );
+    process.exit(1);
+  }
+  console.log(colors.green(`Summary: 0 failures, ${pluralize(warnings, "warning")}.`));
 }
 
 async function handleProxy(args: string[]): Promise<void> {
@@ -3605,7 +3951,7 @@ async function main() {
 
   // --name flag: treat the next arg as an explicit app name, bypassing
   // subcommand dispatch. Useful when the app name collides with a reserved
-  // subcommand (run, alias, hosts, list, trust, clean, prune, proxy, service).
+  // subcommand (run, alias, hosts, list, doctor, trust, clean, prune, proxy, service).
   if (args[0] === "--name") {
     args.shift();
     if (!args[0]) {
@@ -3644,7 +3990,11 @@ async function main() {
     skipPortless &&
     (isRunCommand ||
       args.length === 0 ||
-      (args.length >= 2 && args[0] !== "proxy" && args[0] !== "clean" && args[0] !== "service"))
+      (args.length >= 2 &&
+        args[0] !== "proxy" &&
+        args[0] !== "clean" &&
+        args[0] !== "doctor" &&
+        args[0] !== "service"))
   ) {
     const parsed = isRunCommand ? parseRunArgs(args) : parseAppArgs(args);
     let commandArgs = parsed.commandArgs;
@@ -3662,7 +4012,7 @@ async function main() {
     return;
   }
 
-  // Global dispatch: help, version, trust, clean, prune, list, alias, hosts, proxy, service
+  // Global dispatch: help, version, trust, clean, prune, list, doctor, alias, hosts, proxy, service
   // When `run` is used, skip these so args like "list" or "--help" are treated
   // as child-command tokens, not portless subcommands.
   if (!isRunCommand) {
@@ -3695,6 +4045,10 @@ async function main() {
     }
     if (args[0] === "list") {
       await handleList();
+      return;
+    }
+    if (args[0] === "doctor") {
+      await handleDoctor(args);
       return;
     }
     if (args[0] === "get") {

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -9,7 +9,13 @@ import { spawn, spawnSync } from "node:child_process";
 import { StringDecoder } from "node:string_decoder";
 import { createSNICallback, ensureCerts, isCATrusted, trustCA, untrustCA } from "./certs.js";
 import { createHttpRedirectServer, createProxyServer } from "./proxy.js";
-import { fixOwnership, formatUrl, isErrnoException, parseHostname } from "./utils.js";
+import {
+  fixOwnership,
+  formatUrl,
+  isErrnoException,
+  isProcessAlive as isPidAlive,
+  parseHostname,
+} from "./utils.js";
 import {
   checkHostResolution,
   getManagedHostnames,
@@ -2266,12 +2272,7 @@ function printDoctorFinding(finding: DoctorFinding): void {
 
 function isProcessAliveForDoctor(pid: number): boolean {
   if (pid <= 0) return true;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
+  return isPidAlive(pid);
 }
 
 function checkPathWritable(targetPath: string): boolean {
@@ -2294,6 +2295,10 @@ function checkCommandAvailable(command: string, args: string[]): boolean {
 
 function pluralize(count: number, singular: string, plural = `${singular}s`): string {
   return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function isValidTcpPort(port: number): boolean {
+  return Number.isInteger(port) && port >= 1 && port <= 65535;
 }
 
 function doctorProxyStartHint(proxyPort: number, tls: boolean): string {
@@ -2533,12 +2538,24 @@ ${colors.bold("Options:")}
   }
 
   const routePortChecks = await Promise.all(
-    liveRoutes.map(async (route) => ({
-      route,
-      listening: await isPortListening(route.port),
-    }))
+    liveRoutes.map(async (route) => {
+      const validPort = isValidTcpPort(route.port);
+      return {
+        route,
+        invalidPort: !validPort,
+        listening: validPort ? await isPortListening(route.port) : false,
+      };
+    })
   );
-  for (const { route, listening } of routePortChecks) {
+  for (const { route, invalidPort, listening } of routePortChecks) {
+    if (invalidPort) {
+      add(
+        "warn",
+        `Route ${route.hostname} has invalid port ${route.port}.`,
+        route.pid === 0 ? "Remove or recreate the alias." : "Run: portless prune"
+      );
+      continue;
+    }
     if (listening) continue;
     add(
       "warn",

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -59,6 +59,7 @@ import {
   isWindows,
   killTree,
   readLanMarker,
+  readCustomCertMarker,
   readPersistedProxyState,
   readTldFromDir,
   readTlsMarker,
@@ -67,6 +68,7 @@ import {
   augmentedPath,
   validateTld,
   waitForProxy,
+  writeCustomCertMarker,
   writeLanMarker,
   writeTldFile,
   writeTlsMarker,
@@ -432,7 +434,8 @@ function startProxyServer(
   tld: string,
   tlsOptions?: { cert: Buffer; key: Buffer },
   lanIp?: string | null,
-  strict?: boolean
+  strict?: boolean,
+  customCert = false
 ): void {
   store.ensureDir();
 
@@ -592,6 +595,7 @@ function startProxyServer(
     fs.writeFileSync(store.pidPath, process.pid.toString(), { mode: FILE_MODE });
     fs.writeFileSync(store.portFilePath, proxyPort.toString(), { mode: FILE_MODE });
     writeTlsMarker(store.dir, isTls);
+    writeCustomCertMarker(store.dir, isTls && customCert);
     writeTldFile(store.dir, tld);
     writeLanMarker(store.dir, activeLanIp);
     fixOwnership(store.dir, store.pidPath, store.portFilePath);
@@ -604,7 +608,7 @@ function startProxyServer(
     if (activeLanIp) {
       console.log(chalk.green(`LAN mode: ${activeLanIp}`));
       console.log(chalk.gray("Services are discoverable as <name>.local on your network"));
-      if (isTls) {
+      if (isTls && !customCert) {
         console.log(chalk.yellow("For HTTPS on devices, install the CA certificate:"));
         console.log(chalk.gray(`  ${path.join(store.dir, "ca.pem")}`));
       }
@@ -650,6 +654,7 @@ function startProxyServer(
       // Port file may already be removed; non-fatal
     }
     writeTlsMarker(store.dir, false);
+    writeCustomCertMarker(store.dir, false);
     writeTldFile(store.dir, DEFAULT_TLD);
     writeLanMarker(store.dir, null);
     if (autoSyncHosts) cleanHostsFile();
@@ -702,6 +707,7 @@ async function stopProxy(store: RouteStore, proxyPort: number, _tls: boolean): P
             // Port file may already be absent; non-fatal
           }
           writeTlsMarker(store.dir, false);
+          writeCustomCertMarker(store.dir, false);
           writeTldFile(store.dir, DEFAULT_TLD);
           writeLanMarker(store.dir, null);
           console.log(colors.green(`Killed process ${pid}. Proxy stopped.`));
@@ -742,6 +748,7 @@ async function stopProxy(store: RouteStore, proxyPort: number, _tls: boolean): P
       console.error(colors.red("Corrupted PID file. Removing it."));
       fs.unlinkSync(pidPath);
       writeTlsMarker(store.dir, false);
+      writeCustomCertMarker(store.dir, false);
       writeTldFile(store.dir, DEFAULT_TLD);
       writeLanMarker(store.dir, null);
       return;
@@ -763,6 +770,7 @@ async function stopProxy(store: RouteStore, proxyPort: number, _tls: boolean): P
         // Port file may already be absent; non-fatal
       }
       writeTlsMarker(store.dir, false);
+      writeCustomCertMarker(store.dir, false);
       writeTldFile(store.dir, DEFAULT_TLD);
       writeLanMarker(store.dir, null);
       return;
@@ -780,6 +788,7 @@ async function stopProxy(store: RouteStore, proxyPort: number, _tls: boolean): P
       console.log(colors.yellow("Removing stale PID file."));
       fs.unlinkSync(pidPath);
       writeTlsMarker(store.dir, false);
+      writeCustomCertMarker(store.dir, false);
       writeTldFile(store.dir, DEFAULT_TLD);
       writeLanMarker(store.dir, null);
       return;
@@ -793,6 +802,7 @@ async function stopProxy(store: RouteStore, proxyPort: number, _tls: boolean): P
       // Port file may already be removed; non-fatal
     }
     writeTlsMarker(store.dir, false);
+    writeCustomCertMarker(store.dir, false);
     writeTldFile(store.dir, DEFAULT_TLD);
     writeLanMarker(store.dir, null);
     console.log(colors.green("Proxy stopped."));
@@ -2355,6 +2365,7 @@ ${colors.bold("Options:")}
   const proxyPort = proxyRunning || portListening || hasPortFile ? probePort : configuredPort;
   const proxyTls = proxyRunning || portListening || hasPortFile ? probeTls : configuredTls;
   const currentProxyStateIsHttp = (proxyRunning || portListening || hasPortFile) && !proxyTls;
+  const proxyUsesCustomCert = proxyTls && readCustomCertMarker(state.dir);
   const stateExists = fs.existsSync(state.dir);
 
   console.log(colors.blue.bold("\nportless doctor\n"));
@@ -2447,7 +2458,9 @@ ${colors.bold("Options:")}
     add("warn", `Proxy is running but the PID file is missing: ${store.pidPath}`);
   }
 
-  if (proxyTls || (!currentProxyStateIsHttp && !isHttpsEnvDisabled())) {
+  if (proxyUsesCustomCert) {
+    add("ok", "Proxy is configured with a custom TLS certificate.");
+  } else if (proxyTls || (!currentProxyStateIsHttp && !isHttpsEnvDisabled())) {
     if (checkCommandAvailable("openssl", ["version"])) {
       add("ok", "OpenSSL is available for certificate generation.");
     } else {
@@ -2463,7 +2476,9 @@ ${colors.bold("Options:")}
     add("info", "HTTPS is disabled, so OpenSSL is not required for this run.");
   }
 
-  if (proxyTls) {
+  if (proxyTls && proxyUsesCustomCert) {
+    add("info", "Generated local CA is not required for custom TLS certificates.");
+  } else if (proxyTls) {
     const caPath = path.join(state.dir, "ca.pem");
     if (fs.existsSync(caPath)) {
       if (isCATrusted(state.dir)) {
@@ -3035,7 +3050,15 @@ ${colors.bold("LAN mode (--lan):")}
   // Foreground mode: run the proxy directly in this process
   if (isForeground) {
     console.log(chalk.blue.bold("\nportless proxy\n"));
-    startProxyServer(store, proxyPort, tld, tlsOptions, lanIp, desiredWildcard ? false : undefined);
+    startProxyServer(
+      store,
+      proxyPort,
+      tld,
+      tlsOptions,
+      lanIp,
+      desiredWildcard ? false : undefined,
+      !!(customCertPath && customKeyPath)
+    );
     return;
   }
 

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -2354,6 +2354,7 @@ ${colors.bold("Options:")}
   const portListening = proxyRunning ? true : await isPortListening(probePort);
   const proxyPort = proxyRunning || portListening || hasPortFile ? probePort : configuredPort;
   const proxyTls = proxyRunning || portListening || hasPortFile ? probeTls : configuredTls;
+  const currentProxyStateIsHttp = (proxyRunning || portListening || hasPortFile) && !proxyTls;
   const stateExists = fs.existsSync(state.dir);
 
   console.log(colors.blue.bold("\nportless doctor\n"));
@@ -2418,10 +2419,25 @@ ${colors.bold("Options:")}
       const pid = parseInt(rawPid, 10);
       if (isNaN(pid) || pid <= 0) {
         add("fail", `Proxy PID file is invalid: ${store.pidPath}`);
-      } else if (isProcessAliveForDoctor(pid)) {
-        add("ok", `Proxy PID file points to a running process: ${pid}`);
-      } else {
+      } else if (!isProcessAliveForDoctor(pid)) {
         add("warn", `Proxy PID file is stale: ${pid}`, "Run: portless proxy stop");
+      } else if (!proxyRunning) {
+        add(
+          "warn",
+          `Proxy PID file points to PID ${pid}, but no portless proxy is responding on port ${proxyPort}.`,
+          "Run: portless proxy stop"
+        );
+      } else {
+        const portPid = findPidOnPort(proxyPort);
+        if (portPid !== null && portPid !== pid) {
+          add(
+            "warn",
+            `Proxy PID file points to PID ${pid}, but port ${proxyPort} is owned by PID ${portPid}.`,
+            "Run: portless proxy stop"
+          );
+        } else {
+          add("ok", `Proxy PID file points to the responding proxy process: ${pid}`);
+        }
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -2431,7 +2447,7 @@ ${colors.bold("Options:")}
     add("warn", `Proxy is running but the PID file is missing: ${store.pidPath}`);
   }
 
-  if (proxyTls || !isHttpsEnvDisabled()) {
+  if (proxyTls || (!currentProxyStateIsHttp && !isHttpsEnvDisabled())) {
     if (checkCommandAvailable("openssl", ["version"])) {
       add("ok", "OpenSSL is available for certificate generation.");
     } else {

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -2284,6 +2284,16 @@ function checkPathWritable(targetPath: string): boolean {
   }
 }
 
+function findExistingAncestor(targetPath: string): string | null {
+  let current = targetPath;
+  for (;;) {
+    if (fs.existsSync(current)) return current;
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
 function checkCommandAvailable(command: string, args: string[]): boolean {
   const result = spawnSync(command, args, {
     stdio: "ignore",
@@ -2404,11 +2414,21 @@ ${colors.bold("Options:")}
       add("fail", `Could not inspect state directory: ${message}`);
     }
   } else {
-    const parentDir = path.dirname(state.dir);
-    if (checkPathWritable(parentDir)) {
-      add("info", `State directory has not been created yet: ${state.dir}`);
+    const ancestor = findExistingAncestor(path.dirname(state.dir));
+    if (!ancestor) {
+      add(
+        "fail",
+        `State directory does not exist and no writable ancestor was found: ${state.dir}`
+      );
     } else {
-      add("fail", `State directory does not exist and parent is not writable: ${parentDir}`);
+      const ancestorStat = fs.statSync(ancestor);
+      if (!ancestorStat.isDirectory()) {
+        add("fail", `State directory does not exist and ancestor is not a directory: ${ancestor}`);
+      } else if (checkPathWritable(ancestor)) {
+        add("info", `State directory has not been created yet: ${state.dir}`);
+      } else {
+        add("fail", `State directory does not exist and ancestor is not writable: ${ancestor}`);
+      }
     }
   }
 

--- a/packages/portless/src/routes.ts
+++ b/packages/portless/src/routes.ts
@@ -265,13 +265,17 @@ export class RouteStore {
       try {
         parsed = JSON.parse(raw);
       } catch {
+        this.onWarning?.(`Corrupted routes file (invalid JSON): ${this.routesPath}`);
         return [];
       }
       if (!Array.isArray(parsed)) {
+        this.onWarning?.(`Corrupted routes file (expected array): ${this.routesPath}`);
         return [];
       }
       return parsed.filter(isValidRoute);
-    } catch {
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.onWarning?.(`Could not read routes file: ${message}`);
       return [];
     }
   }

--- a/packages/portless/src/utils.test.ts
+++ b/packages/portless/src/utils.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from "vitest";
-import { escapeHtml, formatUrl, isErrnoException, parseHostname } from "./utils.js";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { escapeHtml, formatUrl, isErrnoException, isProcessAlive, parseHostname } from "./utils.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("escapeHtml", () => {
   it("escapes angle brackets", () => {
@@ -54,6 +58,41 @@ describe("isErrnoException", () => {
     const err = new Error("fail");
     (err as unknown as Record<string, unknown>).code = 42;
     expect(isErrnoException(err)).toBe(false);
+  });
+});
+
+describe("isProcessAlive", () => {
+  it("returns true when signal 0 succeeds", () => {
+    vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    expect(isProcessAlive(123)).toBe(true);
+  });
+
+  it("treats EPERM as an alive process", () => {
+    const err = new Error("permission denied") as NodeJS.ErrnoException;
+    err.code = "EPERM";
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      throw err;
+    });
+
+    expect(isProcessAlive(123)).toBe(true);
+  });
+
+  it("returns false when the process does not exist", () => {
+    const err = new Error("missing") as NodeJS.ErrnoException;
+    err.code = "ESRCH";
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      throw err;
+    });
+
+    expect(isProcessAlive(123)).toBe(false);
+  });
+
+  it("returns false for non-positive PIDs", () => {
+    const spy = vi.spyOn(process, "kill");
+
+    expect(isProcessAlive(0)).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/portless/src/utils.ts
+++ b/packages/portless/src/utils.ts
@@ -30,6 +30,17 @@ export function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
   );
 }
 
+/** Return whether a process exists, treating permission denial as alive. */
+export function isProcessAlive(pid: number): boolean {
+  if (pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return isErrnoException(err) && err.code === "EPERM";
+  }
+}
+
 /**
  * Escape HTML special characters to prevent XSS.
  */

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -284,6 +284,7 @@ The chosen service configuration is written into launchd, systemd, or Task Sched
 | `portless get <name>`                  | Print URL for a service (for cross-service wiring)             |
 | `portless get <name> --no-worktree`    | Print URL without worktree prefix                              |
 | `portless list`                        | Show active routes                                             |
+| `portless doctor`                      | Check proxy, routes, DNS, CA trust, and LAN prerequisites      |
 | `portless trust`                       | Add local CA to system trust store (for HTTPS)                 |
 | `portless clean`                       | Remove state, CA trust entry, and /etc/hosts block             |
 | `portless prune`                       | Kill orphaned dev servers from crashed sessions                |
@@ -317,7 +318,7 @@ The chosen service configuration is written into launchd, systemd, or Task Sched
 | `portless run --help`                  | Show help for a subcommand (also: alias, hosts, clean)         |
 | `portless --version` / `-v`            | Show version                                                   |
 
-**Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `trust`, `clean`, `prune`, `proxy`, and `service` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name, or `portless --name <name> <cmd>` to force any name including reserved ones.
+**Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `doctor`, `trust`, `clean`, `prune`, `proxy`, and `service` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name, or `portless --name <name> <cmd>` to force any name including reserved ones.
 
 ## portless.json
 
@@ -351,6 +352,10 @@ An object supports all per-app fields (`name`, `script`, `appPort`, `proxy`):
 Precedence (closest wins): CLI flags > package.json `"portless"` key > portless.json app entry > defaults.
 
 ## Troubleshooting
+
+### Run diagnostics
+
+Use `portless doctor` first when local routing or HTTPS behavior looks wrong. It is read-only and checks Node.js, state directory permissions, proxy liveness, route entries, hostname resolution, local CA trust, and LAN mode prerequisites.
 
 ### Proxy not running
 


### PR DESCRIPTION
- Add read-only health diagnostics for proxy, routes, DNS, CA trust, and LAN prerequisites
- Document the doctor command in CLI help, README, docs, and the portless skill
- Cover doctor behavior with focused CLI tests