### PR TITLE
feat: add worktree hostname template config

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,14 +84,25 @@ Without an `apps` map, hostnames follow the `<package>.<project>.localhost` conv
 
 ### Config fields
 
-| Field     | Type    | Default  | Description                                               |
-| --------- | ------- | -------- | --------------------------------------------------------- |
-| `name`    | string  | inferred | Base app name. Worktree prefix still applies.             |
-| `script`  | string  | `"dev"`  | Name of a `package.json` script to run.                   |
-| `appPort` | number  | auto     | Fixed port for the child process.                         |
-| `proxy`   | boolean | auto     | Whether to route through the proxy. Auto-detected.        |
-| `apps`    | object  |          | Overrides for workspace packages, keyed by relative path. |
-| `turbo`   | boolean | `true`   | Set `false` to use direct spawning instead of turborepo.  |
+| Field      | Type    | Default  | Description                                               |
+| ---------- | ------- | -------- | --------------------------------------------------------- |
+| `name`     | string  | inferred | Base app name. Worktree hostname rules still apply.       |
+| `script`   | string  | `"dev"`  | Name of a `package.json` script to run.                   |
+| `appPort`  | number  | auto     | Fixed port for the child process.                         |
+| `proxy`    | boolean | auto     | Whether to route through the proxy. Auto-detected.        |
+| `worktree` | object  |          | Git worktree hostname options.                            |
+| `apps`     | object  |          | Overrides for workspace packages, keyed by relative path. |
+| `turbo`    | boolean | `true`   | Set `false` to use direct spawning instead of turborepo.  |
+
+Use `worktree.hostnameTemplate` to place the worktree label somewhere other than the first subdomain:
+
+```json
+{
+  "worktree": {
+    "hostnameTemplate": "test.{worktree}-local.myapp"
+  }
+}
+```
 
 ### package.json "portless" key
 
@@ -104,7 +115,7 @@ Instead of a separate `portless.json`, you can add a `"portless"` key to your `p
 }
 ```
 
-An object supports all per-app fields (`name`, `script`, `appPort`, `proxy`):
+An object supports all per-app fields (`name`, `script`, `appPort`, `proxy`, `worktree`):
 
 ```json
 {
@@ -192,13 +203,27 @@ portless run next dev   # -> https://myapp.localhost
 portless run next dev   # -> https://fix-ui.myapp.localhost
 ```
 
-Use `--name` to override the inferred base name while keeping the worktree prefix:
+Use `--name` to override the inferred base name while keeping worktree hostname rules:
 
 ```bash
 portless run --name myapp next dev   # -> https://fix-ui.myapp.localhost
 ```
 
 Put `portless run` in your `package.json` once and it works everywhere. The main checkout uses the plain name, each worktree gets a unique subdomain. No collisions, no `--force`.
+
+If a project needs the worktree label somewhere other than the first subdomain, configure a hostname template:
+
+```json
+{
+  "portless": {
+    "worktree": {
+      "hostnameTemplate": "test.{worktree}-local.myapp"
+    }
+  }
+}
+```
+
+Then a linked worktree on branch `fix-ui` uses `https://test.fix-ui-local.myapp.localhost` by default, or `https://test.fix-ui-local.myapp.com` when the proxy TLD is `com`.
 
 ## Custom TLD
 

