### PR TITLE
Add worktree name template config

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,14 +82,15 @@ Without an `apps` map, hostnames follow the `<package>.<project>.localhost` conv
 
 ### Config fields
 
-| Field     | Type    | Default  | Description                                               |
-| --------- | ------- | -------- | --------------------------------------------------------- |
-| `name`    | string  | inferred | Base app name. Worktree prefix still applies.             |
-| `script`  | string  | `"dev"`  | Name of a `package.json` script to run.                   |
-| `appPort` | number  | auto     | Fixed port for the child process.                         |
-| `proxy`   | boolean | auto     | Whether to route through the proxy. Auto-detected.        |
-| `apps`    | object  |          | Overrides for workspace packages, keyed by relative path. |
-| `turbo`   | boolean | `true`   | Set `false` to use direct spawning instead of turborepo.  |
+| Field                  | Type    | Default             | Description                                               |
+| ---------------------- | ------- | ------------------- | --------------------------------------------------------- |
+| `name`                 | string  | inferred            | Base app name. Worktree prefix still applies.             |
+| `script`               | string  | `"dev"`             | Name of a `package.json` script to run.                   |
+| `appPort`              | number  | auto                | Fixed port for the child process.                         |
+| `proxy`                | boolean | auto                | Whether to route through the proxy. Auto-detected.        |
+| `worktreeNameTemplate` | string  | `{worktree}.{name}` | Template used for linked worktree hostnames.              |
+| `apps`                 | object  |                     | Overrides for workspace packages, keyed by relative path. |
+| `turbo`                | boolean | `true`              | Set `false` to use direct spawning instead of turborepo.  |
 
 ### package.json "portless" key
 
@@ -102,7 +103,7 @@ Instead of a separate `portless.json`, you can add a `"portless"` key to your `p
 }
 ```
 
-An object supports all per-app fields (`name`, `script`, `appPort`, `proxy`):
+An object supports all per-app fields (`name`, `script`, `appPort`, `proxy`, `worktreeNameTemplate`):
 
 ```json
 {
@@ -197,6 +198,20 @@ portless run --name myapp next dev   # -> https://fix-ui.myapp.localhost
 ```
 
 Put `portless run` in your `package.json` once and it works everywhere. The main checkout uses the plain name, each worktree gets a unique subdomain. No collisions, no `--force`.
+
+Use `worktreeNameTemplate` when the branch label needs to appear somewhere other than the first subdomain. The template applies only to linked worktrees and supports `{name}` and `{worktree}` placeholders:
+
+```json
+{
+  "name": "tenant.app",
+  "worktreeNameTemplate": "tenant.{worktree}.app"
+}
+```
+
+```bash
+PORTLESS_TLD=test portless run next dev
+# -> https://tenant.fix-ui.app.test
+```
 
 ## Custom TLD
 

--- a/packages/portless/src/auto.test.ts
+++ b/packages/portless/src/auto.test.ts
@@ -8,6 +8,7 @@ import {
   truncateLabel,
   inferProjectName,
   detectWorktreePrefix,
+  applyWorktreeNameTemplate,
 } from "./auto.js";
 
 // ---------------------------------------------------------------------------
