### PR TITLE
Add multi-TLD proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ HTTPS with HTTP/2 is enabled by default. On first run, portless generates a loca
 
 The proxy auto-starts when you run an app. A random port (4000-4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, VitePlus, Astro, React Router, Angular, Expo, React Native), portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag.
 
-When auto-starting, portless reuses the configuration (port, TLS, TLD) from the most recent proxy run, so a restart or reboot does not silently revert to defaults. Explicit env vars (`PORTLESS_PORT`, `PORTLESS_HTTPS`, etc.) always take priority.
+When auto-starting, portless reuses the configuration (port, TLS, TLDs) from the most recent proxy run, so a restart or reboot does not silently revert to defaults. Explicit env vars (`PORTLESS_PORT`, `PORTLESS_HTTPS`, etc.) always take priority.
 
 In non-interactive environments (no TTY, or `CI=1`), portless exits with a descriptive error instead of prompting, so task runners like turborepo and CI scripts fail early with a clear message.
 
@@ -210,6 +210,17 @@ portless myapp next dev
 
 The proxy auto-syncs `/etc/hosts` for route hostnames (including `.test`), so those domains resolve on your machine.
 
+Repeat `--tld` to serve the same app names under multiple TLDs from one proxy:
+
+```bash
+portless proxy start --tld localhost --tld test
+portless myapp next dev
+# -> https://myapp.localhost
+# -> https://myapp.test
+```
+
+When multiple TLDs are configured, `PORTLESS_URL` uses the first TLD. `PORTLESS_TLD` also accepts a comma separated list, e.g. `PORTLESS_TLD=localhost,test`.
+
 Recommended: `.test` (IANA-reserved, no collision risk). Avoid `.local` (conflicts with mDNS/Bonjour) and `.dev` (Google-owned, forces HTTPS via HSTS).
 
 ## How it works
@@ -264,7 +275,7 @@ portless service uninstall
 
 The service uses portless defaults unless install options or `PORTLESS_*` environment variables are provided: HTTPS on port 443 with `.localhost` names. `service install` accepts the proxy options you would use with `proxy start`, including `--port`, `--no-tls`, `--lan`, `--ip`, `--tld`, `--wildcard`, `--cert`, and `--key`. Use `--state-dir <path>` or `PORTLESS_STATE_DIR=<path>` to choose where service state and logs are written.
 
-The chosen service configuration is written into launchd, systemd, or Task Scheduler and reused after reboot. `portless service status` reports the installed port, HTTPS mode, TLD, LAN mode, wildcard mode, and state directory. macOS and Linux install a root-owned service so port 443 can bind at boot. Windows installs a Task Scheduler startup task that runs as SYSTEM. Installation and removal may require administrator privileges. `portless clean` automatically removes the service.
+The chosen service configuration is written into launchd, systemd, or Task Scheduler and reused after reboot. `portless service status` reports the installed port, HTTPS mode, TLDs, LAN mode, wildcard mode, and state directory. macOS and Linux install a root-owned service so port 443 can bind at boot. Windows installs a Task Scheduler startup task that runs as SYSTEM. Installation and removal may require administrator privileges. `portless clean` automatically removes the service.
 
 ## LAN mode
 
@@ -276,7 +287,7 @@ portless proxy start --lan --ip 192.168.1.42
 
 `--lan` switches the proxy to mDNS discovery: services are advertised as `<name>.local` and reachable from any device on the same network. Portless auto-detects your LAN IP and follows Wi-Fi/IP changes automatically, but you can pin another address with `--ip <address>` or by exporting `PORTLESS_LAN_IP`. Set `PORTLESS_LAN=1` in your shell (0/1 boolean) to make LAN mode the default whenever the proxy starts.
 
-Portless remembers LAN mode via `proxy.lan`, so if you stop a LAN proxy and start it again, it stays in LAN mode. All proxy settings (port, TLS, TLD, LAN) are persisted and reused on auto-start unless overridden by explicit flags or env vars. Use `PORTLESS_LAN=0` for one start to switch back to `.localhost` mode. If a proxy is already running with different explicit LAN/TLS/TLD settings, portless warns and asks you to stop it first.
+Portless remembers LAN mode via `proxy.lan`, so if you stop a LAN proxy and start it again, it stays in LAN mode. All proxy settings (port, TLS, TLDs, LAN) are persisted and reused on auto-start unless overridden by explicit flags or env vars. Use `PORTLESS_LAN=0` for one start to switch back to `.localhost` mode. If a proxy is already running with different explicit LAN/TLS/TLD settings, portless warns and asks you to stop it first.
 
 LAN mode depends on the system mDNS tools that portless already spawns: macOS ships with `dns-sd`, while Linux uses `avahi-publish-address` from `avahi-utils` (install via `sudo apt install avahi-utils` or your distro’s equivalent). If the command is missing or your network isn’t reachable, `portless proxy start --lan` prints the relevant error and exits.
 
@@ -386,7 +397,7 @@ portless service uninstall       # Remove the startup service
 --cert <path>                    Use a custom TLS certificate
 --key <path>                     Use a custom TLS private key
 --foreground                     Run proxy in foreground instead of daemon
---tld <tld>                      Use a custom TLD instead of .localhost (e.g. test)
+--tld <tld>                      Use a custom TLD instead of .localhost; repeat for more
 --wildcard                       Allow unregistered subdomains to fall back to parent route
 --state-dir <path>               Use a custom state directory with service install
 --script <name>                  Run a specific package.json script (default: dev)
