### PR TITLE
Security: Unvalidated state directory environment variable enables arbitrary file deletion

### DIFF
--- a/packages/portless/src/clean-utils.ts
+++ b/packages/portless/src/clean-utils.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { LEGACY_SYSTEM_STATE_DIR, USER_STATE_DIR } from "./cli-utils.js";
 
@@ -38,7 +39,21 @@ export function collectStateDirsForCleanup(): string[] {
   };
   add(USER_STATE_DIR);
   add(LEGACY_SYSTEM_STATE_DIR);
-  add(process.env.PORTLESS_STATE_DIR);
+
+  const envDir = process.env.PORTLESS_STATE_DIR;
+  if (envDir) {
+    const trimmed = envDir.trim();
+    if (trimmed) {
+      const resolved = path.resolve(trimmed);
+      if (fs.existsSync(resolved)) {
+        const home = os.homedir();
+        if (resolved.startsWith(home + path.sep)) {
+          dirs.add(resolved);
+        }
+      }
+    }
+  }
+
   return [...dirs];
 }
 


### PR DESCRIPTION
## Problem

The `collectStateDirsForCleanup()` function includes `process.env.PORTLESS_STATE_DIR` as a directory to clean. While it trims and resolves the path, there's no validation that this points to an expected state directory structure. If an attacker can control this environment variable, they could point it to any directory on the system. Combined with `removePortlessStateFiles()` which deletes files with names from a hardcoded allowlist AND recursively removes a `host-certs` directory, this could enable deletion of sensitive files if the target directory contains files matching the allowlist (e.g., `routes.json`, `ca.pem`).

Real-world attack scenario: A shared development environment where environment variables are set from untrusted sources, or a supply chain attack that sets malicious environment variables. An attacker could set `PORTLESS_STATE_DIR=/etc` or another sensitive directory.

While the file deletion is limited to the allowlisted filenames, the `host-certs` directory removal is recursive and could delete nested contents.


**Severity**: `high`
**File**: `packages/portless/src/clean-utils.ts`

## Solution

Validate that the state directory path matches expected locations (e.g., contains `.portless` or is under the user's home directory):


## Changes

- `packages/portless/src/clean-utils.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
