### PR TITLE
fix(proxy): route requests addressed to a route's tailscale hostname

### DIFF
--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1333,7 +1333,10 @@ async function runApp(
         tailscaleFunnel: wantsFunnel || undefined,
       });
     } catch {
-      // Non-fatal: route display metadata only
+      // Non-fatal: the local hostname keeps routing without it, but the
+      // proxy needs tailscaleUrl to route requests arriving with the
+      // public .ts.net Host header (see findRoute), so the tailscale URL
+      // may 404 until the route is re-registered.
     }
   }
 

--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -324,6 +324,80 @@ describe("createProxyServer", () => {
       expect(res.status).toBe(404);
     });
 
+    it("matches the tailscale route registered for the request port", async () => {
+      const backendA = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("app on :443");
+        })
+      );
+      const backendB = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("app on :8443");
+        })
+      );
+      await listen(backendA);
+      await listen(backendB);
+      const addrA = backendA.address();
+      const addrB = backendB.address();
+      if (!addrA || typeof addrA === "string") throw new Error("no addr");
+      if (!addrB || typeof addrB === "string") throw new Error("no addr");
+
+      const routes: RouteInfo[] = [
+        {
+          hostname: "app-a.localhost",
+          port: addrA.port,
+          tailscaleUrl: "https://my-device.tail1234.ts.net",
+        },
+        {
+          hostname: "app-b.localhost",
+          port: addrB.port,
+          tailscaleUrl: "https://my-device.tail1234.ts.net:8443",
+        },
+      ];
+      const server = trackServer(
+        createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+      );
+      await listen(server);
+
+      const resB = await request(server, { host: "my-device.tail1234.ts.net:8443" });
+      expect(resB.status).toBe(200);
+      expect(resB.body).toBe("app on :8443");
+
+      const resA = await request(server, { host: "my-device.tail1234.ts.net" });
+      expect(resA.status).toBe(200);
+      expect(resA.body).toBe("app on :443");
+    });
+
+    it("matches a tailscale route by hostname when the request port differs", async () => {
+      const backend = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("only app");
+        })
+      );
+      await listen(backend);
+      const addr = backend.address();
+      if (!addr || typeof addr === "string") throw new Error("no addr");
+
+      const routes: RouteInfo[] = [
+        {
+          hostname: "myapp.localhost",
+          port: addr.port,
+          tailscaleUrl: "https://my-device.tail1234.ts.net:8443",
+        },
+      ];
+      const server = trackServer(
+        createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "my-device.tail1234.ts.net" });
+      expect(res.status).toBe(200);
+      expect(res.body).toBe("only app");
+    });
+
     it("returns 404 for unregistered subdomain prefix by default", async () => {
       const backend = trackServer(
         http.createServer((_req, res) => {

--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -251,6 +251,79 @@ describe("createProxyServer", () => {
       expect(res.body).toBe("matched");
     });
 
+    it("routes requests addressed to a route's tailscale hostname (issue #297)", async () => {
+      const backend = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("funnel hit");
+        })
+      );
+      await listen(backend);
+      const backendAddr = backend.address();
+      if (!backendAddr || typeof backendAddr === "string") throw new Error("no addr");
+
+      const routes: RouteInfo[] = [
+        {
+          hostname: "myapp.localhost",
+          port: backendAddr.port,
+          tailscaleUrl: "https://my-device.tail1234.ts.net",
+        },
+      ];
+      const server = trackServer(
+        createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "my-device.tail1234.ts.net" });
+      expect(res.status).toBe(200);
+      expect(res.body).toBe("funnel hit");
+    });
+
+    it("routes tailscale hostname even when the local hostname is worktree-prefixed (issue #343)", async () => {
+      const backend = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("worktree funnel hit");
+        })
+      );
+      await listen(backend);
+      const backendAddr = backend.address();
+      if (!backendAddr || typeof backendAddr === "string") throw new Error("no addr");
+
+      const routes: RouteInfo[] = [
+        {
+          hostname: "myfeature.myapp.localhost",
+          port: backendAddr.port,
+          tailscaleUrl: "https://my-device.tail1234.ts.net",
+        },
+      ];
+      const server = trackServer(
+        createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT, strict: true })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "my-device.tail1234.ts.net" });
+      expect(res.status).toBe(200);
+      expect(res.body).toBe("worktree funnel hit");
+    });
+
+    it("does not match tailscale hostname against unrelated hosts", async () => {
+      const routes: RouteInfo[] = [
+        {
+          hostname: "myapp.localhost",
+          port: 4001,
+          tailscaleUrl: "https://my-device.tail1234.ts.net",
+        },
+      ];
+      const server = trackServer(
+        createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "other-device.tail1234.ts.net" });
+      expect(res.status).toBe(404);
+    });
+
     it("returns 404 for unregistered subdomain prefix by default", async () => {
       const backend = trackServer(
         http.createServer((_req, res) => {

--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -398,6 +398,78 @@ describe("createProxyServer", () => {
       expect(res.body).toBe("only app");
     });
 
+    it("routes an explicit :443 tailscale Host to the default-port app when another route shares the hostname (review: ctate)", async () => {
+      const backendDefault = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("app on :443");
+        })
+      );
+      const backendAlt = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("app on :8443");
+        })
+      );
+      await listen(backendDefault);
+      await listen(backendAlt);
+      const addrDefault = backendDefault.address();
+      const addrAlt = backendAlt.address();
+      if (!addrDefault || typeof addrDefault === "string") throw new Error("no addr");
+      if (!addrAlt || typeof addrAlt === "string") throw new Error("no addr");
+
+      // The alternate-port route is listed first so a port-insensitive fallback
+      // would resolve the explicit :443 request to the wrong app.
+      const routes: RouteInfo[] = [
+        {
+          hostname: "app-b.localhost",
+          port: addrAlt.port,
+          tailscaleUrl: "https://my-device.tail1234.ts.net:8443",
+        },
+        {
+          hostname: "app-a.localhost",
+          port: addrDefault.port,
+          tailscaleUrl: "https://my-device.tail1234.ts.net",
+        },
+      ];
+      const server = trackServer(
+        createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "my-device.tail1234.ts.net:443" });
+      expect(res.status).toBe(200);
+      expect(res.body).toBe("app on :443");
+    });
+
+    it("matches a tailscale hostname case-insensitively (review: ctate)", async () => {
+      const backend = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("mixed case funnel hit");
+        })
+      );
+      await listen(backend);
+      const backendAddr = backend.address();
+      if (!backendAddr || typeof backendAddr === "string") throw new Error("no addr");
+
+      const routes: RouteInfo[] = [
+        {
+          hostname: "myapp.localhost",
+          port: backendAddr.port,
+          tailscaleUrl: "https://my-device.tail1234.ts.net",
+        },
+      ];
+      const server = trackServer(
+        createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "My-Device.Tail1234.TS.net" });
+      expect(res.status).toBe(200);
+      expect(res.body).toBe("mixed case funnel hit");
+    });
+
     it("returns 404 for unregistered subdomain prefix by default", async () => {
       const backend = trackServer(
         http.createServer((_req, res) => {

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -76,21 +76,36 @@ const PORTLESS_HOPS_HEADER = "x-portless-hops";
  */
 const MAX_PROXY_HOPS = 5;
 
+/** Extract the hostname from a route's tailscaleUrl, or undefined if unset/invalid. */
+function tailscaleHostname(tailscaleUrl: string | undefined): string | undefined {
+  if (!tailscaleUrl) return undefined;
+  try {
+    return new URL(tailscaleUrl).hostname;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Find the route matching a given host. Matches exact hostname first, then
- * falls back to wildcard subdomain matching (e.g. tenant.myapp.localhost
- * matches a route registered for myapp.localhost).
+ * the hostname of the route's public Tailscale Serve/Funnel URL (so inbound
+ * funnel traffic with Host: <device>.<tailnet>.ts.net resolves to the same
+ * upstream as the local hostname), then falls back to wildcard subdomain
+ * matching (e.g. tenant.myapp.localhost matches a route registered for
+ * myapp.localhost).
  *
- * When `strict` is true, only exact matches are returned; unregistered
- * subdomain prefixes will not fall back to the base service.
+ * When `strict` is true, only exact matches (local or tailscale hostname)
+ * are returned; unregistered subdomain prefixes will not fall back to the
+ * base service.
  */
 function findRoute(
-  routes: { hostname: string; port: number }[],
+  routes: { hostname: string; port: number; tailscaleUrl?: string }[],
   host: string,
   strict?: boolean
 ): { hostname: string; port: number } | undefined {
   return (
     routes.find((r) => r.hostname === host) ||
+    routes.find((r) => tailscaleHostname(r.tailscaleUrl) === host) ||
     (strict ? undefined : routes.find((r) => host.endsWith("." + r.hostname)))
   );
 }

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -76,37 +76,34 @@ const PORTLESS_HOPS_HEADER = "x-portless-hops";
  */
 const MAX_PROXY_HOPS = 5;
 
-/** Extract the hostname from a route's tailscaleUrl, or undefined if unset/invalid. */
-function tailscaleHostname(tailscaleUrl: string | undefined): string | undefined {
+/** Authority (hostname, plus port when non-default) of a route's tailscaleUrl, or undefined if unset or invalid. */
+function tailscaleAuthority(tailscaleUrl: string | undefined): string | undefined {
   if (!tailscaleUrl) return undefined;
   try {
-    return new URL(tailscaleUrl).hostname;
+    return new URL(tailscaleUrl).host;
   } catch {
     return undefined;
   }
 }
 
 /**
- * Find the route matching a given host. Matches exact hostname first, then
- * the hostname of the route's public Tailscale Serve/Funnel URL (so inbound
- * funnel traffic with Host: <device>.<tailnet>.ts.net resolves to the same
- * upstream as the local hostname), then falls back to wildcard subdomain
- * matching (e.g. tenant.myapp.localhost matches a route registered for
- * myapp.localhost).
- *
- * When `strict` is true, only exact matches (local or tailscale hostname)
- * are returned; unregistered subdomain prefixes will not fall back to the
- * base service.
+ * Find the route matching a request's host, which may include a port. Match
+ * order: local hostname, tailscale authority (hostname and port), tailscale
+ * hostname ignoring port, then wildcard subdomain. The authority tier
+ * disambiguates apps sharing a `.ts.net` hostname on different ports; the
+ * hostname tier keeps other-port requests resolving. `strict` drops the wildcard.
  */
 function findRoute(
   routes: { hostname: string; port: number; tailscaleUrl?: string }[],
   host: string,
   strict?: boolean
 ): { hostname: string; port: number } | undefined {
+  const hostname = host.split(":")[0];
   return (
-    routes.find((r) => r.hostname === host) ||
-    routes.find((r) => tailscaleHostname(r.tailscaleUrl) === host) ||
-    (strict ? undefined : routes.find((r) => host.endsWith("." + r.hostname)))
+    routes.find((r) => r.hostname === hostname) ||
+    routes.find((r) => tailscaleAuthority(r.tailscaleUrl) === host) ||
+    routes.find((r) => tailscaleAuthority(r.tailscaleUrl)?.split(":")[0] === hostname) ||
+    (strict ? undefined : routes.find((r) => hostname.endsWith("." + r.hostname)))
   );
 }
 
@@ -142,7 +139,8 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
     res.setHeader(PORTLESS_HEADER, "1");
 
     const routes = getRoutes();
-    const host = getRequestHost(req).split(":")[0];
+    const rawHost = getRequestHost(req);
+    const host = rawHost.split(":")[0];
 
     if (!host) {
       res.writeHead(400, { "Content-Type": "text/plain" });
@@ -173,7 +171,7 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
       return;
     }
 
-    const route = findRoute(routes, host, strict);
+    const route = findRoute(routes, rawHost, strict);
 
     if (!route) {
       const safeHost = escapeHtml(host);
@@ -301,8 +299,7 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
     }
 
     const routes = getRoutes();
-    const host = getRequestHost(req).split(":")[0];
-    const route = findRoute(routes, host, strict);
+    const route = findRoute(routes, getRequestHost(req), strict);
 
     if (!route) {
       socket.destroy();

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -80,10 +80,26 @@ const MAX_PROXY_HOPS = 5;
 function tailscaleAuthority(tailscaleUrl: string | undefined): string | undefined {
   if (!tailscaleUrl) return undefined;
   try {
+    // `URL` lowercases the host and drops the default `:443`, so the value is
+    // already in the normalized form findRoute compares against.
     return new URL(tailscaleUrl).host;
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Normalize a request authority for comparison: lowercase it (Host is
+ * case-insensitive) and drop an explicit `:443`, the default HTTPS port that
+ * `URL` strips from a route's stored tailscale authority. Without this a
+ * mixed-case Host never matches, and an explicit `dev.ts.net:443` misses the
+ * authority tier and falls through to the port-insensitive hostname tier,
+ * resolving to the wrong app when several routes share a `.ts.net` hostname on
+ * different ports.
+ */
+function normalizeAuthority(host: string): string {
+  const lower = host.toLowerCase();
+  return lower.endsWith(":443") ? lower.slice(0, -":443".length) : lower;
 }
 
 /**
@@ -92,18 +108,21 @@ function tailscaleAuthority(tailscaleUrl: string | undefined): string | undefine
  * hostname ignoring port, then wildcard subdomain. The authority tier
  * disambiguates apps sharing a `.ts.net` hostname on different ports; the
  * hostname tier keeps other-port requests resolving. `strict` drops the wildcard.
+ * All comparisons run against the normalized authority so they are
+ * case-insensitive and treat an explicit `:443` as the default HTTPS port.
  */
 function findRoute(
   routes: { hostname: string; port: number; tailscaleUrl?: string }[],
   host: string,
   strict?: boolean
 ): { hostname: string; port: number } | undefined {
-  const hostname = host.split(":")[0];
+  const authority = normalizeAuthority(host);
+  const hostname = authority.split(":")[0];
   return (
-    routes.find((r) => r.hostname === hostname) ||
-    routes.find((r) => tailscaleAuthority(r.tailscaleUrl) === host) ||
+    routes.find((r) => r.hostname.toLowerCase() === hostname) ||
+    routes.find((r) => tailscaleAuthority(r.tailscaleUrl) === authority) ||
     routes.find((r) => tailscaleAuthority(r.tailscaleUrl)?.split(":")[0] === hostname) ||
-    (strict ? undefined : routes.find((r) => hostname.endsWith("." + r.hostname)))
+    (strict ? undefined : routes.find((r) => hostname.endsWith("." + r.hostname.toLowerCase())))
   );
 }
 

--- a/packages/portless/src/types.ts
+++ b/packages/portless/src/types.ts
@@ -2,6 +2,12 @@
 export interface RouteInfo {
   hostname: string;
   port: number;
+  /**
+   * Public Tailscale Serve/Funnel URL for this route, when one is active
+   * (e.g. "https://my-device.tail1234.ts.net"). Requests whose Host header
+   * matches this URL's hostname are routed to the same upstream.
+   */
+  tailscaleUrl?: string;
 }
 
 export interface ProxyServerOptions {


### PR DESCRIPTION
## Bug

Requests with the Tailscale hostname (`Host: <device>.<tailnet>.ts.net`) got portless's 404 instead of routing to the app. `findRoute` matched `r.hostname` (the local name) only, so tailnet traffic never resolved. #343 is the same cause seen from a git worktree.

## Fix

`findRoute` now matches the route's `tailscaleUrl` after the local hostname and before the wildcard fallback, in two tiers:

- exact authority (hostname and port), so apps sharing one `.ts.net` hostname on different HTTPS ports resolve to the right route
- hostname regardless of port, a non-breaking fallback so a request reaching the proxy on a different port still resolves

URL parsing is guarded and keyed off `tailscaleUrl` presence, so `tailscale serve` routes benefit too. The request and WebSocket paths share `findRoute`. Supersedes #349, thanks @ahfoysal.

## Tests

- 5 proxy tests: funnel hostname (`#297`), worktree-prefixed under `strict` (`#343`), negative case, and two for ports (same hostname on 443 and 8443 route to their own app; a single app resolves when the request port differs)
- reverting `proxy.ts` fails the port and issue tests
- `tsc --noEmit`, `eslint` green

Fixes #297. Fixes #343.