@@ -407,7 +418,7 @@ PORTLESS_APP_PORT=<number>       Use a fixed port for the app (same as --app-por
 PORTLESS_HTTPS=0                 Disable HTTPS (same as --no-tls)
 PORTLESS_LAN=1                   Enable LAN mode when set to 1 (auto-detects LAN IP)
 PORTLESS_LAN_IP=<address>        Pin a specific LAN IP for LAN mode
-PORTLESS_TLD=<tld>               Use a custom TLD (e.g. test; default: localhost)
+PORTLESS_TLD=<tld>[,<tld>]       Use one or more TLDs (e.g. localhost,test)
 PORTLESS_WILDCARD=1              Allow unregistered subdomains to fall back to parent route
 PORTLESS_SYNC_HOSTS=0            Disable auto-sync of /etc/hosts (on by default)
 PORTLESS_TAILSCALE=1             Share apps on your Tailscale network (same as --tailscale)
@@ -418,7 +429,7 @@ PORTLESS_STATE_DIR=<path>        Override the state directory
 # Injected into child processes
 PORT                             Ephemeral port the child should listen on
 HOST                             Usually 127.0.0.1 (omitted for Expo in LAN mode)
-PORTLESS_URL                     Public URL (e.g. https://myapp.localhost)
+PORTLESS_URL                     Primary public URL (e.g. https://myapp.localhost)
 PORTLESS_TAILSCALE_URL           Tailscale URL of the app (when --tailscale is active)
 PORTLESS_NGROK_URL               ngrok URL of the app (when --ngrok is active)
 NODE_EXTRA_CA_CERTS              Path to the portless CA (when HTTPS is active)

--- a/apps/docs/src/app/commands/page.mdx
+++ b/apps/docs/src/app/commands/page.mdx
@@ -190,7 +190,7 @@ portless proxy start
     </tr>
     <tr>
       <td>`--tld <tld>`</td>
-      <td>Use a custom TLD instead of `.localhost` (e.g. `test`). Hostnames still sync to `/etc/hosts` by default.</td>
+      <td>Use a custom TLD instead of `.localhost` (e.g. `test`). Repeat for more TLDs. Hostnames still sync to `/etc/hosts` by default.</td>
     </tr>
     <tr>
       <td>`--cert <path>`</td>
@@ -226,7 +226,7 @@ portless service uninstall
 
 Installs the proxy as an OS startup service. The default is HTTPS on port 443 with `.localhost` names, but `service install` accepts proxy options including `--port`, `--no-tls`, `--lan`, `--ip`, `--tld`, `--wildcard`, `--cert`, and `--key`. Use `--state-dir <path>` or `PORTLESS_STATE_DIR=<path>` to choose where service state and logs are written.
 
-The chosen service configuration is written into launchd, systemd, or Task Scheduler and reused after reboot. `portless service status` reports the installed port, HTTPS mode, TLD, LAN mode, wildcard mode, and state directory. macOS and Linux use a root-owned service so port 443 can bind at boot. Windows uses a Task Scheduler startup task that runs as SYSTEM. Installation and removal may require administrator privileges. `portless clean` automatically removes the service.
+The chosen service configuration is written into launchd, systemd, or Task Scheduler and reused after reboot. `portless service status` reports the installed port, HTTPS mode, TLDs, LAN mode, wildcard mode, and state directory. macOS and Linux use a root-owned service so port 443 can bind at boot. Windows uses a Task Scheduler startup task that runs as SYSTEM. Installation and removal may require administrator privileges. `portless clean` automatically removes the service.
 
 ### LAN mode
 

--- a/apps/docs/src/app/configuration/page.mdx
+++ b/apps/docs/src/app/configuration/page.mdx
@@ -177,7 +177,7 @@ For `appPort`: CLI `--app-port` flag > `PORTLESS_APP_PORT` env var > `package.js
     </tr>
     <tr>
       <td>`PORTLESS_TLD`</td>
-      <td>Use a custom TLD instead of `.localhost` (e.g. `test`)</td>
+      <td>Use one or more TLDs (e.g. `localhost,test`)</td>
       <td>`localhost`</td>
     </tr>
     <tr>

--- a/apps/docs/src/app/page.mdx
+++ b/apps/docs/src/app/page.mdx
@@ -113,6 +113,17 @@ portless myapp next dev
 
 The proxy auto-syncs `/etc/hosts` for route hostnames, so `.test` and other dev hostnames resolve on your machine.
 
+Repeat `--tld` to serve the same app names under multiple TLDs from one proxy:
+
+```bash
+portless proxy start --tld localhost --tld test
+portless myapp next dev
+# -> https://myapp.localhost
+# -> https://myapp.test
+```
+
+When multiple TLDs are configured, `PORTLESS_URL` uses the first TLD. `PORTLESS_TLD` accepts the same comma separated list format, e.g. `PORTLESS_TLD=localhost,test`.
+
 Recommended: `.test` (IANA-reserved, no collision risk). Avoid `.local` (conflicts with mDNS/Bonjour) and `.dev` (Google-owned, forces HTTPS via HSTS).
 
 ## How it works

--- a/packages/portless/src/certs.ts
+++ b/packages/portless/src/certs.ts
@@ -750,13 +750,14 @@ export function createSNICallback(
   stateDir: string,
   defaultCert: Buffer,
   defaultKey: Buffer,
-  tld = "localhost",
+  tlds: string | readonly string[] = "localhost",
   caCert?: Buffer
 ): (servername: string, cb: (err: Error | null, ctx?: tls.SecureContext) => void) => void {
   const cache = new Map<string, tls.SecureContext>();
   const pending = new Map<string, Promise<tls.SecureContext>>();
+  const configuredTlds = Array.isArray(tlds) ? tlds : [tlds];
 
-  // Pre-cache the default context for the bare TLD itself.
+  // Pre-cache the default context for the built-in localhost certificate.
   // Include the CA certificate so clients receive the full chain.
   const defaultCtx = tls.createSecureContext({
     cert: caCert ? Buffer.concat([defaultCert, caCert]) : defaultCert,
@@ -764,12 +765,12 @@ export function createSNICallback(
   });
 
   return (servername: string, cb: (err: Error | null, ctx?: tls.SecureContext) => void) => {
-    // The bare TLD (e.g. "localhost" or "test") uses the default cert.
+    // The bare localhost name uses the default cert.
     // All subdomains need a cert with an exact SAN entry.
     // For .localhost: RFC 2606 §2 designates it as a reserved TLD, so
     // "*.localhost" sits at the public-suffix boundary and TLS specs do
     // not permit wildcard certificates at that level.
-    if (servername === tld) {
+    if (servername === "localhost" && configuredTlds.includes("localhost")) {
       cb(null, defaultCtx);
       return;
     }

--- a/packages/portless/src/clean-utils.test.ts
+++ b/packages/portless/src/clean-utils.test.ts
@@ -37,6 +37,7 @@ describe("removePortlessStateFiles", () => {
     fs.writeFileSync(path.join(tmpDir, "ca.pem"), "pem");
     fs.writeFileSync(path.join(tmpDir, "proxy.port"), "443");
     fs.writeFileSync(path.join(tmpDir, "proxy.custom-cert"), "1");
+    fs.writeFileSync(path.join(tmpDir, "proxy.tlds"), "localhost\ntest\n");
     fs.mkdirSync(path.join(tmpDir, "host-certs"));
     fs.writeFileSync(path.join(tmpDir, "host-certs", "x.pem"), "x");
 
@@ -47,6 +48,7 @@ describe("removePortlessStateFiles", () => {
     expect(fs.existsSync(path.join(tmpDir, "routes.json"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, "ca.pem"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, "proxy.custom-cert"))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, "proxy.tlds"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, "host-certs"))).toBe(false);
     expect(fs.readFileSync(path.join(tmpDir, "user-notes.txt"), "utf-8")).toBe("keep me");
   });

--- a/packages/portless/src/clean-utils.ts
+++ b/packages/portless/src/clean-utils.ts
@@ -12,6 +12,7 @@ const PORTLESS_STATE_FILES = [
   "proxy.tls",
   "proxy.custom-cert",
   "proxy.tld",
+  "proxy.tlds",
   "proxy.lan",
   "ca-key.pem",
   "ca.pem",

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -18,18 +18,22 @@ import {
   findFreePort,
   getDefaultPort,
   getDefaultTld,
+  getDefaultTlds,
   getProtocolPort,
   isHttpsEnvDisabled,
   injectFrameworkFlags,
   isProxyRunning,
   parsePidFromNetstat,
+  parseTldList,
   readLanMarker,
   readPersistedProxyState,
   readTldFromDir,
+  readTldsFromDir,
   resolveStateDir,
   validateTld,
   writeLanMarker,
   writeTldFile,
+  writeTldsFile,
   writeTlsMarker,
 } from "./cli-utils.js";
 
@@ -761,6 +765,52 @@ describe("getDefaultTld", () => {
     process.env.PORTLESS_TLD = "";
     expect(getDefaultTld()).toBe(DEFAULT_TLD);
   });
+
+  it("returns the first TLD when PORTLESS_TLD contains a list", () => {
+    process.env.PORTLESS_TLD = "localhost,test";
+    expect(getDefaultTld()).toBe("localhost");
+  });
+});
+
+describe("getDefaultTlds", () => {
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env.PORTLESS_TLD;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.PORTLESS_TLD;
+    } else {
+      process.env.PORTLESS_TLD = originalEnv;
+    }
+  });
+
+  it("returns DEFAULT_TLD when PORTLESS_TLD is not set", () => {
+    delete process.env.PORTLESS_TLD;
+    expect(getDefaultTlds()).toEqual([DEFAULT_TLD]);
+  });
+
+  it("parses comma separated values", () => {
+    process.env.PORTLESS_TLD = "localhost, test";
+    expect(getDefaultTlds()).toEqual(["localhost", "test"]);
+  });
+
+  it("deduplicates values in order", () => {
+    process.env.PORTLESS_TLD = "test,localhost,test";
+    expect(getDefaultTlds()).toEqual(["test", "localhost"]);
+  });
+});
+
+describe("parseTldList", () => {
+  it("parses and normalizes values", () => {
+    expect(parseTldList(" TEST,localhost ")).toEqual(["test", "localhost"]);
+  });
+
+  it("rejects empty list entries", () => {
+    expect(() => parseTldList("test,")).toThrow("TLD cannot be empty");
+  });
 });
 
 describe("buildProxyStartConfig", () => {
@@ -779,6 +829,7 @@ describe("buildProxyStartConfig", () => {
       })
     ).toEqual({
       effectiveTld: "local",
+      effectiveTlds: ["local"],
       args: [
         "--foreground",
         "--port",
@@ -803,6 +854,7 @@ describe("buildProxyStartConfig", () => {
       })
     ).toEqual({
       effectiveTld: "local",
+      effectiveTlds: ["local"],
       args: ["--no-tls", "--lan", INTERNAL_LAN_IP_FLAG, "192.168.1.42"],
     });
   });
@@ -816,7 +868,23 @@ describe("buildProxyStartConfig", () => {
       })
     ).toEqual({
       effectiveTld: "test",
+      effectiveTlds: ["test"],
       args: ["--no-tls", "--tld", "test"],
+    });
+  });
+
+  it("emits each TLD outside LAN mode", () => {
+    expect(
+      buildProxyStartConfig({
+        useHttps: true,
+        lanMode: false,
+        tld: "localhost",
+        tlds: ["localhost", "test"],
+      })
+    ).toEqual({
+      effectiveTld: "localhost",
+      effectiveTlds: ["localhost", "test"],
+      args: ["--https", "--tld", "localhost", "--tld", "test"],
     });
   });
 });
@@ -884,11 +952,20 @@ describe("readTldFromDir / writeTldFile", () => {
 
   it("returns DEFAULT_TLD when file does not exist", () => {
     expect(readTldFromDir(tmpDir)).toBe(DEFAULT_TLD);
+    expect(readTldsFromDir(tmpDir)).toEqual([DEFAULT_TLD]);
   });
 
   it("writes and reads a custom TLD", () => {
     writeTldFile(tmpDir, "test");
     expect(readTldFromDir(tmpDir)).toBe("test");
+    expect(readTldsFromDir(tmpDir)).toEqual(["test"]);
+  });
+
+  it("writes and reads multiple TLDs", () => {
+    writeTldsFile(tmpDir, ["localhost", "test"]);
+    expect(readTldFromDir(tmpDir)).toBe("localhost");
+    expect(readTldsFromDir(tmpDir)).toEqual(["localhost", "test"]);
+    expect(fs.readFileSync(path.join(tmpDir, "proxy.tld"), "utf-8")).toBe("localhost");
   });
 
   it("removes the file when writing the default TLD", () => {
@@ -897,6 +974,7 @@ describe("readTldFromDir / writeTldFile", () => {
 
     writeTldFile(tmpDir, DEFAULT_TLD);
     expect(fs.existsSync(path.join(tmpDir, "proxy.tld"))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, "proxy.tlds"))).toBe(false);
     expect(readTldFromDir(tmpDir)).toBe(DEFAULT_TLD);
   });
 
@@ -983,6 +1061,16 @@ describe("readPersistedProxyState", () => {
     const state = readPersistedProxyState();
     expect(state).not.toBeNull();
     expect(state!.tld).toBe("test");
+    expect(state!.tlds).toEqual(["test"]);
+  });
+
+  it("reads TLD list from persisted state", () => {
+    fs.writeFileSync(path.join(tmpDir, "proxy.port"), "1355");
+    writeTldsFile(tmpDir, ["localhost", "test"]);
+    const state = readPersistedProxyState();
+    expect(state).not.toBeNull();
+    expect(state!.tld).toBe("localhost");
+    expect(state!.tlds).toEqual(["localhost", "test"]);
   });
 
   it("reads LAN mode from persisted state", () => {
@@ -1003,6 +1091,7 @@ describe("readPersistedProxyState", () => {
       port: 1355,
       tls: true,
       tld: "local",
+      tlds: ["local"],
       lanMode: true,
     });
   });

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -279,11 +279,30 @@ export function validateTld(tld: string): string | null {
   return null;
 }
 
+/** Parse a comma separated TLD list and remove duplicates in order. */
+export function parseTldList(value: string, source = "TLD"): string[] {
+  const trimmed = value.trim();
+  if (!trimmed) return [];
+
+  const tlds: string[] = [];
+  const seen = new Set<string>();
+  for (const rawPart of trimmed.split(",")) {
+    const tld = rawPart.trim().toLowerCase();
+    const err = validateTld(tld);
+    if (err) throw new Error(source === "TLD" ? err : `${source}: ${err}`);
+    if (!seen.has(tld)) {
+      seen.add(tld);
+      tlds.push(tld);
+    }
+  }
+  return tlds;
+}
+
 /** Name of the file that stores the proxy's active TLD. */
 const TLD_FILE = "proxy.tld";
+const TLDS_FILE = "proxy.tlds";
 
-/** Read the TLD from a state directory. Returns DEFAULT_TLD if absent. */
-export function readTldFromDir(dir: string): string {
+function readLegacyTldFromDir(dir: string): string {
   try {
     const raw = fs.readFileSync(path.join(dir, TLD_FILE), "utf-8").trim();
     return raw || DEFAULT_TLD;
@@ -292,30 +311,75 @@ export function readTldFromDir(dir: string): string {
   }
 }
 
-/** Write or remove the TLD file in the state directory. */
-export function writeTldFile(dir: string, tld: string): void {
-  const filePath = path.join(dir, TLD_FILE);
-  if (tld === DEFAULT_TLD) {
+/** Read all TLDs from a state directory. Returns the default TLD if absent. */
+export function readTldsFromDir(dir: string): string[] {
+  try {
+    const raw = fs.readFileSync(path.join(dir, TLDS_FILE), "utf-8").trim();
+    const parsed = raw.startsWith("[")
+      ? JSON.parse(raw)
+      : raw
+          .split(/\r?\n/)
+          .flatMap((line) => line.split(","))
+          .map((line) => line.trim())
+          .filter(Boolean);
+    if (!Array.isArray(parsed)) return [readLegacyTldFromDir(dir)];
+    const tlds = parsed.flatMap((value) => (typeof value === "string" ? parseTldList(value) : []));
+    return tlds.length > 0 ? [...new Set(tlds)] : [DEFAULT_TLD];
+  } catch {
+    return [readLegacyTldFromDir(dir)];
+  }
+}
+
+/** Read the primary TLD from a state directory. Returns DEFAULT_TLD if absent. */
+export function readTldFromDir(dir: string): string {
+  return readTldsFromDir(dir)[0] ?? DEFAULT_TLD;
+}
+
+/** Write or remove the TLD files in the state directory. */
+export function writeTldsFile(dir: string, tlds: readonly string[]): void {
+  const uniqueTlds = [...new Set(tlds)];
+  const tldsPath = path.join(dir, TLDS_FILE);
+  const tldPath = path.join(dir, TLD_FILE);
+
+  if (uniqueTlds.length === 1 && uniqueTlds[0] === DEFAULT_TLD) {
     try {
-      fs.unlinkSync(filePath);
+      fs.unlinkSync(tldsPath);
+    } catch {
+      // File may already be absent; non-fatal
+    }
+    try {
+      fs.unlinkSync(tldPath);
     } catch {
       // File may already be absent; non-fatal
     }
   } else {
-    fs.writeFileSync(filePath, tld, { mode: 0o644 });
+    fs.writeFileSync(tldsPath, uniqueTlds.join("\n") + "\n", { mode: 0o644 });
+    fs.writeFileSync(tldPath, uniqueTlds[0] ?? DEFAULT_TLD, { mode: 0o644 });
   }
 }
 
+/** Write or remove the primary TLD file in the state directory. */
+export function writeTldFile(dir: string, tld: string): void {
+  writeTldsFile(dir, [tld]);
+}
+
 /**
- * Return the effective TLD. Reads the PORTLESS_TLD env var first,
+ * Return the effective TLD list. Reads the PORTLESS_TLD env var first,
  * falling back to DEFAULT_TLD ("localhost"). Throws on invalid values.
  */
-export function getDefaultTld(): string {
+export function getDefaultTlds(): string[] {
   const val = process.env.PORTLESS_TLD?.trim().toLowerCase();
-  if (!val) return DEFAULT_TLD;
-  const err = validateTld(val);
-  if (err) throw new Error(`PORTLESS_TLD: ${err}`);
-  return val;
+  if (!val) return [DEFAULT_TLD];
+  const tlds = parseTldList(val, "PORTLESS_TLD");
+  return tlds.length > 0 ? tlds : [DEFAULT_TLD];
+}
+
+/**
+ * Return the primary effective TLD. Kept for callers that only need the
+ * display or compatibility value.
+ */
+export function getDefaultTld(): string {
+  return getDefaultTlds()[0] ?? DEFAULT_TLD;
 }
 
 /**
@@ -365,15 +429,17 @@ export function readPersistedProxyState(): {
   port: number;
   tls: boolean;
   tld: string;
+  tlds: string[];
   lanMode: boolean;
 } | null {
   const dir = process.env.PORTLESS_STATE_DIR || USER_STATE_DIR;
   const port = readPortFromDir(dir);
   if (port !== null) {
     const tls = readTlsMarker(dir);
-    const tld = readTldFromDir(dir);
+    const tlds = readTldsFromDir(dir);
+    const tld = tlds[0] ?? DEFAULT_TLD;
     const lanIp = readLanMarker(dir);
-    return { port, tls, tld, lanMode: lanIp !== null || tld === "local" };
+    return { port, tls, tld, tlds, lanMode: lanIp !== null || tlds.includes("local") };
   }
 
   return null;
@@ -387,13 +453,16 @@ export function buildProxyStartConfig(options: {
   lanIp?: string | null;
   lanIpExplicit?: boolean;
   tld: string;
+  tlds?: readonly string[];
   useWildcard?: boolean;
   foreground?: boolean;
   includePort?: boolean;
   proxyPort?: number;
   skipTrust?: boolean;
-}): { effectiveTld: string; args: string[] } {
-  const effectiveTld = options.lanMode ? "local" : options.tld;
+}): { effectiveTld: string; effectiveTlds: string[]; args: string[] } {
+  const requestedTlds = options.tlds && options.tlds.length > 0 ? [...options.tlds] : [options.tld];
+  const effectiveTlds = options.lanMode ? ["local"] : [...new Set(requestedTlds)];
+  const effectiveTld = effectiveTlds[0] ?? DEFAULT_TLD;
   const args: string[] = [];
 
   if (options.foreground) {
@@ -423,8 +492,10 @@ export function buildProxyStartConfig(options: {
         args.push(INTERNAL_LAN_IP_FLAG, options.lanIp);
       }
     }
-  } else if (effectiveTld !== DEFAULT_TLD) {
-    args.push("--tld", effectiveTld);
+  } else if (effectiveTlds.length > 1 || effectiveTld !== DEFAULT_TLD) {
+    for (const tld of effectiveTlds) {
+      args.push("--tld", tld);
+    }
   }
 
   if (options.useWildcard) {
@@ -435,7 +506,7 @@ export function buildProxyStartConfig(options: {
     args.push("--skip-trust");
   }
 
-  return { effectiveTld, args };
+  return { effectiveTld, effectiveTlds, args };
 }
 
 /**
@@ -449,6 +520,7 @@ export async function discoverState(): Promise<{
   port: number;
   tls: boolean;
   tld: string;
+  tlds: string[];
   lanMode: boolean;
   lanIp: string | null;
 }> {
@@ -459,15 +531,26 @@ export async function discoverState(): Promise<{
     const lanIp = readLanMarker(dir);
     if ((await isProxyRunning(port)) || (await isPortListening(port))) {
       const tls = readTlsMarker(dir);
-      const tld = readTldFromDir(dir);
-      return { dir, port, tls, tld, lanMode: lanIp !== null || tld === "local", lanIp };
+      const tlds = readTldsFromDir(dir);
+      const tld = tlds[0] ?? DEFAULT_TLD;
+      return {
+        dir,
+        port,
+        tls,
+        tld,
+        tlds,
+        lanMode: lanIp !== null || tlds.includes("local"),
+        lanIp,
+      };
     }
 
+    const tlds = readTldsFromDir(dir);
     return {
       dir,
       port,
       tls: readTlsMarker(dir),
-      tld: readTldFromDir(dir),
+      tld: tlds[0] ?? DEFAULT_TLD,
+      tlds,
       lanMode: lanIp !== null,
       lanIp: null,
     };
@@ -481,14 +564,16 @@ export async function discoverState(): Promise<{
     // avoids TLS handshake timeouts that can cause false negatives.
     if (await isProxyRunning(userPort)) {
       const tls = readTlsMarker(USER_STATE_DIR);
-      const tld = readTldFromDir(USER_STATE_DIR);
+      const tlds = readTldsFromDir(USER_STATE_DIR);
+      const tld = tlds[0] ?? DEFAULT_TLD;
       const lanIp = readLanMarker(USER_STATE_DIR);
       return {
         dir: USER_STATE_DIR,
         port: userPort,
         tls,
         tld,
-        lanMode: lanIp !== null || tld === "local",
+        tlds,
+        lanMode: lanIp !== null || tlds.includes("local"),
         lanIp,
       };
     }
@@ -500,14 +585,16 @@ export async function discoverState(): Promise<{
   if (legacyPort !== null) {
     if (await isProxyRunning(legacyPort)) {
       const tls = readTlsMarker(LEGACY_SYSTEM_STATE_DIR);
-      const tld = readTldFromDir(LEGACY_SYSTEM_STATE_DIR);
+      const tlds = readTldsFromDir(LEGACY_SYSTEM_STATE_DIR);
+      const tld = tlds[0] ?? DEFAULT_TLD;
       const lanIp = readLanMarker(LEGACY_SYSTEM_STATE_DIR);
       return {
         dir: LEGACY_SYSTEM_STATE_DIR,
         port: legacyPort,
         tls,
         tld,
-        lanMode: lanIp !== null || tld === "local",
+        tlds,
+        lanMode: lanIp !== null || tlds.includes("local"),
         lanIp,
       };
     }
@@ -525,18 +612,29 @@ export async function discoverState(): Promise<{
       // When the marker is missing, infer TLS from the port:
       // 443 is always HTTPS, 80 is always HTTP.
       const tls = markerTls || port === getProtocolPort(true);
-      const tld = readTldFromDir(dir);
+      const tlds = readTldsFromDir(dir);
+      const tld = tlds[0] ?? DEFAULT_TLD;
       const lanIp = readLanMarker(dir);
-      return { dir, port, tls, tld, lanMode: lanIp !== null || tld === "local", lanIp };
+      return {
+        dir,
+        port,
+        tls,
+        tld,
+        tlds,
+        lanMode: lanIp !== null || tlds.includes("local"),
+        lanIp,
+      };
     }
   }
 
   const dir = resolveStateDir(configuredPort);
+  const tlds = readTldsFromDir(dir);
   return {
     dir,
     port: configuredPort,
     tls: readTlsMarker(dir),
-    tld: readTldFromDir(dir),
+    tld: tlds[0] ?? DEFAULT_TLD,
+    tlds,
     lanMode: readLanMarker(dir) !== null,
     lanIp: null,
   };

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -1200,6 +1200,7 @@ describe("CLI", () => {
             )}, "utf-8"));`,
             `fs.writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify({`,
             "  PORTLESS_URL: process.env.PORTLESS_URL,",
+            "  __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: process.env.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS,",
             "  routes,",
             "}));",
           ].join("\n") + "\n"
@@ -1215,10 +1216,12 @@ describe("CLI", () => {
         expect(status).toBe(0);
         const capture = JSON.parse(fs.readFileSync(capturePath, "utf-8")) as {
           PORTLESS_URL: string;
+          __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: string;
           routes: Array<{ hostname: string; port: number }>;
         };
 
         expect(capture.PORTLESS_URL).toBe(`http://myapp.localhost:${proxyPort}`);
+        expect(capture.__VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS).toBe(".localhost,.test");
         expect(capture.routes.map((route) => route.hostname).sort()).toEqual([
           "myapp.localhost",
           "myapp.test",

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -1169,6 +1169,65 @@ describe("CLI", () => {
         fs.rmSync(shimDir, { recursive: true, force: true });
       }
     });
+
+    it("registers one app route per configured TLD", async () => {
+      const server = http.createServer((_req, res) => {
+        res.setHeader("X-Portless", "1");
+        res.end("ok");
+      });
+
+      try {
+        const proxyPort = await new Promise<number>((resolve) => {
+          server.listen(0, "127.0.0.1", () => {
+            const addr = server.address();
+            if (addr && typeof addr !== "string") {
+              resolve(addr.port);
+            }
+          });
+        });
+
+        fs.writeFileSync(path.join(tmpDir, "proxy.port"), proxyPort.toString());
+        fs.writeFileSync(path.join(tmpDir, "proxy.tlds"), "localhost\ntest\n");
+
+        const capturePath = path.join(tmpDir, "multi-tld-capture.json");
+        const scriptPath = path.join(tmpDir, "capture-routes.js");
+        fs.writeFileSync(
+          scriptPath,
+          [
+            'const fs = require("node:fs");',
+            `const routes = JSON.parse(fs.readFileSync(${JSON.stringify(
+              path.join(tmpDir, "routes.json")
+            )}, "utf-8"));`,
+            `fs.writeFileSync(${JSON.stringify(capturePath)}, JSON.stringify({`,
+            "  PORTLESS_URL: process.env.PORTLESS_URL,",
+            "  routes,",
+            "}));",
+          ].join("\n") + "\n"
+        );
+
+        const { status } = run(["run", "--name", "myapp", "node", scriptPath], {
+          env: {
+            PORTLESS_STATE_DIR: tmpDir,
+            PORTLESS_HTTPS: "0",
+          },
+        });
+
+        expect(status).toBe(0);
+        const capture = JSON.parse(fs.readFileSync(capturePath, "utf-8")) as {
+          PORTLESS_URL: string;
+          routes: Array<{ hostname: string; port: number }>;
+        };
+
+        expect(capture.PORTLESS_URL).toBe(`http://myapp.localhost:${proxyPort}`);
+        expect(capture.routes.map((route) => route.hostname).sort()).toEqual([
+          "myapp.localhost",
+          "myapp.test",
+        ]);
+        expect(new Set(capture.routes.map((route) => route.port)).size).toBe(1);
+      } finally {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    });
   });
 
   describe("NODE_EXTRA_CA_CERTS injection", () => {

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -469,6 +469,10 @@ function formatUrls(hostnames: readonly string[], proxyPort: number, tls: boolea
   return hostnames.map((hostname) => formatUrl(hostname, proxyPort, tls));
 }
 
+function formatViteAllowedHosts(tlds: readonly string[]): string {
+  return tlds.map((configuredTld) => `.${configuredTld}`).join(",");
+}
+
 function addRoutes(
   store: RouteStore,
   hostnames: readonly string[],
@@ -1433,9 +1437,7 @@ async function runApp(
       PORT: port.toString(),
       ...(hostBind ? { HOST: hostBind } : {}),
       PORTLESS_URL: finalUrl,
-      __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: tlds
-        .map((configuredTld) => `.${configuredTld}`)
-        .join(","),
+      __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: formatViteAllowedHosts(tlds),
       // Note: EXPO_PACKAGER_PROXY_URL is not used — expo-dev-client removed
       // baked-in pinging, making this env var ineffective. Expo handles its
       // own LAN discovery natively.
@@ -3502,6 +3504,7 @@ async function spawnProxiedApp(
       PORT: String(appPort),
       HOST: "127.0.0.1",
       PORTLESS_URL: url,
+      __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: formatViteAllowedHosts(tlds),
     };
 
     if (tls) {
@@ -3749,6 +3752,7 @@ async function runWithTurbo(
       PORT: String(appPort),
       HOST: "127.0.0.1",
       PORTLESS_URL: url,
+      __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: formatViteAllowedHosts(tlds),
     };
     if (tls) {
       const caPath = path.join(stateDir, "ca.pem");

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -15,6 +15,7 @@ import {
   isErrnoException,
   isProcessAlive as isPidAlive,
   parseHostname,
+  parseHostnames,
 } from "./utils.js";
 import {
   checkHostResolution,
@@ -55,7 +56,7 @@ import {
   findPidOnPort,
   findPidsOnPort,
   getDefaultPort,
-  getDefaultTld,
+  getDefaultTlds,
   injectFrameworkFlags,
   isHttpsEnvDisabled,
   isPortListening,
@@ -64,19 +65,20 @@ import {
   isProxyRunning,
   isWindows,
   killTree,
+  parseTldList,
   readLanMarker,
   readCustomCertMarker,
   readPersistedProxyState,
-  readTldFromDir,
+  readTldsFromDir,
   readTlsMarker,
   resolveStateDir,
   spawnCommand,
   augmentedPath,
-  validateTld,
   waitForProxy,
   writeCustomCertMarker,
   writeLanMarker,
   writeTldFile,
+  writeTldsFile,
   writeTlsMarker,
 } from "./cli-utils.js";
 import { collectStateDirsForCleanup, removePortlessStateFiles } from "./clean-utils.js";
@@ -138,7 +140,7 @@ type ProxyConfigExplicitness = {
   customCert: boolean;
   lanMode: boolean;
   lanIp: boolean;
-  tld: boolean;
+  tlds: boolean;
   useWildcard: boolean;
 };
 
@@ -150,10 +152,28 @@ type ProxyConfig = {
   lanIp: string | null;
   lanIpExplicit: boolean;
   tld: string;
+  tlds: string[];
   useWildcard: boolean;
 };
 
-function defaultProxyConfig(tld: string, useHttps: boolean, lanMode: boolean): ProxyConfig {
+function normalizeTlds(tlds: readonly string[]): string[] {
+  return [...new Set(tlds.length > 0 ? tlds : [DEFAULT_TLD])];
+}
+
+function primaryTld(tlds: readonly string[]): string {
+  return tlds[0] ?? DEFAULT_TLD;
+}
+
+function formatTldList(tlds: readonly string[]): string {
+  return tlds.map((tld) => `.${tld}`).join(", ");
+}
+
+function defaultProxyConfig(
+  tlds: readonly string[],
+  useHttps: boolean,
+  lanMode: boolean
+): ProxyConfig {
+  const effectiveTlds = lanMode ? ["local"] : normalizeTlds(tlds);
   return {
     useHttps,
     customCertPath: null,
@@ -161,7 +181,8 @@ function defaultProxyConfig(tld: string, useHttps: boolean, lanMode: boolean): P
     lanMode,
     lanIp: null,
     lanIpExplicit: false,
-    tld: lanMode ? "local" : tld,
+    tld: primaryTld(effectiveTlds),
+    tlds: effectiveTlds,
     useWildcard: false,
   };
 }
@@ -169,17 +190,17 @@ function defaultProxyConfig(tld: string, useHttps: boolean, lanMode: boolean): P
 function resolveProxyConfig(options: {
   persistedLanMode: boolean;
   explicit: ProxyConfigExplicitness;
-  defaultTld: string;
+  defaultTlds: string[];
   useHttps: boolean;
   customCertPath: string | null;
   customKeyPath: string | null;
   lanMode: boolean;
   lanIp: string | null;
-  tld: string;
+  tlds: string[];
   useWildcard: boolean;
 }): ProxyConfig {
   const config = defaultProxyConfig(
-    options.defaultTld,
+    options.defaultTlds,
     options.useHttps,
     options.explicit.lanMode ? options.lanMode : options.persistedLanMode
   );
@@ -203,8 +224,9 @@ function resolveProxyConfig(options: {
     if (!options.lanMode) {
       config.lanIp = null;
       config.lanIpExplicit = false;
-      if (!options.explicit.tld) {
-        config.tld = options.defaultTld;
+      if (!options.explicit.tlds) {
+        config.tlds = normalizeTlds(options.defaultTlds);
+        config.tld = primaryTld(config.tlds);
       }
     }
   }
@@ -215,8 +237,9 @@ function resolveProxyConfig(options: {
     config.lanIpExplicit = true;
   }
 
-  if (options.explicit.tld) {
-    config.tld = options.tld;
+  if (options.explicit.tlds) {
+    config.tlds = normalizeTlds(options.tlds);
+    config.tld = primaryTld(config.tlds);
   }
 
   if (options.explicit.useWildcard) {
@@ -229,6 +252,7 @@ function resolveProxyConfig(options: {
   }
 
   if (config.lanMode) {
+    config.tlds = ["local"];
     config.tld = "local";
     if (!config.lanIpExplicit) {
       config.lanIp = null;
@@ -245,16 +269,18 @@ function resolveProxyConfig(options: {
 
 function readCurrentProxyConfig(dir: string): ProxyConfig {
   const lanIp = readLanMarker(dir);
-  const tld = readTldFromDir(dir);
+  const tlds = readTldsFromDir(dir);
+  const tld = primaryTld(tlds);
 
   return {
     useHttps: readTlsMarker(dir),
     customCertPath: null,
     customKeyPath: null,
-    lanMode: lanIp !== null || tld === "local",
+    lanMode: lanIp !== null || tlds.includes("local"),
     lanIp,
     lanIpExplicit: false,
     tld,
+    tlds,
     useWildcard: false,
   };
 }
@@ -288,9 +314,13 @@ function getProxyConfigMismatchMessages(
     );
   }
 
-  if (explicit.tld && desiredConfig.tld !== actualConfig.tld) {
+  if (
+    explicit.tlds &&
+    (desiredConfig.tlds.length !== actualConfig.tlds.length ||
+      desiredConfig.tlds.some((tld, index) => tld !== actualConfig.tlds[index]))
+  ) {
     messages.push(
-      `requested .${desiredConfig.tld}, but the running proxy is using .${actualConfig.tld}`
+      `requested ${formatTldList(desiredConfig.tlds)}, but the running proxy is using ${formatTldList(actualConfig.tlds)}`
     );
   }
 
@@ -307,6 +337,7 @@ function formatProxyStartCommand(proxyPort: number, config: ProxyConfig): string
     lanIp: config.lanIpExplicit ? config.lanIp : null,
     lanIpExplicit: config.lanIpExplicit,
     tld: config.tld,
+    tlds: config.tlds,
     useWildcard: config.useWildcard,
     includePort: proxyPort !== getDefaultPort(config.useHttps),
     proxyPort,
@@ -430,6 +461,54 @@ function formatProcessExitSuffix(code: number | null, signal: NodeJS.Signals | n
   return "";
 }
 
+function buildHostnames(name: string, tlds: readonly string[]): string[] {
+  return parseHostnames(name, normalizeTlds(tlds));
+}
+
+function formatUrls(hostnames: readonly string[], proxyPort: number, tls: boolean): string[] {
+  return hostnames.map((hostname) => formatUrl(hostname, proxyPort, tls));
+}
+
+function addRoutes(
+  store: RouteStore,
+  hostnames: readonly string[],
+  port: number,
+  pid: number,
+  force = false
+): number[] {
+  const registered: string[] = [];
+  const killedPids: number[] = [];
+  try {
+    for (const hostname of hostnames) {
+      const killedPid = store.addRoute(hostname, port, pid, force);
+      registered.push(hostname);
+      if (killedPid !== undefined) {
+        killedPids.push(killedPid);
+      }
+    }
+  } catch (err) {
+    for (const hostname of registered) {
+      try {
+        store.removeRoute(hostname, pid);
+      } catch {
+        // Non-fatal rollback cleanup.
+      }
+    }
+    throw err;
+  }
+  return [...new Set(killedPids)];
+}
+
+function removeRoutes(store: RouteStore, hostnames: readonly string[], ownerPid?: number): void {
+  for (const hostname of hostnames) {
+    try {
+      store.removeRoute(hostname, ownerPid);
+    } catch {
+      // Non-fatal cleanup.
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Proxy server lifecycle
 // ---------------------------------------------------------------------------
@@ -438,6 +517,7 @@ function startProxyServer(
   store: RouteStore,
   proxyPort: number,
   tld: string,
+  tlds: string[],
   tlsOptions?: { cert: Buffer; key: Buffer },
   lanIp?: string | null,
   strict?: boolean,
@@ -557,6 +637,7 @@ function startProxyServer(
     getRoutes: () => cachedRoutes,
     proxyPort,
     tld,
+    tlds,
     strict,
     onError: (msg) => console.error(colors.red(msg)),
     tls: tlsOptions,
@@ -602,11 +683,12 @@ function startProxyServer(
     fs.writeFileSync(store.portFilePath, proxyPort.toString(), { mode: FILE_MODE });
     writeTlsMarker(store.dir, isTls);
     writeCustomCertMarker(store.dir, isTls && customCert);
-    writeTldFile(store.dir, tld);
+    writeTldsFile(store.dir, tlds);
     writeLanMarker(store.dir, activeLanIp);
     fixOwnership(store.dir, store.pidPath, store.portFilePath);
     const proto = isTls ? "HTTPS/2" : "HTTP";
-    const tldLabel = tld !== DEFAULT_TLD ? ` (TLD: .${tld})` : "";
+    const tldLabel =
+      tlds.length > 1 || tld !== DEFAULT_TLD ? ` (TLDs: ${formatTldList(tlds)})` : "";
     const modeLabel = strict === false ? " (wildcard)" : "";
     console.log(
       colors.green(`${proto} proxy listening on port ${proxyPort}${tldLabel}${modeLabel}`)
@@ -863,31 +945,33 @@ interface ProxyDesiredState {
   explicit: ProxyConfigExplicitness;
   desiredConfig: ReturnType<typeof resolveProxyConfig>;
   envTld: string;
+  envTlds: string[];
 }
 
 function resolveProxyDesiredState(lanMode: boolean): ProxyDesiredState {
-  const envTld = getDefaultTld();
+  const envTlds = getDefaultTlds();
+  const envTld = primaryTld(envTlds);
   const explicit: ProxyConfigExplicitness = {
     useHttps: process.env.PORTLESS_HTTPS !== undefined,
     customCert: false,
     lanMode: process.env.PORTLESS_LAN !== undefined,
     lanIp: process.env.PORTLESS_LAN_IP !== undefined,
-    tld: process.env.PORTLESS_TLD !== undefined,
+    tlds: process.env.PORTLESS_TLD !== undefined,
     useWildcard: process.env.PORTLESS_WILDCARD !== undefined,
   };
   const desiredConfig = resolveProxyConfig({
     persistedLanMode: lanMode,
     explicit,
-    defaultTld: envTld,
+    defaultTlds: envTlds,
     useHttps: !isHttpsEnvDisabled(),
     customCertPath: null,
     customKeyPath: null,
     lanMode: isLanEnvEnabled(),
     lanIp: process.env.PORTLESS_LAN_IP || null,
-    tld: envTld,
+    tlds: envTlds,
     useWildcard: isWildcardEnvEnabled(),
   });
-  return { explicit, desiredConfig, envTld };
+  return { explicit, desiredConfig, envTld, envTlds };
 }
 
 /**
@@ -918,8 +1002,13 @@ async function ensureProxyRunning(
     if (!explicit.useHttps && persisted.tls !== desiredConfig.useHttps) {
       startConfig.useHttps = persisted.tls;
     }
-    if (!explicit.tld && persisted.tld !== desiredConfig.tld) {
-      startConfig.tld = persisted.tld;
+    if (
+      !explicit.tlds &&
+      (persisted.tlds.length !== desiredConfig.tlds.length ||
+        persisted.tlds.some((tld, index) => tld !== desiredConfig.tlds[index]))
+    ) {
+      startConfig.tlds = persisted.tlds;
+      startConfig.tld = primaryTld(persisted.tlds);
     }
     if (!explicit.lanMode && persisted.lanMode !== desiredConfig.lanMode) {
       startConfig.lanMode = persisted.lanMode;
@@ -959,6 +1048,7 @@ async function ensureProxyRunning(
     lanIp: startConfig.lanIpExplicit ? startConfig.lanIp : null,
     lanIpExplicit: startConfig.lanIpExplicit,
     tld: startConfig.tld,
+    tlds: startConfig.tlds,
     useWildcard: startConfig.useWildcard,
     includePort: startPort !== undefined,
     proxyPort: startPort,
@@ -1005,7 +1095,7 @@ async function runApp(
   name: string,
   commandArgs: string[],
   tls: boolean,
-  tld: string,
+  tlds: string[],
   force: boolean,
   autoInfo?: { nameSource: string; prefix?: string; prefixSource?: string },
   desiredPort?: number,
@@ -1064,14 +1154,14 @@ async function runApp(
   }
 
   // Validate the hostname before we try to auto-start the proxy.
-  parseHostname(name, tld);
+  buildHostnames(name, tlds);
 
   const ensureResult = await ensureProxyRunning(proxyPort, tls, desired);
 
   if (ensureResult.started) {
     proxyPort = ensureResult.state.port;
     stateDir = ensureResult.state.dir;
-    tld = ensureResult.state.tld;
+    tlds = ensureResult.state.tlds;
     tls = ensureResult.state.tls;
     lanMode = ensureResult.state.lanMode;
     lanIp = ensureResult.state.lanIp;
@@ -1094,25 +1184,30 @@ async function runApp(
     }
     lanMode = runningConfig.lanMode;
     lanIp = runningConfig.lanIp;
+    tlds = runningConfig.tlds;
     console.log(chalk.gray("-- Proxy is running"));
   }
 
-  // Compute hostname after auto-start so tld reflects the running proxy
-  // (e.g. --lan changes tld from "localhost" to "local")
-  const hostname = parseHostname(name, tld);
+  // Compute hostnames after auto-start so TLDs reflect the running proxy.
+  const hostnames = buildHostnames(name, tlds);
+  const hostname = hostnames[0]!;
 
-  if (desired.envTld !== DEFAULT_TLD && desired.envTld !== tld) {
+  if (
+    desired.explicit.tlds &&
+    (desired.envTlds.some((envConfiguredTld, index) => envConfiguredTld !== tlds[index]) ||
+      desired.envTlds.length !== tlds.length)
+  ) {
     console.warn(
       chalk.yellow(
-        `Warning: PORTLESS_TLD=${desired.envTld} but the running proxy uses .${tld}. Using .${tld}.`
+        `Warning: PORTLESS_TLD=${desired.envTlds.join(",")} but the running proxy uses ${formatTldList(tlds)}.`
       )
     );
   }
 
   if (lanIp) {
-    console.log(chalk.gray(`-- ${hostname} (LAN: ${lanIp})`));
+    console.log(chalk.gray(`-- ${hostnames.join(", ")} (LAN: ${lanIp})`));
   } else {
-    console.log(chalk.gray(`-- ${hostname} (auto-resolves to 127.0.0.1)`));
+    console.log(chalk.gray(`-- ${hostnames.join(", ")} (auto-resolves to 127.0.0.1)`));
   }
   if (autoInfo) {
     const baseName = autoInfo.prefix ? name.slice(autoInfo.prefix.length + 1) : name;
@@ -1130,9 +1225,9 @@ async function runApp(
   }
 
   // Register route (--force kills the existing owner if any)
-  let killedPid: number | undefined;
+  let killedPids: number[] = [];
   try {
-    killedPid = store.addRoute(hostname, port, process.pid, force);
+    killedPids = addRoutes(store, hostnames, port, process.pid, force);
   } catch (err) {
     if (err instanceof RouteConflictError) {
       console.error(colors.red(`Error: ${err.message}`));
@@ -1140,12 +1235,19 @@ async function runApp(
     }
     throw err;
   }
-  if (killedPid !== undefined) {
-    console.log(colors.yellow(`Killed existing process (PID ${killedPid})`));
+  if (killedPids.length > 0) {
+    console.log(colors.yellow(`Killed existing process(es): ${killedPids.join(", ")}`));
   }
 
   const finalUrl = formatUrl(hostname, proxyPort, tls);
+  const allUrls = formatUrls(hostnames, proxyPort, tls);
   console.log(chalk.cyan.bold(`\n  -> ${finalUrl}\n`));
+  for (const extraUrl of allUrls.slice(1)) {
+    console.log(chalk.cyan(`  also -> ${extraUrl}`));
+  }
+  if (allUrls.length > 1) {
+    console.log("");
+  }
   if (lanIp) {
     console.log(chalk.green(`  LAN -> ${finalUrl}`));
     console.log(chalk.gray("  (accessible from other devices on the same WiFi network)\n"));
@@ -1273,7 +1375,7 @@ async function runApp(
         // Best-effort cleanup; non-fatal
       }
       try {
-        store.removeRoute(hostname, process.pid);
+        removeRoutes(store, hostnames, process.pid);
       } catch {
         // Best-effort cleanup; non-fatal
       }
@@ -1331,7 +1433,9 @@ async function runApp(
       PORT: port.toString(),
       ...(hostBind ? { HOST: hostBind } : {}),
       PORTLESS_URL: finalUrl,
-      __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: `.${tld}`,
+      __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: tlds
+        .map((configuredTld) => `.${configuredTld}`)
+        .join(","),
       // Note: EXPO_PACKAGER_PROXY_URL is not used — expo-dev-client removed
       // baked-in pinging, making this env var ineffective. Expo handles its
       // own LAN discovery natively.
@@ -1352,7 +1456,7 @@ async function runApp(
         // Best-effort cleanup; non-fatal
       }
       try {
-        store.removeRoute(hostname, process.pid);
+        removeRoutes(store, hostnames, process.pid);
       } catch {
         // Lock acquisition may fail during cleanup; non-fatal
       }
@@ -1703,7 +1807,7 @@ ${colors.bold("Options:")}
   --cert <path>                 Use a custom TLS certificate
   --key <path>                  Use a custom TLS private key
   --foreground                  Run proxy in foreground (for debugging)
-  --tld <tld>                   Use a custom TLD instead of .localhost (e.g. test, dev)
+  --tld <tld>                   Use a custom TLD instead of .localhost; repeat for more
   --wildcard                    Allow unregistered subdomains to fall back to parent route
   --state-dir <path>            Use a custom state directory with service install
   --app-port <number>           Use a fixed port for the app (skip auto-assignment)
@@ -1720,7 +1824,7 @@ ${colors.bold("Environment variables:")}
   PORTLESS_HTTPS=0              Disable HTTPS (same as --no-tls)
   PORTLESS_LAN=1                Enable LAN mode when set to 1 (set in .bashrc / .zshrc)
   PORTLESS_LAN_IP=<address>     Pin a specific LAN IP for LAN mode
-  PORTLESS_TLD=<tld>            Use a custom TLD (e.g. test, dev; default: localhost)
+  PORTLESS_TLD=<tld>[,<tld>]    Use one or more TLDs (e.g. localhost,test)
   PORTLESS_WILDCARD=1           Allow unregistered subdomains to fall back to parent route
   PORTLESS_SYNC_HOSTS=0         Disable auto-sync of ${HOSTS_DISPLAY} (on by default)
   PORTLESS_TAILSCALE=1          Share apps on your Tailscale network (same as --tailscale)
@@ -1732,7 +1836,7 @@ ${colors.bold("Environment variables:")}
 ${colors.bold("Child process environment:")}
   PORT                          Ephemeral port the child should listen on
   HOST                          Usually 127.0.0.1 (omitted for Expo in LAN mode)
-  PORTLESS_URL                  Public URL of the app (e.g. https://myapp.localhost)
+  PORTLESS_URL                  Primary public URL of the app
   PORTLESS_LAN                  Set to 1 when proxy is in LAN mode
   PORTLESS_TAILSCALE_URL        Tailscale URL of the app (when --tailscale is active)
   PORTLESS_NGROK_URL            ngrok URL of the app (when --ngrok is active)
@@ -2067,8 +2171,8 @@ ${colors.bold("Examples:")}
   const worktree = skipWorktree ? null : detectWorktreePrefix();
   const effectiveName = worktree ? `${worktree.prefix}.${name}` : name;
 
-  const { port, tls, tld } = await discoverState();
-  const hostname = parseHostname(effectiveName, tld);
+  const { port, tls, tlds } = await discoverState();
+  const hostname = buildHostnames(effectiveName, tlds)[0]!;
   const url = formatUrl(hostname, port, tls);
   // Print bare URL to stdout so it works in $(portless get <name>)
   process.stdout.write(url + "\n");
@@ -2092,7 +2196,7 @@ ${colors.bold("Examples:")}
     process.exit(0);
   }
 
-  const { dir, tld } = await discoverState();
+  const { dir, tlds } = await discoverState();
   const store = new RouteStore(dir, {
     onWarning: (msg) => console.warn(colors.yellow(msg)),
   });
@@ -2104,15 +2208,15 @@ ${colors.bold("Examples:")}
       console.error(colors.cyan("  portless alias --remove <name>"));
       process.exit(1);
     }
-    const hostname = parseHostname(aliasName, tld);
+    const hostnames = buildHostnames(aliasName, tlds);
     const routes = store.loadRoutes();
-    const existing = routes.find((r) => r.hostname === hostname && r.pid === 0);
+    const existing = routes.find((r) => hostnames.includes(r.hostname) && r.pid === 0);
     if (!existing) {
-      console.error(colors.red(`Error: No alias found for "${hostname}".`));
+      console.error(colors.red(`Error: No alias found for "${hostnames.join(", ")}".`));
       process.exit(1);
     }
-    store.removeRoute(hostname);
-    console.log(colors.green(`Removed alias: ${hostname}`));
+    removeRoutes(store, hostnames);
+    console.log(colors.green(`Removed alias: ${hostnames.join(", ")}`));
     return;
   }
 
@@ -2128,7 +2232,7 @@ ${colors.bold("Examples:")}
     process.exit(1);
   }
 
-  const hostname = parseHostname(aliasName, tld);
+  const hostnames = buildHostnames(aliasName, tlds);
   const port = parseInt(aliasPort, 10);
   if (isNaN(port) || port < 1 || port > 65535) {
     console.error(colors.red(`Error: Invalid port "${aliasPort}". Must be 1-65535.`));
@@ -2136,8 +2240,8 @@ ${colors.bold("Examples:")}
   }
 
   const force = args.includes("--force");
-  store.addRoute(hostname, port, 0, force);
-  console.log(colors.green(`Alias registered: ${hostname} -> 127.0.0.1:${port}`));
+  addRoutes(store, hostnames, port, 0, force);
+  console.log(colors.green(`Alias registered: ${hostnames.join(", ")} -> 127.0.0.1:${port}`));
 }
 
 async function handleHosts(args: string[]): Promise<void> {
@@ -2358,6 +2462,7 @@ ${colors.bold("Options:")}
       port: getDefaultPort(!isHttpsEnvDisabled()),
       tls: !isHttpsEnvDisabled(),
       tld: DEFAULT_TLD,
+      tlds: [DEFAULT_TLD],
       lanMode: isLanEnvEnabled(),
       lanIp: null,
     };
@@ -2389,7 +2494,9 @@ ${colors.bold("Options:")}
   console.log(`Platform: ${process.platform} ${process.arch}`);
   console.log(`State dir: ${state.dir}`);
   console.log(`Proxy target: ${formatUrl("127.0.0.1", proxyPort, proxyTls)}`);
-  console.log(`Mode: ${proxyTls ? "HTTPS" : "HTTP"}, .${state.tld}${state.lanMode ? ", LAN" : ""}`);
+  console.log(
+    `Mode: ${proxyTls ? "HTTPS" : "HTTP"}, ${formatTldList(state.tlds)}${state.lanMode ? ", LAN" : ""}`
+  );
   console.log("");
 
   const nodeMajor = parseInt(process.versions.node.split(".")[0], 10);
@@ -2679,6 +2786,7 @@ ${colors.bold("Usage:")}
   ${colors.cyan("portless proxy start --foreground")}   Start in foreground (for debugging)
   ${colors.cyan("portless proxy start -p 1355")}        Start on a custom port (no sudo)
   ${colors.cyan("portless proxy start --tld test")}     Use .test instead of .localhost
+  ${colors.cyan("portless proxy start --tld localhost --tld test")}  Serve both TLDs
   ${colors.cyan("portless proxy start --wildcard")}     Allow unregistered subdomains to fall back to parent
   ${colors.cyan("portless proxy stop")}                 Stop the proxy
 
@@ -2751,28 +2859,35 @@ ${colors.bold("LAN mode (--lan):")}
     hasExplicitPort = true;
   }
 
-  // Parse --tld flag
-  let tld: string;
+  // Parse --tld flags
+  let tlds: string[];
   try {
-    tld = getDefaultTld();
+    tlds = getDefaultTlds();
   } catch (err) {
     console.error(colors.red(`Error: ${(err as Error).message}`));
     process.exit(1);
   }
-  const tldIdx = args.indexOf("--tld");
-  if (tldIdx !== -1) {
-    const tldValue = args[tldIdx + 1];
-    if (!tldValue || tldValue.startsWith("-")) {
-      console.error(colors.red("Error: --tld requires a TLD value (e.g. test, localhost)."));
-      process.exit(1);
+  const tldFlagValues: string[] = [];
+  for (let i = 0; i < args.length; i += 1) {
+    if (args[i] === "--tld") {
+      const tldValue = args[i + 1];
+      if (!tldValue || tldValue.startsWith("-")) {
+        console.error(colors.red("Error: --tld requires a TLD value (e.g. test, localhost)."));
+        process.exit(1);
+      }
+      tldFlagValues.push(tldValue);
+      i += 1;
     }
-    tld = tldValue.trim().toLowerCase();
-    const tldErr = validateTld(tld);
-    if (tldErr) {
-      console.error(colors.red(`Error: ${tldErr}`));
+  }
+  if (tldFlagValues.length > 0) {
+    try {
+      tlds = normalizeTlds(tldFlagValues.flatMap((value) => parseTldList(value)));
+    } catch (err) {
+      console.error(colors.red(`Error: ${(err as Error).message}`));
       process.exit(1);
     }
   }
+  let tld = primaryTld(tlds);
   // Parse --wildcard flag (disables the default strict subdomain matching)
   const useWildcard = args.includes("--wildcard") || isWildcardEnvEnabled();
 
@@ -2786,7 +2901,7 @@ ${colors.bold("LAN mode (--lan):")}
     customCert: customCertPath !== null || customKeyPath !== null,
     lanMode: process.env.PORTLESS_LAN !== undefined,
     lanIp: process.env.PORTLESS_LAN_IP !== undefined,
-    tld: tldIdx !== -1 || process.env.PORTLESS_TLD !== undefined,
+    tlds: tldFlagValues.length > 0 || process.env.PORTLESS_TLD !== undefined,
     useWildcard: args.includes("--wildcard") || process.env.PORTLESS_WILDCARD !== undefined,
   };
 
@@ -2809,13 +2924,13 @@ ${colors.bold("LAN mode (--lan):")}
   const desiredConfig = resolveProxyConfig({
     persistedLanMode,
     explicit,
-    defaultTld: getDefaultTld(),
+    defaultTlds: getDefaultTlds(),
     useHttps: wantHttps || !!(customCertPath && customKeyPath),
     customCertPath,
     customKeyPath,
     lanMode: isLanEnvEnabled(),
     lanIp: process.env.PORTLESS_LAN_IP || null,
-    tld,
+    tlds,
     useWildcard,
   });
   const lanMode = desiredConfig.lanMode;
@@ -2823,6 +2938,7 @@ ${colors.bold("LAN mode (--lan):")}
   customCertPath = desiredConfig.customCertPath;
   customKeyPath = desiredConfig.customKeyPath;
   tld = desiredConfig.tld;
+  tlds = desiredConfig.tlds;
   const desiredWildcard = desiredConfig.useWildcard;
   let lanIp: string | null = desiredConfig.lanIpExplicit ? desiredConfig.lanIp : null;
 
@@ -2831,28 +2947,31 @@ ${colors.bold("LAN mode (--lan):")}
     stateDir = resolveStateDir(proxyPort);
   }
 
-  if (lanMode && tldIdx !== -1) {
-    const userTld = args[tldIdx + 1];
-    if (userTld && userTld !== "local") {
+  if (lanMode && tldFlagValues.length > 0) {
+    const userTlds = tldFlagValues.join(", ");
+    if (userTlds !== "local") {
       console.warn(
         chalk.yellow(
-          `Warning: --lan forces .local TLD (mDNS requirement). Ignoring --tld ${userTld}.`
+          `Warning: --lan forces .local TLD (mDNS requirement). Ignoring --tld ${userTlds}.`
         )
       );
     }
   }
 
-  const riskyReason = RISKY_TLDS.get(tld);
-  if (riskyReason && !lanMode) {
-    console.warn(colors.yellow(`Warning: .${tld}: ${riskyReason}`));
+  for (const configuredTld of tlds) {
+    const riskyReason = RISKY_TLDS.get(configuredTld);
+    if (riskyReason && !lanMode) {
+      console.warn(colors.yellow(`Warning: .${configuredTld}: ${riskyReason}`));
+    }
   }
 
   const syncDisabled =
     process.env.PORTLESS_SYNC_HOSTS === "0" || process.env.PORTLESS_SYNC_HOSTS === "false";
-  if (tld !== DEFAULT_TLD && !lanMode && syncDisabled) {
+  const nonDefaultTlds = tlds.filter((configuredTld) => configuredTld !== DEFAULT_TLD);
+  if (nonDefaultTlds.length > 0 && !lanMode && syncDisabled) {
     console.warn(
       colors.yellow(
-        `Warning: .${tld} domains require ${HOSTS_DISPLAY} entries to resolve to 127.0.0.1.`
+        `Warning: ${formatTldList(nonDefaultTlds)} domains require ${HOSTS_DISPLAY} entries to resolve to 127.0.0.1.`
       )
     );
     console.warn(colors.yellow("Hosts sync is disabled. To add entries manually, run:"));
@@ -2926,6 +3045,7 @@ ${colors.bold("LAN mode (--lan):")}
     lanIp: desiredConfig.lanIpExplicit ? lanIp : null,
     lanIpExplicit: desiredConfig.lanIpExplicit,
     tld,
+    tlds,
     useWildcard: desiredWildcard,
   };
 
@@ -2945,6 +3065,7 @@ ${colors.bold("LAN mode (--lan):")}
         lanIp: desiredConfig.lanIpExplicit ? lanIp : null,
         lanIpExplicit: desiredConfig.lanIpExplicit,
         tld,
+        tlds,
         useWildcard: desiredWildcard,
         foreground: isForeground,
         includePort: true,
@@ -3079,7 +3200,7 @@ ${colors.bold("LAN mode (--lan):")}
         cert,
         key,
         ca,
-        SNICallback: createSNICallback(stateDir, cert, key, tld, ca),
+        SNICallback: createSNICallback(stateDir, cert, key, tlds, ca),
       };
     }
   }
@@ -3091,6 +3212,7 @@ ${colors.bold("LAN mode (--lan):")}
       store,
       proxyPort,
       tld,
+      tlds,
       tlsOptions,
       lanIp,
       desiredWildcard ? false : undefined,
@@ -3123,6 +3245,7 @@ ${colors.bold("LAN mode (--lan):")}
         lanIp: desiredConfig.lanIpExplicit ? lanIp : null,
         lanIpExplicit: desiredConfig.lanIpExplicit,
         tld,
+        tlds,
         useWildcard: desiredWildcard,
         foreground: true,
         includePort: true,
@@ -3260,7 +3383,7 @@ async function handleDefaultSingle(
   const worktree = detectWorktreePrefix(cwd);
   const effectiveName = worktree ? `${worktree.prefix}.${baseName}` : baseName;
 
-  const { dir, port, tls, tld, lanMode, lanIp } = await discoverState();
+  const { dir, port, tls, tlds, lanMode, lanIp } = await discoverState();
   const store = new RouteStore(dir, {
     onWarning: (msg) => console.warn(colors.yellow(msg)),
   });
@@ -3271,7 +3394,7 @@ async function handleDefaultSingle(
     effectiveName,
     resolved,
     tls,
-    tld,
+    tlds,
     false,
     { nameSource, prefix: worktree?.prefix, prefixSource: worktree?.source },
     appConfig?.appPort,
@@ -3341,12 +3464,12 @@ async function spawnProxiedApp(
   stateDir: string,
   proxyPort: number,
   tls: boolean,
-  tld: string,
+  tlds: string[],
   exitCodes: Map<string, number | null>
 ): Promise<{
   child: ReturnType<typeof spawn>;
   displayUrl: string;
-  route: { store: RouteStore; hostname: string } | null;
+  route: { store: RouteStore; hostnames: string[] } | null;
 }> {
   const usesPortless = app.commandArgs[0] === "portless";
 
@@ -3355,7 +3478,7 @@ async function spawnProxiedApp(
 
   let env: Record<string, string | undefined>;
   let store: RouteStore | null = null;
-  let hostname: string | null = null;
+  let hostnames: string[] = [];
   let displayUrl: string;
 
   if (usesPortless) {
@@ -3367,14 +3490,12 @@ async function spawnProxiedApp(
     });
 
     const appPort = app.appPort ?? (await findFreePort());
-    const protocol = tls ? "https" : "http";
-    const portSuffix =
-      (tls && proxyPort === 443) || (!tls && proxyPort === 80) ? "" : `:${proxyPort}`;
-    const url = `${protocol}://${app.name}.${tld}${portSuffix}`;
+    hostnames = buildHostnames(app.name, tlds);
+    const urls = formatUrls(hostnames, proxyPort, tls);
+    const url = urls[0]!;
     displayUrl = url;
 
-    hostname = parseHostname(app.name, tld);
-    store.addRoute(hostname, appPort, process.pid);
+    addRoutes(store, hostnames, appPort, process.pid);
 
     env = {
       ...pkgEnv,
@@ -3395,7 +3516,7 @@ async function spawnProxiedApp(
   pipeOutput(child, chalk.cyan(`[${app.name}]`));
 
   const capturedStore = store;
-  const capturedHostname = hostname;
+  const capturedHostnames = hostnames;
   child.on("exit", (code, signal) => {
     exitCodes.set(app.name, code);
     if (code !== 0 && code !== null) {
@@ -3403,16 +3524,12 @@ async function spawnProxiedApp(
     } else if (signal) {
       console.error(colors.yellow(`[${app.name}] killed by ${signal}`));
     }
-    if (capturedStore && capturedHostname) {
-      try {
-        capturedStore.removeRoute(capturedHostname, process.pid);
-      } catch {
-        // non-fatal
-      }
+    if (capturedStore && capturedHostnames.length > 0) {
+      removeRoutes(capturedStore, capturedHostnames, process.pid);
     }
   });
 
-  const route = store && hostname ? { store, hostname } : null;
+  const route = store && hostnames.length > 0 ? { store, hostnames } : null;
   return { child, displayUrl, route };
 }
 
@@ -3558,7 +3675,7 @@ async function handleDefaultMulti(
 
   console.log(chalk.blue.bold(`\nportless\n`));
 
-  let { dir, port, tls, tld } = await discoverState();
+  let { dir, port, tls, tlds } = await discoverState();
 
   if (proxiedApps.length > 0) {
     let multiDesired: ProxyDesiredState;
@@ -3573,10 +3690,10 @@ async function handleDefaultMulti(
       dir = ensureResult.state.dir;
       port = ensureResult.state.port;
       tls = ensureResult.state.tls;
-      tld = ensureResult.state.tld;
+      tlds = ensureResult.state.tlds;
     } else {
       // Proxy was already running; re-discover to pick up current state.
-      ({ dir, port, tls, tld } = await discoverState());
+      ({ dir, port, tls, tlds } = await discoverState());
     }
 
     if (tls && !isCATrusted(dir)) {
@@ -3587,9 +3704,9 @@ async function handleDefaultMulti(
   const useTurbo = loaded?.config.turbo !== false && hasTurboConfig(wsRoot);
 
   if (useTurbo) {
-    await runWithTurbo(wsRoot, dir, port, tls, tld, scriptName, proxiedApps, taskApps, extraArgs);
+    await runWithTurbo(wsRoot, dir, port, tls, tlds, scriptName, proxiedApps, taskApps, extraArgs);
   } else {
-    await runWithDirectSpawn(dir, port, tls, tld, proxiedApps, taskApps);
+    await runWithDirectSpawn(dir, port, tls, tlds, proxiedApps, taskApps);
   }
 }
 
@@ -3598,7 +3715,7 @@ async function runWithTurbo(
   stateDir: string,
   proxyPort: number,
   tls: boolean,
-  tld: string,
+  tlds: string[],
   scriptName: string,
   proxiedApps: MultiAppEntry[],
   taskApps: MultiAppEntry[],
@@ -3609,7 +3726,7 @@ async function runWithTurbo(
   });
 
   const manifest: Record<string, ManifestEntry> = {};
-  const routes: { hostname: string }[] = [];
+  const routes: { hostnames: string[] }[] = [];
   const appUrls: { label: string; url: string }[] = [];
 
   for (const app of proxiedApps) {
@@ -3620,15 +3737,13 @@ async function runWithTurbo(
     }
 
     const appPort = app.appPort ?? (await findFreePort());
-    const protocol = tls ? "https" : "http";
-    const portSuffix =
-      (tls && proxyPort === 443) || (!tls && proxyPort === 80) ? "" : `:${proxyPort}`;
-    const url = `${protocol}://${app.name}.${tld}${portSuffix}`;
+    const hostnames = buildHostnames(app.name, tlds);
+    const urls = formatUrls(hostnames, proxyPort, tls);
+    const url = urls[0]!;
     appUrls.push({ label: app.label, url });
 
-    const hostname = parseHostname(app.name, tld);
-    store.addRoute(hostname, appPort, process.pid);
-    routes.push({ hostname });
+    addRoutes(store, hostnames, appPort, process.pid);
+    routes.push({ hostnames });
 
     const entry: ManifestEntry = {
       PORT: String(appPort),
@@ -3690,12 +3805,8 @@ async function runWithTurbo(
       }
     }, SIGKILL_TIMEOUT_MS).unref();
 
-    for (const { hostname } of routes) {
-      try {
-        store.removeRoute(hostname, process.pid);
-      } catch {
-        // non-fatal
-      }
+    for (const { hostnames } of routes) {
+      removeRoutes(store, hostnames, process.pid);
     }
     removeManifest();
   };
@@ -3718,14 +3829,14 @@ async function runWithDirectSpawn(
   stateDir: string,
   proxyPort: number,
   tls: boolean,
-  tld: string,
+  tlds: string[],
   proxiedApps: MultiAppEntry[],
   taskApps: MultiAppEntry[]
 ): Promise<void> {
   const children: ReturnType<typeof spawn>[] = [];
   const exitCodes = new Map<string, number | null>();
   const appUrls: { label: string; url: string }[] = [];
-  const routeEntries: { store: RouteStore; hostname: string }[] = [];
+  const routeEntries: { store: RouteStore; hostnames: string[] }[] = [];
 
   // Sequential: each spawnProxiedApp calls findFreePort() which binds/releases
   // a port, so parallel spawning could cause port collisions.
@@ -3735,7 +3846,7 @@ async function runWithDirectSpawn(
       stateDir,
       proxyPort,
       tls,
-      tld,
+      tlds,
       exitCodes
     );
     children.push(child);
@@ -3777,12 +3888,8 @@ async function runWithDirectSpawn(
       }
     }, SIGKILL_TIMEOUT_MS).unref();
 
-    for (const { store, hostname } of routeEntries) {
-      try {
-        store.removeRoute(hostname, process.pid);
-      } catch {
-        // non-fatal
-      }
+    for (const { store, hostnames } of routeEntries) {
+      removeRoutes(store, hostnames, process.pid);
     }
   };
 
@@ -3861,7 +3968,7 @@ async function handleRunMode(args: string[], globalScript?: string): Promise<voi
   const worktree = detectWorktreePrefix();
   const effectiveName = worktree ? `${worktree.prefix}.${baseName}` : baseName;
 
-  const { dir, port, tls, tld, lanMode, lanIp } = await discoverState();
+  const { dir, port, tls, tlds, lanMode, lanIp } = await discoverState();
   const store = new RouteStore(dir, {
     onWarning: (msg) => console.warn(colors.yellow(msg)),
   });
@@ -3872,7 +3979,7 @@ async function handleRunMode(args: string[], globalScript?: string): Promise<voi
     effectiveName,
     parsed.commandArgs,
     tls,
-    tld,
+    tlds,
     parsed.force,
     { nameSource, prefix: worktree?.prefix, prefixSource: worktree?.source },
     parsed.appPort,
@@ -3907,7 +4014,7 @@ async function handleNamedMode(args: string[]): Promise<void> {
     .join(".");
   parseHostname(safeName, DEFAULT_TLD);
 
-  const { dir, port, tls, tld, lanMode, lanIp } = await discoverState();
+  const { dir, port, tls, tlds, lanMode, lanIp } = await discoverState();
   const store = new RouteStore(dir, {
     onWarning: (msg) => console.warn(colors.yellow(msg)),
   });
@@ -3918,7 +4025,7 @@ async function handleNamedMode(args: string[]): Promise<void> {
     safeName,
     parsed.commandArgs,
     tls,
-    tld,
+    tlds,
     parsed.force,
     undefined,
     parsed.appPort,

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -114,11 +114,13 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
     getRoutes,
     proxyPort,
     tld = "localhost",
+    tlds = [tld],
     strict = true,
     onError = (msg: string) => console.error(msg),
     tls,
   } = options;
-  const tldSuffix = `.${tld}`;
+  const tldSuffixes = [...new Set(tlds.length > 0 ? tlds : [tld])].map((value) => `.${value}`);
+  const primaryTldSuffix = tldSuffixes[0] ?? ".localhost";
 
   const handleRequest = (req: http.IncomingMessage, res: http.ServerResponse) => {
     const reqTls = isEncrypted(req);
@@ -147,7 +149,7 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
           "Loop Detected",
           `<div class="content"><p class="desc">This request has passed through portless ${hops} times. This usually means a dev server (Vite, webpack, etc.) is proxying requests back through portless without rewriting the Host header.</p><div class="section"><p class="label">Fix: add changeOrigin to your proxy config</p><pre class="terminal">proxy: {
   "/api": {
-    target: "${reqTls ? "https" : "http"}://&lt;backend&gt;${escapeHtml(tldSuffix)}${reqTls ? "" : ":&lt;port&gt;"}",
+    target: "${reqTls ? "https" : "http"}://&lt;backend&gt;${escapeHtml(primaryTldSuffix)}${reqTls ? "" : ":&lt;port&gt;"}",
     changeOrigin: true,
   },
 }</pre></div></div>`
@@ -160,7 +162,8 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
 
     if (!route) {
       const safeHost = escapeHtml(host);
-      const strippedHost = host.endsWith(tldSuffix) ? host.slice(0, -tldSuffix.length) : host;
+      const matchedSuffix = tldSuffixes.find((suffix) => host.endsWith(suffix));
+      const strippedHost = matchedSuffix ? host.slice(0, -matchedSuffix.length) : host;
       const safeSuggestion = escapeHtml(strippedHost);
       const routesList =
         routes.length > 0

--- a/packages/portless/src/service.test.ts
+++ b/packages/portless/src/service.test.ts
@@ -484,6 +484,7 @@ describe("handleService", () => {
       port: currentPort,
       tls: true,
       tld: "localhost",
+      tlds: ["localhost"],
       lanMode: false,
       lanIp: null,
     });

--- a/packages/portless/src/service.test.ts
+++ b/packages/portless/src/service.test.ts
@@ -631,7 +631,7 @@ describe("handleService", () => {
     const output = logSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
     expect(output).toContain("Proxy on 8443");
     expect(output).toContain("HTTPS: no");
-    expect(output).toContain("TLD: local");
+    expect(output).toContain("TLDs: .local");
     expect(output).toContain("LAN mode: yes");
     expect(output).toContain("LAN IP: 192.168.1.42");
     expect(output).toContain("Wildcard: yes");

--- a/packages/portless/src/service.ts
+++ b/packages/portless/src/service.ts
@@ -10,7 +10,7 @@ import {
   discoverState,
   getProtocolPort,
   isProxyRunning,
-  validateTld,
+  parseTldList,
 } from "./cli-utils.js";
 import { isMdnsSupported } from "./mdns.js";
 import { fixOwnership } from "./utils.js";
@@ -23,6 +23,18 @@ const INTERNAL_ELEVATED_ENV = "PORTLESS_INTERNAL_SERVICE_ELEVATED";
 const SERVICE_ENV_KEYS = new Set(["PORTLESS_SYNC_HOSTS"]);
 
 type SupportedPlatform = "darwin" | "linux" | "win32";
+
+function normalizeTlds(tlds: readonly string[]): string[] {
+  return [...new Set(tlds.length > 0 ? tlds : [DEFAULT_TLD])];
+}
+
+function primaryTld(tlds: readonly string[]): string {
+  return tlds[0] ?? DEFAULT_TLD;
+}
+
+function formatTldList(tlds: readonly string[]): string {
+  return tlds.map((tld) => `.${tld}`).join(", ");
+}
 
 type CommandRunner = (
   command: string,
@@ -63,6 +75,7 @@ export type ServiceInstallConfig = {
   lanIp: string | null;
   lanIpExplicit: boolean;
   tld: string;
+  tlds: string[];
   useWildcard: boolean;
   extraEnv: Record<string, string>;
 };
@@ -80,6 +93,7 @@ const DEFAULT_SERVICE_CONFIG: ServiceInstallConfig = {
   lanIp: null,
   lanIpExplicit: false,
   tld: DEFAULT_TLD,
+  tlds: [DEFAULT_TLD],
   useWildcard: false,
   extraEnv: {},
 };
@@ -254,10 +268,8 @@ function parseServiceInstallConfig(
   }
 
   if (env.PORTLESS_TLD) {
-    const tld = env.PORTLESS_TLD.trim().toLowerCase();
-    const err = validateTld(tld);
-    if (err) throw new Error(`PORTLESS_TLD: ${err}`);
-    config.tld = tld;
+    config.tlds = normalizeTlds(parseTldList(env.PORTLESS_TLD, "PORTLESS_TLD"));
+    config.tld = primaryTld(config.tlds);
   }
 
   const envWildcard = parseBooleanEnv(env.PORTLESS_WILDCARD);
@@ -272,6 +284,7 @@ function parseServiceInstallConfig(
   }
 
   const tokens = args[0] === "service" ? args.slice(2) : args;
+  let tldFlagSeen = false;
   for (let i = 0; i < tokens.length; i += 1) {
     const token = tokens[i];
     switch (token) {
@@ -296,10 +309,10 @@ function parseServiceInstallConfig(
         i += 1;
         break;
       case "--tld": {
-        const tld = getFlagValue(tokens, i, token).trim().toLowerCase();
-        const err = validateTld(tld);
-        if (err) throw new Error(err);
-        config.tld = tld;
+        const tlds = parseTldList(getFlagValue(tokens, i, token));
+        config.tlds = normalizeTlds([...(tldFlagSeen ? config.tlds : []), ...tlds]);
+        config.tld = primaryTld(config.tlds);
+        tldFlagSeen = true;
         i += 1;
         break;
       }
@@ -345,6 +358,9 @@ function parseServiceInstallConfig(
   if (!config.lanMode) {
     config.lanIp = null;
     config.lanIpExplicit = false;
+  } else {
+    config.tlds = ["local"];
+    config.tld = "local";
   }
 
   return config;
@@ -403,6 +419,7 @@ function buildProxyCommand(entryScript: string, serviceConfig: ServiceInstallCon
     lanIp: serviceConfig.lanIp,
     lanIpExplicit: serviceConfig.lanIpExplicit,
     tld: serviceConfig.tld,
+    tlds: serviceConfig.tlds,
     useWildcard: serviceConfig.useWildcard,
     foreground: true,
     includePort: true,
@@ -428,8 +445,8 @@ function buildServiceEnv(ctx: ServiceContext): Record<string, string> {
 
   if (ctx.config.lanMode) {
     env.PORTLESS_TLD = "local";
-  } else if (ctx.config.tld !== DEFAULT_TLD) {
-    env.PORTLESS_TLD = ctx.config.tld;
+  } else if (ctx.config.tlds.length > 1 || ctx.config.tld !== DEFAULT_TLD) {
+    env.PORTLESS_TLD = ctx.config.tlds.join(",");
   }
 
   if (ctx.platform === "win32") {
@@ -540,6 +557,13 @@ export function buildServiceSpec(options: {
     ...options.installConfig,
     extraEnv: options.installConfig?.extraEnv ?? {},
   };
+  installConfig.tlds = installConfig.lanMode
+    ? ["local"]
+    : normalizeTlds(
+        options.installConfig?.tlds ??
+          (options.installConfig?.tld ? [options.installConfig.tld] : installConfig.tlds)
+      );
+  installConfig.tld = primaryTld(installConfig.tlds);
   const stateDir =
     options.stateDir ||
     installConfig.stateDir ||
@@ -1148,7 +1172,7 @@ async function printServiceStatus(entryScript: string, runner: CommandRunner): P
     `  Proxy on ${config.proxyPort}: ${status.proxyRunning ? "responding" : "not responding"}`
   );
   console.log(`  HTTPS: ${config.useHttps ? "yes" : "no"}`);
-  console.log(`  TLD: ${config.lanMode ? "local" : config.tld}`);
+  console.log(`  TLDs: ${config.lanMode ? ".local" : formatTldList(config.tlds)}`);
   console.log(`  LAN mode: ${config.lanMode ? "yes" : "no"}`);
   if (config.lanIpExplicit && config.lanIp) {
     console.log(`  LAN IP: ${config.lanIp}`);
@@ -1177,7 +1201,7 @@ ${colors.bold("Install options:")}
   --https                          Enable HTTPS
   --lan                            Enable LAN mode
   --ip <address>                   Pin a specific LAN IP
-  --tld <tld>                      Use a custom TLD outside LAN mode
+  --tld <tld>                      Use a custom TLD outside LAN mode, repeatable
   --wildcard                       Allow subdomain fallback
   --cert <path>                    Use a custom TLS certificate
   --key <path>                     Use a custom TLS private key

--- a/packages/portless/src/turbo.ts
+++ b/packages/portless/src/turbo.ts
@@ -56,6 +56,7 @@ export interface ManifestEntry {
   PORT: string;
   HOST: string;
   PORTLESS_URL: string;
+  __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS?: string;
   NODE_EXTRA_CA_CERTS?: string;
 }
 

--- a/packages/portless/src/types.ts
+++ b/packages/portless/src/types.ts
@@ -11,6 +11,8 @@ export interface ProxyServerOptions {
   proxyPort: number;
   /** TLD suffix used for hostnames (default: "localhost"). */
   tld?: string;
+  /** All TLD suffixes used for hostnames. The first one is used for examples. */
+  tlds?: string[];
   /**
    * When true, only exact hostname matches are used. Unregistered subdomain
    * prefixes return 404 instead of falling back to the base service.

--- a/packages/portless/src/utils.test.ts
+++ b/packages/portless/src/utils.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { escapeHtml, formatUrl, isErrnoException, isProcessAlive, parseHostname } from "./utils.js";
+import {
+  escapeHtml,
+  formatUrl,
+  isErrnoException,
+  isProcessAlive,
+  parseHostname,
+  parseHostnames,
+} from "./utils.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -232,5 +239,25 @@ describe("parseHostname", () => {
     it("works with dev TLD", () => {
       expect(parseHostname("myapp", "dev")).toBe("myapp.dev");
     });
+  });
+});
+
+describe("parseHostnames", () => {
+  it("builds one hostname per TLD", () => {
+    expect(parseHostnames("myapp", ["localhost", "test"])).toEqual([
+      "myapp.localhost",
+      "myapp.test",
+    ]);
+  });
+
+  it("strips an active TLD before building all hostnames", () => {
+    expect(parseHostnames("api.myapp.test", ["localhost", "test"])).toEqual([
+      "api.myapp.localhost",
+      "api.myapp.test",
+    ]);
+  });
+
+  it("deduplicates TLDs", () => {
+    expect(parseHostnames("myapp", ["test", "test"])).toEqual(["myapp.test"]);
   });
 });

--- a/packages/portless/src/utils.ts
+++ b/packages/portless/src/utils.ts
@@ -118,3 +118,26 @@ export function parseHostname(input: string, tld = "localhost"): string {
 
   return hostname;
 }
+
+/**
+ * Parse a hostname input for every configured TLD. If the input already ends
+ * with one of those TLDs, use the stripped base name for the full set.
+ */
+export function parseHostnames(input: string, tlds: readonly string[] = ["localhost"]): string[] {
+  const uniqueTlds = [...new Set(tlds)];
+  let baseInput = input
+    .trim()
+    .replace(/^https?:\/\//, "")
+    .split("/")[0]
+    .toLowerCase();
+
+  for (const tld of uniqueTlds) {
+    const suffix = `.${tld}`;
+    if (baseInput.endsWith(suffix)) {
+      baseInput = baseInput.slice(0, -suffix.length);
+      break;
+    }
+  }
+
+  return uniqueTlds.map((tld) => parseHostname(baseInput, tld));
+}

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -48,7 +48,7 @@ portless myapp next dev
 # -> https://myapp.localhost
 ```
 
-The proxy auto-starts when you run an app. You can also start it explicitly with `portless proxy start`. Auto-start reuses the configuration (port, TLS, TLD) from the most recent proxy run, so a restart or reboot does not silently revert to defaults. Explicit env vars always take priority.
+The proxy auto-starts when you run an app. You can also start it explicitly with `portless proxy start`. Auto-start reuses the configuration (port, TLS, TLDs) from the most recent proxy run, so a restart or reboot does not silently revert to defaults. Explicit env vars always take priority.
 
 In non-interactive environments (no TTY, or `CI=1`), portless exits with a descriptive error instead of prompting. Task runners like turborepo should pre-start the proxy.
 
@@ -163,6 +163,8 @@ PORTLESS=0 pnpm dev   # Bypasses proxy, uses default port
 
 `.localhost` domains resolve to `127.0.0.1` natively in Chrome, Firefox, and Edge. Safari relies on the system DNS resolver, which may not handle `.localhost` subdomains on all configurations. Run `portless hosts sync` to add entries to `/etc/hosts` if needed.
 
+Use `portless proxy start --tld localhost --tld test` to serve the same app names under multiple TLDs from one proxy. `PORTLESS_URL` uses the first configured TLD. `PORTLESS_TLD` accepts the same comma separated list format, e.g. `PORTLESS_TLD=localhost,test`.
+
 Most frameworks (Next.js, Express, Nuxt, etc.) respect the `PORT` env var automatically. For frameworks that ignore `PORT` (Vite, VitePlus, Astro, React Router, Angular, Expo, React Native), portless auto-injects the correct `--port` flag and, when needed, a matching `--host` CLI flag.
 
 ### State directory
@@ -178,7 +180,7 @@ Portless stores its state (routes, PID file, port file) in `~/.portless`. Overri
 | `PORTLESS_HTTPS`      | HTTPS on by default; set to `0` to disable (same as `--no-tls`)             |
 | `PORTLESS_LAN`        | Set to `1` to always enable LAN mode (auto-detects LAN IP)                  |
 | `PORTLESS_LAN_IP`     | Pin a specific LAN IP for LAN mode                                          |
-| `PORTLESS_TLD`        | Use a custom TLD instead of localhost (e.g. test)                           |
+| `PORTLESS_TLD`        | Use one or more TLDs (e.g. localhost,test)                                  |
 | `PORTLESS_WILDCARD`   | Set to `1` to allow unregistered subdomains to fall back to parent          |
 | `PORTLESS_SYNC_HOSTS` | Set to `0` to disable auto-sync of /etc/hosts (on by default)               |
 | `PORTLESS_TAILSCALE`  | Set to `1` to share apps on your Tailscale network (same as `--tailscale`)  |
@@ -209,7 +211,7 @@ portless proxy start --lan --ip 192.168.1.42
 
 `--lan` advertises `<name>.local` hostnames over mDNS so any device on the same Wi-Fi can reach your apps. Portless auto-detects your LAN IP and follows network changes automatically, but you can pin a specific address with `--ip <address>` or the `PORTLESS_LAN_IP` environment variable. Set `PORTLESS_LAN=1` to default to LAN mode every time the proxy starts.
 
-Portless remembers LAN mode via `proxy.lan`, so if you stop a LAN proxy and start again, it stays in LAN mode. All proxy settings (port, TLS, TLD, LAN) are persisted and reused on auto-start unless overridden by explicit flags or env vars. Use `PORTLESS_LAN=0` for one start to switch back to `.localhost` mode. If a proxy is already running with different explicit LAN/TLS/TLD settings, portless warns and asks you to stop it first.
+Portless remembers LAN mode via `proxy.lan`, so if you stop a LAN proxy and start again, it stays in LAN mode. All proxy settings (port, TLS, TLDs, LAN) are persisted and reused on auto-start unless overridden by explicit flags or env vars. Use `PORTLESS_LAN=0` for one start to switch back to `.localhost` mode. If a proxy is already running with different explicit LAN/TLS/TLD settings, portless warns and asks you to stop it first.
 
 LAN mode depends on the system mDNS helpers that portless launches: macOS includes `dns-sd`, while Linux uses `avahi-publish-address` from `avahi-utils` (install via `sudo apt install avahi-utils` or your distro’s tooling).
 
@@ -269,54 +271,55 @@ portless service uninstall
 
 The service uses portless defaults unless install options or `PORTLESS_*` environment variables are provided: HTTPS on port 443 with `.localhost` names. `service install` accepts proxy options including `--port`, `--no-tls`, `--lan`, `--ip`, `--tld`, `--wildcard`, `--cert`, and `--key`. Use `--state-dir <path>` or `PORTLESS_STATE_DIR=<path>` to choose where service state and logs are written.
 
-The chosen service configuration is written into launchd, systemd, or Task Scheduler and reused after reboot. `portless service status` reports the installed port, HTTPS mode, TLD, LAN mode, wildcard mode, and state directory. macOS and Linux install a root-owned service so port 443 can bind at boot. Windows installs a Task Scheduler startup task that runs as SYSTEM. Installation and removal may require administrator privileges. `portless clean` automatically removes the service.
+The chosen service configuration is written into launchd, systemd, or Task Scheduler and reused after reboot. `portless service status` reports the installed port, HTTPS mode, TLDs, LAN mode, wildcard mode, and state directory. macOS and Linux install a root-owned service so port 443 can bind at boot. Windows installs a Task Scheduler startup task that runs as SYSTEM. Installation and removal may require administrator privileges. `portless clean` automatically removes the service.
 
 ## CLI Reference
 
-| Command                                | Description                                                    |
-| -------------------------------------- | -------------------------------------------------------------- |
-| `portless`                             | Run dev script through proxy                                   |
-| `portless`                             | From monorepo root: run all workspace packages                 |
-| `portless --script <name>`             | Run a specific package.json script (default: dev)              |
-| `portless run [cmd] [args...]`         | Infer name from project, run through proxy (auto-starts)       |
-| `portless run --name <name> <cmd>`     | Override inferred base name (worktree prefix still applies)    |
-| `portless <name> <cmd> [args...]`      | Run app at `https://<name>.localhost` (auto-starts proxy)      |
-| `portless get <name>`                  | Print URL for a service (for cross-service wiring)             |
-| `portless get <name> --no-worktree`    | Print URL without worktree prefix                              |
-| `portless list`                        | Show active routes                                             |
-| `portless doctor`                      | Check proxy, routes, DNS, CA trust, and LAN prerequisites      |
-| `portless trust`                       | Add local CA to system trust store (for HTTPS)                 |
-| `portless clean`                       | Remove state, CA trust entry, and /etc/hosts block             |
-| `portless prune`                       | Kill orphaned dev servers from crashed sessions                |
-| `portless prune --force`               | Kill orphans with SIGKILL instead of SIGTERM                   |
-| `portless proxy start`                 | Start HTTPS proxy as a daemon (port 443, auto-elevates)        |
-| `portless proxy start --no-tls`        | Start without HTTPS (plain HTTP on port 80)                    |
-| `portless proxy start --lan`           | Start in LAN mode (mDNS `.local`, auto-follows LAN IP changes) |
-| `portless proxy start -p <number>`     | Start the proxy on a custom port                               |
-| `portless proxy start --tld test`      | Use .test instead of .localhost                                |
-| `portless proxy start --foreground`    | Start the proxy in foreground (for debugging)                  |
-| `portless proxy start --wildcard`      | Allow unregistered subdomains to fall back to parent route     |
-| `portless proxy stop`                  | Stop the proxy                                                 |
-| `portless service install`             | Start the HTTPS proxy when the OS starts                       |
-| `portless service install --lan`       | Start the service in LAN mode                                  |
-| `portless service install --wildcard`  | Persist wildcard routing in the startup service                |
-| `portless service status`              | Show service and proxy status                                  |
-| `portless service uninstall`           | Remove the startup service                                     |
-| `portless alias <name> <port>`         | Register a static route (e.g. for Docker containers)           |
-| `portless alias <name> <port> --force` | Overwrite an existing route                                    |
-| `portless alias --remove <name>`       | Remove a static route                                          |
-| `portless hosts sync`                  | Add routes to /etc/hosts (fixes Safari)                        |
-| `portless hosts clean`                 | Remove portless entries from /etc/hosts                        |
-| `portless <name> --app-port <n> <cmd>` | Use a fixed port for the app instead of auto-assignment        |
-| `portless <name> --tailscale <cmd>`    | Share the app on your Tailscale network (tailnet)              |
-| `portless <name> --funnel <cmd>`       | Share the app publicly via Tailscale Funnel                    |
-| `portless <name> --ngrok <cmd>`        | Share the app publicly via ngrok                               |
-| `portless <name> --force <cmd>`        | Kill the existing process and take over its route              |
-| `portless --name <name> <cmd>`         | Force `<name>` as app name (bypasses subcommand dispatch)      |
-| `portless <name> -- <cmd> [args...]`   | Stop flag parsing; everything after `--` is passed to child    |
-| `portless --help` / `-h`               | Show help                                                      |
-| `portless run --help`                  | Show help for a subcommand (also: alias, hosts, clean)         |
-| `portless --version` / `-v`            | Show version                                                   |
+| Command                                           | Description                                                    |
+| ------------------------------------------------- | -------------------------------------------------------------- |
+| `portless`                                        | Run dev script through proxy                                   |
+| `portless`                                        | From monorepo root: run all workspace packages                 |
+| `portless --script <name>`                        | Run a specific package.json script (default: dev)              |
+| `portless run [cmd] [args...]`                    | Infer name from project, run through proxy (auto-starts)       |
+| `portless run --name <name> <cmd>`                | Override inferred base name (worktree prefix still applies)    |
+| `portless <name> <cmd> [args...]`                 | Run app at `https://<name>.localhost` (auto-starts proxy)      |
+| `portless get <name>`                             | Print URL for a service (for cross-service wiring)             |
+| `portless get <name> --no-worktree`               | Print URL without worktree prefix                              |
+| `portless list`                                   | Show active routes                                             |
+| `portless doctor`                                 | Check proxy, routes, DNS, CA trust, and LAN prerequisites      |
+| `portless trust`                                  | Add local CA to system trust store (for HTTPS)                 |
+| `portless clean`                                  | Remove state, CA trust entry, and /etc/hosts block             |
+| `portless prune`                                  | Kill orphaned dev servers from crashed sessions                |
+| `portless prune --force`                          | Kill orphans with SIGKILL instead of SIGTERM                   |
+| `portless proxy start`                            | Start HTTPS proxy as a daemon (port 443, auto-elevates)        |
+| `portless proxy start --no-tls`                   | Start without HTTPS (plain HTTP on port 80)                    |
+| `portless proxy start --lan`                      | Start in LAN mode (mDNS `.local`, auto-follows LAN IP changes) |
+| `portless proxy start -p <number>`                | Start the proxy on a custom port                               |
+| `portless proxy start --tld test`                 | Use .test instead of .localhost                                |
+| `portless proxy start --tld localhost --tld test` | Serve both TLDs from one proxy                                 |
+| `portless proxy start --foreground`               | Start the proxy in foreground (for debugging)                  |
+| `portless proxy start --wildcard`                 | Allow unregistered subdomains to fall back to parent route     |
+| `portless proxy stop`                             | Stop the proxy                                                 |
+| `portless service install`                        | Start the HTTPS proxy when the OS starts                       |
+| `portless service install --lan`                  | Start the service in LAN mode                                  |
+| `portless service install --wildcard`             | Persist wildcard routing in the startup service                |
+| `portless service status`                         | Show service and proxy status                                  |
+| `portless service uninstall`                      | Remove the startup service                                     |
+| `portless alias <name> <port>`                    | Register a static route (e.g. for Docker containers)           |
+| `portless alias <name> <port> --force`            | Overwrite an existing route                                    |
+| `portless alias --remove <name>`                  | Remove a static route                                          |
+| `portless hosts sync`                             | Add routes to /etc/hosts (fixes Safari)                        |
+| `portless hosts clean`                            | Remove portless entries from /etc/hosts                        |
+| `portless <name> --app-port <n> <cmd>`            | Use a fixed port for the app instead of auto-assignment        |
+| `portless <name> --tailscale <cmd>`               | Share the app on your Tailscale network (tailnet)              |
+| `portless <name> --funnel <cmd>`                  | Share the app publicly via Tailscale Funnel                    |
+| `portless <name> --ngrok <cmd>`                   | Share the app publicly via ngrok                               |
+| `portless <name> --force <cmd>`                   | Kill the existing process and take over its route              |
+| `portless --name <name> <cmd>`                    | Force `<name>` as app name (bypasses subcommand dispatch)      |
+| `portless <name> -- <cmd> [args...]`              | Stop flag parsing; everything after `--` is passed to child    |
+| `portless --help` / `-h`                          | Show help                                                      |
+| `portless run --help`                             | Show help for a subcommand (also: alias, hosts, clean)         |
+| `portless --version` / `-v`                       | Show version                                                   |
 
 **Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `doctor`, `trust`, `clean`, `prune`, `proxy`, and `service` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name, or `portless --name <name> <cmd>` to force any name including reserved ones.
 


### PR DESCRIPTION
- Allow repeated `--tld` flags and comma separated PORTLESS_TLD values
- Register routes, service state, and TLS handling across configured TLDs
- Update docs, CLI help, and tests for multi-TLD behavior