### PR TITLE
fix(portless): proxy tailscale public hostnames for tunnel routes fixes #343

### DIFF
--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -218,6 +218,72 @@ describe("createProxyServer", () => {
       expect(res.body).toBe("exact");
     });
 
+    it("routes requests for tailscale public URL hostnames", async () => {
+      const backend = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("tailscale routed");
+        })
+      );
+      await listen(backend);
+      const backendAddr = backend.address();
+      if (!backendAddr || typeof backendAddr === "string") throw new Error("no addr");
+
+      const routes: RouteInfo[] = [
+        {
+          hostname: "myfeature.myapp.localhost",
+          port: backendAddr.port,
+          tailscaleUrl: "https://example.tailnet.ts.net",
+        },
+      ];
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => routes,
+          proxyPort: TEST_PROXY_PORT,
+        })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "example.tailnet.ts.net" });
+      expect(res.status).toBe(200);
+      expect(res.body).toBe("tailscale routed");
+    });
+
+    it("matches tailscale hostnames via URL parsing even when exact host isn't in routes", async () => {
+      const backend = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("tailhost parse");
+        })
+      );
+      await listen(backend);
+      const backendAddr = backend.address();
+      if (!backendAddr || typeof backendAddr === "string") throw new Error("no addr");
+
+      const routes: RouteInfo[] = [
+        {
+          hostname: "other.localhost",
+          port: 4001,
+        },
+        {
+          hostname: "myfeature.myapp.localhost",
+          port: backendAddr.port,
+          tailscaleUrl: "https://node-name.tailnet.ts.net/path",
+        },
+      ];
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => routes,
+          proxyPort: TEST_PROXY_PORT,
+        })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "node-name.tailnet.ts.net" });
+      expect(res.status).toBe(200);
+      expect(res.body).toBe("tailhost parse");
+    });
+
     it("returns 404 when subdomain does not match any route", async () => {
       const routes: RouteInfo[] = [{ hostname: "myapp.localhost", port: 4001 }];
       const server = trackServer(

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -32,6 +32,14 @@ function getRequestHost(req: http.IncomingMessage): string {
   return req.headers.host || "";
 }
 
+function normalizeTailscaleHost(value: string): string {
+  try {
+    return new URL(value).hostname;
+  } catch {
+    return "";
+  }
+}
+
 /**
  * Detect whether a request arrived over an encrypted (TLS) connection.
  * Works for both native TLS sockets and HTTP/2 streams.
@@ -89,10 +97,22 @@ function findRoute(
   host: string,
   strict?: boolean
 ): { hostname: string; port: number } | undefined {
-  return (
-    routes.find((r) => r.hostname === host) ||
-    (strict ? undefined : routes.find((r) => host.endsWith("." + r.hostname)))
-  );
+  const exactRoute = routes.find((r) => r.hostname === host);
+  if (exactRoute) {
+    return exactRoute;
+  }
+
+  if (!strict) {
+    const wildcardRoute = routes.find((r) => host.endsWith(`.${r.hostname}`));
+    if (wildcardRoute) {
+      return wildcardRoute;
+    }
+  }
+
+  return routes.find((route) => {
+    const tailscaleHost = normalizeTailscaleHost(route.tailscaleUrl || "");
+    return !!tailscaleHost && tailscaleHost === host;
+  });
 }
 
 /** Server type returned by createProxyServer (plain HTTP/1.1 or net.Server TLS wrapper). */

--- a/packages/portless/src/types.ts
+++ b/packages/portless/src/types.ts
@@ -2,6 +2,7 @@
 export interface RouteInfo {
   hostname: string;
   port: number;
+  tailscaleUrl?: string;
 }
 
 export interface ProxyServerOptions {


### PR DESCRIPTION
## Why this change
This fixes #343 where `portless run --funnel` in a git worktree can return `portless` 404s on the public `.ts.net` URL. The proxy had no route match for the tunnel hostname because it only looked up `hostname` entries.

## What changed
- Added optional `tailscaleUrl` to `RouteInfo`.
- Extended proxy route matching to check, after normal `hostname` matching, whether any route's `tailscaleUrl` host matches the incoming Host header.
- Added proxy tests for public Tailscale hostname routing (including URL-form hostnames).

## Risk
Low. Existing localhost routing behavior is unchanged; this only adds additional match candidates based on stored tailnet route metadata.

## Validation
- `pnpm --filter portless exec vitest run src/proxy.test.ts` (47 passed)
- Repo hook formatting/lint ran on commit.