@@ -105,6 +106,32 @@ describe("truncateLabel", () => {
     expect(result.length).toBeLessThanOrEqual(63);
     // Should not have double hyphens from trailing-hyphen stripping + hash separator
     expect(result).not.toMatch(/--/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyWorktreeNameTemplate
+// ---------------------------------------------------------------------------
+
+describe("applyWorktreeNameTemplate", () => {
+  it("formats worktree names with default and custom templates", () => {
+    expect(applyWorktreeNameTemplate("myapp", "fix-ui")).toBe("fix-ui.myapp");
+    expect(
+      applyWorktreeNameTemplate(
+        "fronttest.labs.local.hunet",
+        "fix-ui",
+        "fronttest.{worktree}.labs.local.hunet"
+      )
+    ).toBe("fronttest.fix-ui.labs.local.hunet");
+    expect(applyWorktreeNameTemplate("myapp", "fix-ui", "{name}.{worktree}")).toBe("myapp.fix-ui");
+  });
+
+  it("truncates labels after placeholder replacement", () => {
+    const longWorktree = "feature-" + "a".repeat(80);
+    const result = applyWorktreeNameTemplate("myapp", longWorktree);
+
+    expect(result.split(".")[0].length).toBeLessThanOrEqual(63);
+    expect(result.endsWith(".myapp")).toBe(true);
   });
 });
 

--- a/packages/portless/src/auto.ts
+++ b/packages/portless/src/auto.ts
@@ -159,6 +159,21 @@ export interface WorktreePrefix {
   source: string;
 }
 
+const DEFAULT_WORKTREE_NAME_TEMPLATE = "{worktree}.{name}";
+
+export function applyWorktreeNameTemplate(
+  baseName: string,
+  worktreePrefix: string,
+  template = DEFAULT_WORKTREE_NAME_TEMPLATE
+): string {
+  return template
+    .replace(/\{name\}/g, baseName)
+    .replace(/\{worktree\}/g, worktreePrefix)
+    .split(".")
+    .map((label) => truncateLabel(label))
+    .join(".");
+}
+
 /** Branch names that represent the default/primary checkout — no prefix needed. */
 const DEFAULT_BRANCHES = new Set(["main", "master"]);
 

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -39,6 +39,7 @@ import {
   detectWorktreePrefix,
   truncateLabel,
   sanitizeForHostname,
+  applyWorktreeNameTemplate,
 } from "./auto.js";
 import {
   buildProxyStartConfig,
@@ -1007,7 +1008,12 @@ async function runApp(
   tls: boolean,
   tld: string,
   force: boolean,
-  autoInfo?: { nameSource: string; prefix?: string; prefixSource?: string },
+  autoInfo?: {
+    nameSource: string;
+    baseName?: string;
+    prefix?: string;
+    prefixSource?: string;
+  },
   desiredPort?: number,
   lanMode = false,
   lanIp?: string | null
@@ -1115,7 +1121,8 @@ async function runApp(
     console.log(chalk.gray(`-- ${hostname} (auto-resolves to 127.0.0.1)`));
   }
   if (autoInfo) {
-    const baseName = autoInfo.prefix ? name.slice(autoInfo.prefix.length + 1) : name;
+    const baseName =
+      autoInfo.baseName ?? (autoInfo.prefix ? name.slice(autoInfo.prefix.length + 1) : name);
     console.log(chalk.gray(`-- Name "${baseName}" (from ${autoInfo.nameSource})`));
     if (autoInfo.prefix) {
       console.log(chalk.gray(`-- Prefix "${autoInfo.prefix}" (from ${autoInfo.prefixSource})`));
@@ -2065,7 +2072,10 @@ ${colors.bold("Examples:")}
 
   const name = positional[0];
   const worktree = skipWorktree ? null : detectWorktreePrefix();
-  const effectiveName = worktree ? `${worktree.prefix}.${name}` : name;
+  const appConfig = worktree ? loadAppConfig() : null;
+  const effectiveName = worktree
+    ? applyWorktreeNameTemplate(name, worktree.prefix, appConfig?.worktreeNameTemplate)
+    : name;
 
   const { port, tls, tld } = await discoverState();
   const hostname = parseHostname(effectiveName, tld);
@@ -3258,7 +3268,9 @@ async function handleDefaultSingle(
   }
 
   const worktree = detectWorktreePrefix(cwd);
-  const effectiveName = worktree ? `${worktree.prefix}.${baseName}` : baseName;
+  const effectiveName = worktree
+    ? applyWorktreeNameTemplate(baseName, worktree.prefix, appConfig?.worktreeNameTemplate)
+    : baseName;
 
   const { dir, port, tls, tld, lanMode, lanIp } = await discoverState();
   const store = new RouteStore(dir, {
@@ -3273,7 +3285,12 @@ async function handleDefaultSingle(
     tls,
     tld,
     false,
-    { nameSource, prefix: worktree?.prefix, prefixSource: worktree?.source },
+    {
+      nameSource,
+      baseName,
+      prefix: worktree?.prefix,
+      prefixSource: worktree?.source,
+    },
     appConfig?.appPort,
     lanMode,
     lanIp
@@ -3859,7 +3876,9 @@ async function handleRunMode(args: string[], globalScript?: string): Promise<voi
   }
 
   const worktree = detectWorktreePrefix();
-  const effectiveName = worktree ? `${worktree.prefix}.${baseName}` : baseName;
+  const effectiveName = worktree
+    ? applyWorktreeNameTemplate(baseName, worktree.prefix, appConfig?.worktreeNameTemplate)
+    : baseName;
 
   const { dir, port, tls, tld, lanMode, lanIp } = await discoverState();
   const store = new RouteStore(dir, {
@@ -3874,7 +3893,12 @@ async function handleRunMode(args: string[], globalScript?: string): Promise<voi
     tls,
     tld,
     parsed.force,
-    { nameSource, prefix: worktree?.prefix, prefixSource: worktree?.source },
+    {
+      nameSource,
+      baseName,
+      prefix: worktree?.prefix,
+      prefixSource: worktree?.source,
+    },
     parsed.appPort,
     lanMode,
     lanIp

--- a/packages/portless/src/config.test.ts
+++ b/packages/portless/src/config.test.ts
@@ -119,7 +119,12 @@ describe("loadConfig", () => {
   });
 
   it("loads config with all fields", () => {
-    const config = { name: "myapp", script: "start", appPort: 3000 };
+    const config = {
+      name: "myapp",
+      script: "start",
+      appPort: 3000,
+      worktreeNameTemplate: "{name}.{worktree}",
+    };
     fs.writeFileSync(path.join(tmpDir, "portless.json"), JSON.stringify(config));
     const result = loadConfig(tmpDir);
     expect(result!.config).toEqual(config);
@@ -157,12 +162,16 @@ describe("loadConfig", () => {
   it("loads config from package.json portless key", () => {
     fs.writeFileSync(
       path.join(tmpDir, "package.json"),
-      JSON.stringify({ name: "test", portless: { name: "myapp", script: "dev" } })
+      JSON.stringify({
+        name: "test",
+        portless: { name: "myapp", script: "dev", worktreeNameTemplate: "{worktree}.{name}" },
+      })
     );
     const result = loadConfig(tmpDir);
     expect(result).not.toBeNull();
     expect(result!.config.name).toBe("myapp");
     expect(result!.config.script).toBe("dev");
+    expect(result!.config.worktreeNameTemplate).toBe("{worktree}.{name}");
     expect(result!.configDir).toBe(tmpDir);
   });
 
@@ -267,6 +276,17 @@ describe("loadConfig validation", () => {
     expect(() => loadConfig(tmpDir)).toThrow(ConfigValidationError);
   });
 
+  it("validates worktreeNameTemplate", () => {
+    for (const config of [
+      { worktreeNameTemplate: 42 },
+      { worktreeNameTemplate: "{name}.dev" },
+      { worktreeNameTemplate: "{branch}.{name}" },
+    ]) {
+      fs.writeFileSync(path.join(tmpDir, "portless.json"), JSON.stringify(config));
+      expect(() => loadConfig(tmpDir)).toThrow(ConfigValidationError);
+    }
+  });
+
   it("accepts turbo as a boolean", () => {
     fs.writeFileSync(
       path.join(tmpDir, "portless.json"),
@@ -306,9 +326,19 @@ describe("loadConfig validation", () => {
 
 describe("resolveAppConfig", () => {
   it("returns top-level fields when no apps key", () => {
-    const config = { name: "myapp", script: "dev" };
+    const config = {
+      name: "myapp",
+      script: "dev",
+      worktreeNameTemplate: "{name}.{worktree}",
+    };
     const result = resolveAppConfig(config, "/repo", "/repo");
-    expect(result).toEqual({ name: "myapp", script: "dev", appPort: undefined, proxy: undefined });
+    expect(result).toEqual({
+      name: "myapp",
+      script: "dev",
+      appPort: undefined,
+      proxy: undefined,
+      worktreeNameTemplate: "{name}.{worktree}",
+    });
   });
 
   it("returns proxy field from top-level config", () => {
@@ -320,11 +350,12 @@ describe("resolveAppConfig", () => {
   it("returns proxy field from apps entry", () => {
     const config = {
       apps: {
-        "apps/gen": { name: "gen", proxy: false },
+        "apps/gen": { name: "gen", proxy: false, worktreeNameTemplate: "{worktree}.{name}" },
       },
     };
     const result = resolveAppConfig(config, "/repo", "/repo/apps/gen");
     expect(result.proxy).toBe(false);
+    expect(result.worktreeNameTemplate).toBe("{worktree}.{name}");
   });
 
   it("matches exact path in apps map", () => {
@@ -479,10 +510,21 @@ describe("loadPackagePortlessConfig", () => {
   it("returns config from package.json portless key", () => {
     fs.writeFileSync(
       path.join(tmpDir, "package.json"),
-      JSON.stringify({ name: "test", portless: { name: "myapp", script: "start" } })
+      JSON.stringify({
+        name: "test",
+        portless: {
+          name: "myapp",
+          script: "start",
+          worktreeNameTemplate: "{name}.{worktree}",
+        },
+      })
     );
     const result = loadPackagePortlessConfig(tmpDir);
-    expect(result).toEqual({ name: "myapp", script: "start" });
+    expect(result).toEqual({
+      name: "myapp",
+      script: "start",
+      worktreeNameTemplate: "{name}.{worktree}",
+    });
   });
 
   it("returns config from string shorthand", () => {

--- a/packages/portless/src/config.ts
+++ b/packages/portless/src/config.ts
@@ -13,6 +13,7 @@ export interface AppConfig {
   script?: string;
   appPort?: number;
   proxy?: boolean;
+  worktreeNameTemplate?: string;
 }
 
 export interface PortlessConfig extends AppConfig {
@@ -125,7 +126,13 @@ export function resolveAppConfig(
     }
     return {};
   }
-  return { name: config.name, script: config.script, appPort: config.appPort, proxy: config.proxy };
+  return {
+    name: config.name,
+    script: config.script,
+    appPort: config.appPort,
+    proxy: config.proxy,
+    worktreeNameTemplate: config.worktreeNameTemplate,
+  };
 }
 
 /**
@@ -294,8 +301,17 @@ function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
   return err instanceof Error && "code" in err;
 }
 
-const KNOWN_TOP_KEYS = new Set(["name", "script", "appPort", "proxy", "apps", "turbo"]);
-const KNOWN_APP_KEYS = new Set(["name", "script", "appPort", "proxy"]);
+const KNOWN_TOP_KEYS = new Set([
+  "name",
+  "script",
+  "appPort",
+  "proxy",
+  "worktreeNameTemplate",
+  "apps",
+  "turbo",
+]);
+const KNOWN_APP_KEYS = new Set(["name", "script", "appPort", "proxy", "worktreeNameTemplate"]);
+const TEMPLATE_PLACEHOLDER_RE = /\{([^}]+)\}/g;
 
 function validateConfig(config: unknown, configPath: string): asserts config is PortlessConfig {
   if (typeof config !== "object" || config === null || Array.isArray(config)) {
@@ -334,6 +350,8 @@ function validateConfig(config: unknown, configPath: string): asserts config is 
       throw new ConfigValidationError(`"proxy" in ${configPath} must be a boolean.`);
     }
   }
+
+  validateWorktreeNameTemplate(obj.worktreeNameTemplate, "worktreeNameTemplate", configPath);
 
   if (obj.turbo !== undefined) {
     if (typeof obj.turbo !== "boolean") {
@@ -389,7 +407,32 @@ function validateAppConfig(obj: Record<string, unknown>, prefix: string, configP
     }
   }
 
+  validateWorktreeNameTemplate(
+    obj.worktreeNameTemplate,
+    `${prefix}.worktreeNameTemplate`,
+    configPath
+  );
+
   warnUnknownKeys(obj, KNOWN_APP_KEYS, configPath, prefix);
+}
+
+function validateWorktreeNameTemplate(value: unknown, label: string, configPath: string): void {
+  if (value === undefined) return;
+  if (typeof value !== "string" || !value.trim()) {
+    throw new ConfigValidationError(`"${label}" in ${configPath} must be a non-empty string.`);
+  }
+  if (!value.includes("{worktree}")) {
+    throw new ConfigValidationError(`"${label}" in ${configPath} must include "{worktree}".`);
+  }
+  for (const match of value.matchAll(TEMPLATE_PLACEHOLDER_RE)) {
+    const placeholder = match[1];
+    if (placeholder !== "name" && placeholder !== "worktree") {
+      throw new ConfigValidationError(
+        `"${label}" in ${configPath} contains unknown placeholder "{${placeholder}}". ` +
+          `Supported placeholders: "{name}", "{worktree}".`
+      );
+    }
+  }
 }
 
 function warnUnknownKeys(


### PR DESCRIPTION
## Summary
- add `worktreeNameTemplate` config for linked worktree hostname composition
- keep the existing default `{worktree}.{name}` behavior when the option is unset
- validate supported template placeholders and document the config in the README

## Why
Some local multi-tenant domains need the tenant label to remain first while the worktree label appears later in the hostname, for example `tenant.{worktree}.app.test` instead of `{worktree}.tenant.app.test`.

## Validation
- `pnpm --filter portless build`
- `pnpm --filter portless type-check`
- `pnpm --filter portless lint`
- `pnpm --filter portless test`