--- a/apps/docs/src/app/commands/page.mdx
+++ b/apps/docs/src/app/commands/page.mdx
@@ -23,7 +23,7 @@ portless run [--name <name>] [cmd] [args...]
 portless <name> <cmd> [args...]
 ```
 
-`portless run` infers the project name from `portless.json`, `package.json`, git root, or directory name. When no command is given, runs the configured script (default: `"dev"`) from `package.json`. Use `--name` to override the inferred name while still applying worktree prefixes.
+`portless run` infers the project name from `portless.json`, `package.json`, git root, or directory name. When no command is given, runs the configured script (default: `"dev"`) from `package.json`. Use `--name` to override the inferred name while still applying git worktree hostname rules.
 
 `portless <name>` uses an explicit name with no inference or prefixing.
 
@@ -46,7 +46,7 @@ portless docs.myapp next dev
   <tbody>
     <tr>
       <td>`--name <name>`</td>
-      <td>Override the inferred base name (worktree prefix still applies). Only for `portless run`.</td>
+      <td>Override the inferred base name (git worktree hostname rules still apply). Only for `portless run`.</td>
     </tr>
     <tr>
       <td>`--script <name>`</td>
@@ -93,7 +93,7 @@ Print the URL for a service. Useful for wiring services together in scripts or e
 BACKEND_URL=$(portless get backend)
 ```
 
-Applies worktree prefix detection by default. Use `--no-worktree` to skip it.
+Applies git worktree hostname rules by default. Use `--no-worktree` to skip them.
 
 ## Alias (static routes)
 
