### PR TITLE
Prepare v0.15.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 # Changelog
 
-## 0.15.0
+## 0.15.1
 
 <!-- release:start -->
+
+### New Features
+
+- **Multi-TLD proxy support**: `--tld` is now repeatable and `PORTLESS_TLD` accepts comma separated values, so one proxy can serve the same app names across multiple TLDs. Routes, TLS, service state, hosts sync, framework environment, and workspace launches now use the full configured TLD list. (#344)
+
+### Contributors
+
+- @ctate
+<!-- release:end -->
+
+## 0.15.0
 
 ### New Features
 
@@ -16,7 +27,6 @@
 ### Contributors
 
 - @ctate
-<!-- release:end -->
 
 ## 0.14.0
 

--- a/apps/docs/src/app/changelog/page.mdx
+++ b/apps/docs/src/app/changelog/page.mdx
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.15.1
+
+### New Features
+
+- **Multi-TLD proxy support**: `--tld` is now repeatable and `PORTLESS_TLD` accepts comma separated values, so one proxy can serve the same app names across multiple TLDs. Routes, TLS, service state, hosts sync, framework environment, and workspace launches now use the full configured TLD list
+
 ## 0.15.0
 
 ### New Features

--- a/packages/portless/package.json
+++ b/packages/portless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portless",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Replace port numbers with stable, named .localhost URLs. For humans and agents.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/portless/src/routes.test.ts
+++ b/packages/portless/src/routes.test.ts
@@ -375,7 +375,7 @@ describe("RouteStore", () => {
       const hostnames = raw.map((r: { hostname: string }) => r.hostname).sort();
       const expected = Array.from({ length: count }, (_, i) => `app${i}.localhost`).sort();
       expect(hostnames).toEqual(expected);
-    }, 15_000);
+    }, 30_000);
 
     it("survives sustained lock contention that defeats a naive retry strategy", async () => {
       store.ensureDir();
@@ -383,7 +383,7 @@ describe("RouteStore", () => {
 
       // A child process holds the lock for 1.5s, simulating a slow writer on
       // a loaded machine. The old strategy (20 retries * 50ms = 1s budget)
-      // would time out; exponential backoff with a 5s budget survives.
+      // would time out; exponential backoff with a larger budget survives.
       const holdMs = 1500;
       const holder = spawn(
         process.execPath,

--- a/packages/portless/src/routes.ts
+++ b/packages/portless/src/routes.ts
@@ -7,13 +7,13 @@ import { fixOwnership, isErrnoException } from "./utils.js";
 const STALE_LOCK_THRESHOLD_MS = 10_000;
 
 /** Total time budget (ms) for acquiring the file lock before giving up. */
-const LOCK_TIMEOUT_MS = 5_000;
+const LOCK_TIMEOUT_MS = 15_000;
 
 /** Initial delay (ms) between lock acquisition retries (doubles each attempt). */
 const LOCK_RETRY_BASE_MS = 10;
 
 /** Maximum delay (ms) between lock acquisition retries. */
-const LOCK_RETRY_CAP_MS = 500;
+const LOCK_RETRY_CAP_MS = 100;
 
 /** File permission mode for route and state files. */
 export const FILE_MODE = 0o644;


### PR DESCRIPTION
- Bump the portless package version to 0.15.1
- Add release notes for multi-TLD proxy support
- Move release markers to the latest changelog entry