### PR TITLE
Quality: parseHostname silently produces malformed hostname for uppercase protocol prefixes

### DIFF
--- a/packages/portless/src/utils.ts
+++ b/packages/portless/src/utils.ts
@@ -76,7 +76,7 @@ export function parseHostname(input: string, tld = "localhost"): string {
   // Remove any protocol prefix
   let hostname = input
     .trim()
-    .replace(/^https?:\/\//, "")
+    .replace(/^https?:\/\//i, "")
     .split("/")[0]
     .toLowerCase();
 


### PR DESCRIPTION
## Problem

The regex /^https?:\/\// is case-sensitive and runs before .toLowerCase(). If input is "HTTP://myapp.localhost" or "HTTPS://myapp.localhost", the regex doesn't match, so split("/")[0] yields "HTTP:" or "HTTPS:", which after toLowerCase becomes "http:" or "https:". This passes the non-empty check, doesn't end with the TLD suffix, so the suffix is appended producing garbage like "http:.localhost". The function silently returns a malformed hostname instead of either stripping the prefix correctly or throwing a validation error.


**Severity**: `medium`
**File**: `packages/portless/src/utils.ts`

## Solution

Make the regex case-insensitive by adding the 'i' flag:
let hostname = input
  .trim()
  .replace(/^https?:\/\//i, "")
  .split("/")[0]
  .toLowerCase();


## Changes

- `packages/portless/src/utils.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