@@ -246,7 +246,7 @@ Uses `dns-sd` on macOS (built-in) and `avahi-publish-address` on Linux (`avahi-u
 
 **Framework notes:**
 
-- **Next.js**: Add `allowedDevOrigins: ['myapp.local', '*.myapp.local']` to `next.config.js` so LAN mode requests still work when portless adds a git worktree prefix.
+- **Next.js**: Add `allowedDevOrigins: ['myapp.local', '*.myapp.local']` to `next.config.js` so LAN mode requests still work with git worktree hostnames.
 - **Vite / React Router / SvelteKit / Astro**: Handled automatically via `__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS`.
 - **Expo / React Native**: Add `NSAllowsLocalNetworking` to your `app.json` for iOS ATS (see [Getting Started](/) for the `.localhost` equivalent using `NSExceptionDomains`):
 

--- a/apps/docs/src/app/configuration/page.mdx
+++ b/apps/docs/src/app/configuration/page.mdx
@@ -60,6 +60,12 @@ The name is inferred from `package.json` if not set in config. The script defaul
       </td>
     </tr>
     <tr>
+      <td>`worktree`</td>
+      <td>object</td>
+      <td></td>
+      <td>Git worktree hostname options.</td>
+    </tr>
+    <tr>
       <td>`apps`</td>
       <td>object</td>
       <td></td>
@@ -74,6 +80,16 @@ The name is inferred from `package.json` if not set in config. The script defaul
   </tbody>
 </table>
 
+Use `worktree.hostnameTemplate` to place the worktree label somewhere other than the first subdomain:
+
+```json
+{
+  "worktree": {
+    "hostnameTemplate": "test.{worktree}-local.myapp"
+  }
+}
+```
+
 Each `apps` entry has the same shape (`name`, `script`, `appPort`, `proxy`). When `apps` is present, top-level fields apply only in single-app mode.
 
 ### package.json "portless" key
@@ -87,7 +103,7 @@ Instead of a separate `portless.json`, you can add a `"portless"` key to your `p
 }
 ```
 
-An object supports all per-app fields (`name`, `script`, `appPort`, `proxy`):
+An object supports all per-app fields (`name`, `script`, `appPort`, `proxy`, `worktree`):
 
 ```json
 {

--- a/apps/docs/src/app/page.mdx
+++ b/apps/docs/src/app/page.mdx
@@ -95,11 +95,25 @@ portless run next dev   # -> https://fix-ui.myapp.localhost
 
 Put `portless run` in your `package.json` once and it works everywhere. The main checkout uses the plain name, each worktree gets a unique subdomain. No collisions, no `--force`.
 
-Use `--name` to override the inferred base name while keeping the worktree prefix:
+Use `--name` to override the inferred base name while keeping worktree hostname rules:
 
 ```bash
 portless run --name myapp next dev   # -> https://fix-ui.myapp.localhost
 ```
+
+If a project needs the worktree label somewhere other than the first subdomain, configure a hostname template:
+
+```json
+{
+  "portless": {
+    "worktree": {
+      "hostnameTemplate": "test.{worktree}-local.myapp"
+    }
+  }
+}
+```
+
+Then a linked worktree on branch `fix-ui` uses `https://test.fix-ui-local.myapp.localhost`.
 
 ## Custom TLD
 

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -1391,6 +1391,27 @@ describe("CLI", () => {
       expect(stdout.trim()).toMatch(/^https?:\/\/backend\.localhost(:\d+)?$/);
     });
 
+    it("uses configured worktree hostname template", () => {
+      const gitdir = path.join(tmpDir, "fake.git", "worktrees", "wt");
+      fs.mkdirSync(gitdir, { recursive: true });
+      fs.writeFileSync(path.join(gitdir, "HEAD"), "ref: refs/heads/portless-worktree-test\n");
+      fs.writeFileSync(path.join(tmpDir, ".git"), `gitdir: ${gitdir}\n`);
+      fs.writeFileSync(
+        path.join(tmpDir, "portless.json"),
+        JSON.stringify({ worktree: { hostnameTemplate: "test.{worktree}-local.myapp" } })
+      );
+
+      const { status, stdout } = run(["get", "test.local.myapp"], {
+        cwd: tmpDir,
+        env: getEnv(),
+      });
+
+      expect(status).toBe(0);
+      expect(stdout.trim()).toMatch(
+        /^https?:\/\/test\.portless-worktree-test-local\.myapp\.localhost(:\d+)?$/
+      );
+    });
+
     it("exits 1 for invalid hostname", () => {
       const { status, stderr } = run(["get", "my@app"]);
       expect(status).toBe(1);

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -107,6 +107,7 @@ import {
   detectPackageManager,
   loadPackagePortlessConfig,
   ConfigValidationError,
+  WORKTREE_PLACEHOLDER,
 } from "./config.js";
 import type { AppConfig } from "./config.js";
 import { findWorkspaceRoot, discoverWorkspacePackages } from "./workspace.js";
@@ -162,6 +163,16 @@ type ProxyConfig = {
   tlds: string[];
   useWildcard: boolean;
 };
+
+function resolveWorktreeName(
+  name: string,
+  worktree: { prefix: string },
+  hostnameTemplate?: string
+): string {
+  return hostnameTemplate
+    ? hostnameTemplate.replaceAll(WORKTREE_PLACEHOLDER, worktree.prefix)
+    : `${worktree.prefix}.${name}`;
+}
 
 function normalizeTlds(tlds: readonly string[]): string[] {
   return [...new Set(tlds.length > 0 ? tlds : [DEFAULT_TLD])];
@@ -1616,7 +1627,7 @@ ${colors.bold("Usage:")}
   from package.json.
 
 ${colors.bold("Options:")}
-  --name <name>          Override the inferred base name (worktree prefix still applies)
+  --name <name>          Override the inferred base name (worktree hostname rules still apply)
   --force                Kill the existing process and take over its route
   --app-port <number>    Use a fixed port for the app (skip auto-assignment)
   --tailscale            Share the app on your Tailscale network (tailnet)
@@ -1630,8 +1641,8 @@ ${colors.bold("Name inference (in order):")}
   3. Git repo root directory name
   4. Current directory basename
 
-  Use --name to override the inferred name while keeping worktree prefixes.
-  In git worktrees, the branch name is prepended as a subdomain prefix
+  Use --name to override the inferred name while keeping worktree hostname rules.
+  In git worktrees, the branch name distinguishes hostnames by default
   (e.g. feature-auth.myapp.localhost).
 
 ${colors.bold("Examples:")}
@@ -1867,7 +1878,7 @@ ${colors.bold("ngrok sharing:")}
 
 ${colors.bold("Options:")}
   run [--name <name>] <cmd>      Infer project name (or override with --name)
-                                Adds worktree prefix in git worktrees
+                                Applies git worktree hostname rules
   --script <name>               Run a specific package.json script (default: dev)
   -p, --port <number>           Port for the proxy (default: 443, or 80 with --no-tls)
                                 Standard ports auto-elevate with sudo on macOS/Linux
@@ -2209,7 +2220,7 @@ together:
   BACKEND_URL=$(portless get backend)
 
 ${colors.bold("Options:")}
-  --no-worktree          Skip worktree prefix detection
+  --no-worktree          Skip git worktree hostname handling
   --help, -h             Show this help
 
 ${colors.bold("Examples:")}
@@ -2245,8 +2256,10 @@ ${colors.bold("Examples:")}
   }
 
   const name = positional[0];
+  const appConfig = loadAppConfig();
   const worktree = skipWorktree ? null : detectWorktreePrefix();
-  const effectiveName = worktree ? `${worktree.prefix}.${name}` : name;
+  const hostnameTemplate = appConfig?.worktree?.hostnameTemplate;
+  const effectiveName = worktree ? resolveWorktreeName(name, worktree, hostnameTemplate) : name;
 
   const { port, tls, tlds } = await discoverState();
   const hostname = buildHostnames(effectiveName, tlds)[0]!;
@@ -3463,7 +3476,10 @@ async function handleDefaultSingle(
   }
 
   const worktree = detectWorktreePrefix(cwd);
-  const effectiveName = applyWorktreePrefix(baseName, worktree);
+  const hostnameTemplate = appConfig?.worktree?.hostnameTemplate;
+  const effectiveName = worktree
+    ? resolveWorktreeName(baseName, worktree, hostnameTemplate)
+    : baseName;
 
   const { dir, port, tls, tlds, lanMode, lanIp } = await discoverState();
   const store = new RouteStore(dir, {
@@ -3478,7 +3494,11 @@ async function handleDefaultSingle(
     tls,
     tlds,
     false,
-    { nameSource, prefix: worktree?.prefix, prefixSource: worktree?.source },
+    {
+      nameSource,
+      prefix: hostnameTemplate ? undefined : worktree?.prefix,
+      prefixSource: hostnameTemplate ? undefined : worktree?.source,
+    },
     appConfig?.appPort,
     lanMode,
     lanIp
@@ -4057,7 +4077,10 @@ async function handleRunMode(args: string[], globalScript?: string): Promise<voi
   }
 
   const worktree = detectWorktreePrefix();
-  const effectiveName = worktree ? `${worktree.prefix}.${baseName}` : baseName;
+  const hostnameTemplate = appConfig?.worktree?.hostnameTemplate;
+  const effectiveName = worktree
+    ? resolveWorktreeName(baseName, worktree, hostnameTemplate)
+    : baseName;
 
   const { dir, port, tls, tlds, lanMode, lanIp } = await discoverState();
   const store = new RouteStore(dir, {
@@ -4072,7 +4095,11 @@ async function handleRunMode(args: string[], globalScript?: string): Promise<voi
     tls,
     tlds,
     parsed.force,
-    { nameSource, prefix: worktree?.prefix, prefixSource: worktree?.source },
+    {
+      nameSource,
+      prefix: hostnameTemplate ? undefined : worktree?.prefix,
+      prefixSource: hostnameTemplate ? undefined : worktree?.source,
+    },
     parsed.appPort,
     lanMode,
     lanIp

--- a/packages/portless/src/config.test.ts
+++ b/packages/portless/src/config.test.ts
@@ -134,6 +134,17 @@ describe("loadConfig", () => {
     expect(result!.config.proxy).toBe(false);
   });
 
+  it("loads config with worktree hostname template", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "portless.json"),
+      JSON.stringify({ worktree: { hostnameTemplate: "test.{worktree}-local.myapp" } })
+    );
+    const result = loadConfig(tmpDir);
+    expect(result!.config.worktree).toEqual({
+      hostnameTemplate: "test.{worktree}-local.myapp",
+    });
+  });
+
   it("loads config with apps map", () => {
     const config = {
       apps: {
@@ -157,12 +168,22 @@ describe("loadConfig", () => {
   it("loads config from package.json portless key", () => {
     fs.writeFileSync(
       path.join(tmpDir, "package.json"),
-      JSON.stringify({ name: "test", portless: { name: "myapp", script: "dev" } })
+      JSON.stringify({
+        name: "test",
+        portless: {
+          name: "myapp",
+          script: "dev",
+          worktree: { hostnameTemplate: "test.{worktree}-local.myapp" },
+        },
+      })
     );
     const result = loadConfig(tmpDir);
     expect(result).not.toBeNull();
     expect(result!.config.name).toBe("myapp");
     expect(result!.config.script).toBe("dev");
+    expect(result!.config.worktree).toEqual({
+      hostnameTemplate: "test.{worktree}-local.myapp",
+    });
     expect(result!.configDir).toBe(tmpDir);
   });
 
@@ -267,6 +288,14 @@ describe("loadConfig validation", () => {
     expect(() => loadConfig(tmpDir)).toThrow(ConfigValidationError);
   });
 
+  it("throws when worktree hostnameTemplate omits worktree placeholder", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "portless.json"),
+      JSON.stringify({ worktree: { hostnameTemplate: "test.local.myapp" } })
+    );
+    expect(() => loadConfig(tmpDir)).toThrow(ConfigValidationError);
+  });
+
   it("accepts turbo as a boolean", () => {
     fs.writeFileSync(
       path.join(tmpDir, "portless.json"),
@@ -308,7 +337,13 @@ describe("resolveAppConfig", () => {
   it("returns top-level fields when no apps key", () => {
     const config = { name: "myapp", script: "dev" };
     const result = resolveAppConfig(config, "/repo", "/repo");
-    expect(result).toEqual({ name: "myapp", script: "dev", appPort: undefined, proxy: undefined });
+    expect(result).toEqual({
+      name: "myapp",
+      script: "dev",
+      appPort: undefined,
+      proxy: undefined,
+      worktree: undefined,
+    });
   });
 
   it("returns proxy field from top-level config", () => {

--- a/packages/portless/src/config.ts
+++ b/packages/portless/src/config.ts
@@ -13,6 +13,11 @@ export interface AppConfig {
   script?: string;
   appPort?: number;
   proxy?: boolean;
+  worktree?: WorktreeConfig;
+}
+
+export interface WorktreeConfig {
+  hostnameTemplate?: string;
 }
 
 export interface PortlessConfig extends AppConfig {
@@ -26,6 +31,7 @@ export interface LoadedConfig {
 }
 
 const CONFIG_FILENAME = "portless.json";
+export const WORKTREE_PLACEHOLDER = "{worktree}";
 
 /**
  * Load portless config from `cwd`. Checks `portless.json` first, then
@@ -125,7 +131,13 @@ export function resolveAppConfig(
     }
     return {};
   }
-  return { name: config.name, script: config.script, appPort: config.appPort, proxy: config.proxy };
+  return {
+    name: config.name,
+    script: config.script,
+    appPort: config.appPort,
+    proxy: config.proxy,
+    worktree: config.worktree,
+  };
 }
 
 /**
@@ -294,8 +306,9 @@ function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
   return err instanceof Error && "code" in err;
 }
 
-const KNOWN_TOP_KEYS = new Set(["name", "script", "appPort", "proxy", "apps", "turbo"]);
-const KNOWN_APP_KEYS = new Set(["name", "script", "appPort", "proxy"]);
+const KNOWN_TOP_KEYS = new Set(["name", "script", "appPort", "proxy", "worktree", "apps", "turbo"]);
+const KNOWN_APP_KEYS = new Set(["name", "script", "appPort", "proxy", "worktree"]);
+const KNOWN_WORKTREE_KEYS = new Set(["hostnameTemplate"]);
 
 function validateConfig(config: unknown, configPath: string): asserts config is PortlessConfig {
   if (typeof config !== "object" || config === null || Array.isArray(config)) {
@@ -333,6 +346,10 @@ function validateConfig(config: unknown, configPath: string): asserts config is 
     if (typeof obj.proxy !== "boolean") {
       throw new ConfigValidationError(`"proxy" in ${configPath} must be a boolean.`);
     }
+  }
+
+  if (obj.worktree !== undefined) {
+    validateWorktreeConfig(obj.worktree, "worktree", configPath);
   }
 
   if (obj.turbo !== undefined) {
@@ -389,7 +406,33 @@ function validateAppConfig(obj: Record<string, unknown>, prefix: string, configP
     }
   }
 
+  if (obj.worktree !== undefined) {
+    validateWorktreeConfig(obj.worktree, `${prefix}.worktree`, configPath);
+  }
+
   warnUnknownKeys(obj, KNOWN_APP_KEYS, configPath, prefix);
+}
+
+function validateWorktreeConfig(value: unknown, prefix: string, configPath: string): void {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new ConfigValidationError(`"${prefix}" in ${configPath} must be an object.`);
+  }
+
+  const obj = value as Record<string, unknown>;
+  if (obj.hostnameTemplate !== undefined) {
+    if (typeof obj.hostnameTemplate !== "string" || !obj.hostnameTemplate.trim()) {
+      throw new ConfigValidationError(
+        `"${prefix}.hostnameTemplate" in ${configPath} must be a non-empty string.`
+      );
+    }
+    if (!obj.hostnameTemplate.includes(WORKTREE_PLACEHOLDER)) {
+      throw new ConfigValidationError(
+        `"${prefix}.hostnameTemplate" in ${configPath} must include "${WORKTREE_PLACEHOLDER}".`
+      );
+    }
+  }
+
+  warnUnknownKeys(obj, KNOWN_WORKTREE_KEYS, configPath, prefix);
 }
 
 function warnUnknownKeys(

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -147,6 +147,18 @@ portless run next dev   # -> https://fix-ui.myapp.localhost
 
 No config changes needed. Put `portless run` in `package.json` once and it works in all worktrees.
 
+Use `worktree.hostnameTemplate` when the worktree label needs to appear somewhere else:
+
+```json
+{
+  "portless": {
+    "worktree": {
+      "hostnameTemplate": "test.{worktree}-local.myapp"
+    }
+  }
+}
+```
+
 ### Bypassing portless
 
 Set `PORTLESS=0` to run the command directly without the proxy:
@@ -285,10 +297,10 @@ The chosen service configuration is written into launchd, systemd, or Task Sched
 | `portless`                                        | From monorepo root: run all workspace packages                 |
 | `portless --script <name>`                        | Run a specific package.json script (default: dev)              |
 | `portless run [cmd] [args...]`                    | Infer name from project, run through proxy (auto-starts)       |
-| `portless run --name <name> <cmd>`                | Override inferred base name (worktree prefix still applies)    |
+| `portless run --name <name> <cmd>`                | Override inferred base name (worktree hostname rules apply)    |
 | `portless <name> <cmd> [args...]`                 | Run app at `https://<name>.localhost` (auto-starts proxy)      |
 | `portless get <name>`                             | Print URL for a service (for cross-service wiring)             |
-| `portless get <name> --no-worktree`               | Print URL without worktree prefix                              |
+| `portless get <name> --no-worktree`               | Print URL without worktree hostname handling                   |
 | `portless list`                                   | Show active routes                                             |
 | `portless doctor`                                 | Check proxy, routes, DNS, CA trust, and LAN prerequisites      |
 | `portless trust`                                  | Add local CA to system trust store (for HTTPS)                 |
@@ -332,14 +344,15 @@ The chosen service configuration is written into launchd, systemd, or Task Sched
 
 Optional config file. Portless looks for it in the current directory.
 
-| Field     | Type    | Default                    | Description                                              |
-| --------- | ------- | -------------------------- | -------------------------------------------------------- |
-| `name`    | string  | inferred from package.json | Base app name (worktree prefix still applies)            |
-| `script`  | string  | `"dev"`                    | Name of a package.json script to run                     |
-| `appPort` | number  | auto-assigned              | Fixed port for the child process                         |
-| `proxy`   | boolean | auto-detected              | Whether to route through the proxy (`false` for tasks)   |
-| `apps`    | object  |                            | Overrides for workspace packages, keyed by relative path |
-| `turbo`   | boolean | `true`                     | Set `false` to use direct spawning instead of turborepo  |
+| Field      | Type    | Default                    | Description                                              |
+| ---------- | ------- | -------------------------- | -------------------------------------------------------- |
+| `name`     | string  | inferred from package.json | Base app name (worktree hostname rules still apply)      |
+| `script`   | string  | `"dev"`                    | Name of a package.json script to run                     |
+| `appPort`  | number  | auto-assigned              | Fixed port for the child process                         |
+| `proxy`    | boolean | auto-detected              | Whether to route through the proxy (`false` for tasks)   |
+| `worktree` | object  |                            | Git worktree hostname options                            |
+| `apps`     | object  |                            | Overrides for workspace packages, keyed by relative path |
+| `turbo`    | boolean | `true`                     | Set `false` to use direct spawning instead of turborepo  |
 
 Each `apps` entry has the same shape (`name`, `script`, `appPort`, `proxy`). When `apps` is present, top-level fields apply only in single-app mode.
 
@@ -351,7 +364,7 @@ Instead of a separate `portless.json`, you can add a `"portless"` key to your `p
 { "portless": "myapp" }
 ```
 
-An object supports all per-app fields (`name`, `script`, `appPort`, `proxy`):
+An object supports all per-app fields (`name`, `script`, `appPort`, `proxy`, `worktree`):
 
 ```json
 { "portless": { "name": "myapp", "script": "dev:app" } }


### PR DESCRIPTION
## Summary

- Add `worktree.hostnameTemplate` to control linked worktree hostnames
- Keep the existing `<worktree>.<name>` behavior when no template is configured
- Apply the same hostname rules to `portless get`
- Document the new config in README.md, docs, and SKILL.md


## Problem

Portless currently puts the git worktree label at the front of linked worktree hostnames. That works for most apps, but some local environments use specific hostname segments to determine the app or tenant.

For example, a project may need:
```text
tenant.fix-ui.myapp.localhost
```
instead of:
```text
fix-ui.tenant.myapp.localhost
```

## Solution

- Add optional `worktree.hostnameTemplate` config
- Require the template to include `{worktree}` so linked worktree routes stay unique
- Replace `{worktree}` with the detected worktree label in linked worktrees
- Preserve the existing `<worktree>.<name>` behavior when no template is configured
- Use the same hostname rules in `portless run`, default `portless`, and `portless get`

Example:
```json
{
  "portless": {
    "worktree": {
      "hostnameTemplate": "tenant.{worktree}-local.myapp"
    }
  }
}
```

A linked worktree on branch fix-ui resolves to:
```text
https://tenant.fix-ui-local.myapp.localhost
```

## Documentation
- README.md: Added `worktree.hostnameTemplate` config docs and git worktree example
- Docs app: Added the config field and updated worktree hostname wording
- SKILL.md: Added usage guidance for custom worktree hostnames

## Test plan
- [x] `worktree.hostnameTemplate` loads from `portless.json`
- [x] `worktree.hostnameTemplate` loads from the package.json `portless` key
- [x] Config validation rejects templates without `{worktree}`
- [x] `portless get` applies the configured worktree hostname template
- [x] `pnpm --filter portless type-check`
- [x] `pnpm --filter portless build`