### PR TITLE
fix(proxy): dial upstreams over both loopback families

### DIFF
--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -22,6 +22,7 @@ import {
   getProtocolPort,
   isHttpsEnvDisabled,
   injectFrameworkFlags,
+  isPortListening,
   isProxyRunning,
   parsePidFromNetstat,
   parseTldList,
@@ -139,6 +140,35 @@ describe("isProxyRunning", () => {
 
     const result = await isProxyRunning(port);
     expect(result).toBe(false);
+  });
+});
+
+describe("isPortListening", () => {
+  const servers: http.Server[] = [];
+
+  afterEach(async () => {
+    for (const s of servers) {
+      await new Promise<void>((resolve) => s.close(() => resolve()));
+    }
+    servers.length = 0;
+  });
+
+  it("returns false when nothing is listening", async () => {
+    expect(await isPortListening(19877)).toBe(false);
+  });
+
+  it("detects a server listening on IPv6 loopback only (issue #320)", async (ctx) => {
+    const server = http.createServer((_req, res) => res.end("ok"));
+    const ipv6Available = await new Promise<boolean>((resolve) => {
+      server.once("error", () => resolve(false));
+      server.listen(0, "::1", () => resolve(true));
+    });
+    if (!ipv6Available) return ctx.skip();
+    servers.push(server);
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("no addr");
+
+    expect(await isPortListening(addr.port)).toBe(true);
   });
 });
 

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -7,6 +7,7 @@ import * as path from "node:path";
 import * as readline from "node:readline";
 import { execSync, spawn } from "node:child_process";
 import { PORTLESS_HEADER } from "./proxy.js";
+import { createLoopbackConnection } from "./utils.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -722,10 +723,10 @@ export function isProxyRunning(port: number, tls = false): Promise<boolean> {
   });
 }
 
-/** Check whether any process is listening on the given port at 127.0.0.1. */
+/** Check whether any process is listening on the given port on either loopback family. */
 export function isPortListening(port: number): Promise<boolean> {
   return new Promise((resolve) => {
-    const socket = net.createConnection({ host: "127.0.0.1", port });
+    const socket = createLoopbackConnection(port);
     let settled = false;
 
     const finish = (result: boolean) => {
@@ -1048,8 +1049,10 @@ function findFrameworkBasename(commandArgs: string[]): string | null {
  * Handles both direct invocation (`vite dev`) and invocation via package
  * runners (`bunx --bun vite dev`, `npx vite dev`, `yarn dlx vite dev`).
  *
- * The portless proxy connects to 127.0.0.1 (IPv4), so we also inject
- * `--host 127.0.0.1` to prevent frameworks from binding to IPv6 `::1`.
+ * We also inject `--host 127.0.0.1` so frameworks bind IPv4 loopback
+ * predictably. The proxy itself dials both loopback families (see
+ * createLoopbackConnection), so this is belt-and-suspenders for apps
+ * that honor the flag; apps that ignore it and bind `::1` only still work.
  *
  * Note: Expo's `--host` flag is *not* a bind address (it is a connection mode:
  * lan|tunnel|localhost). In LAN mode we skip `--host` entirely — Expo defaults

--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -153,6 +153,31 @@ describe("createProxyServer", () => {
       expect(res.body).toBe("hello from backend");
     });
 
+    it("proxies to a backend listening on IPv6 loopback only (issue #320)", async (ctx) => {
+      const backend = http.createServer((_req, res) => {
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.end("hello from ipv6 backend");
+      });
+      const ipv6Available = await new Promise<boolean>((resolve) => {
+        backend.once("error", () => resolve(false));
+        backend.listen(0, "::1", () => resolve(true));
+      });
+      if (!ipv6Available) return ctx.skip();
+      trackServer(backend);
+      const backendAddr = backend.address();
+      if (!backendAddr || typeof backendAddr === "string") throw new Error("no addr");
+
+      const routes: RouteInfo[] = [{ hostname: "myapp.localhost", port: backendAddr.port }];
+      const server = trackServer(
+        createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "myapp.localhost" });
+      expect(res.status).toBe(200);
+      expect(res.body).toBe("hello from ipv6 backend");
+    });
+
     it("routes wildcard subdomain to matching parent route when strict is false", async () => {
       const backend = trackServer(
         http.createServer((_req, res) => {

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -2,7 +2,7 @@ import * as http from "node:http";
 import * as http2 from "node:http2";
 import * as net from "node:net";
 import type { ProxyServerOptions } from "./types.js";
-import { escapeHtml, formatUrl } from "./utils.js";
+import { createLoopbackConnection, escapeHtml, formatUrl } from "./utils.js";
 import { ARROW_SVG, renderPage } from "./pages.js";
 
 /** Response header used to identify a portless proxy (for health checks). */
@@ -201,8 +201,8 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
 
     const proxyReq = http.request(
       {
-        hostname: "127.0.0.1",
-        port: route.port,
+        // Dial via createLoopbackConnection so ::1-only backends work too.
+        createConnection: () => createLoopbackConnection(route.port),
         path: req.url,
         method: req.method,
         headers: proxyReqHeaders,
@@ -314,8 +314,8 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
     }
 
     const proxyReq = http.request({
-      hostname: "127.0.0.1",
-      port: route.port,
+      // Dial via createLoopbackConnection so ::1-only backends work too.
+      createConnection: () => createLoopbackConnection(route.port),
       path: req.url,
       method: req.method,
       headers: proxyReqHeaders,

--- a/packages/portless/src/utils.ts
+++ b/packages/portless/src/utils.ts
@@ -1,4 +1,39 @@
 import * as fs from "node:fs";
+import * as net from "node:net";
+
+/**
+ * Both loopback families, tried in order. Dev servers that bind `localhost`
+ * on Node 17+ resolve it verbatim and may listen on IPv6 `::1` only (Vite's
+ * default host does this), while most others bind IPv4 `127.0.0.1` only.
+ */
+function loopbackLookup(
+  _hostname: string,
+  _options: unknown,
+  callback: (
+    err: NodeJS.ErrnoException | null,
+    addresses: { address: string; family: number }[]
+  ) => void
+): void {
+  callback(null, [
+    { address: "127.0.0.1", family: 4 },
+    { address: "::1", family: 6 },
+  ]);
+}
+
+/**
+ * Open a TCP connection to a local app port, trying both loopback families
+ * instead of hardcoding IPv4. Uses Node's Happy Eyeballs implementation
+ * (`autoSelectFamily`) with a fixed address list, so no DNS lookup happens:
+ * 127.0.0.1 is attempted first and `::1` is tried when it fails (issue #320).
+ */
+export function createLoopbackConnection(port: number): net.Socket {
+  return net.connect({
+    host: "localhost",
+    port,
+    autoSelectFamily: true,
+    lookup: loopbackLookup as net.LookupFunction,
+  });
+}
 
 /**
  * When running under sudo, fix file ownership so the real user can


### PR DESCRIPTION
## Bug

A registered app that listens on IPv6 loopback only returns portless's 502 page on every request while the app itself is healthy. On Node 17+ `localhost` resolves verbatim, so dev servers that bind `localhost` (Vite's default `server.host`) listen on `::1` only, and the proxy dials the upstream with a hardcoded `127.0.0.1` and gets ECONNREFUSED. Portless already defends against this by injecting `HOST=127.0.0.1` into spawned apps, but Vite does not read the `HOST` env var.

## Fix

- New `createLoopbackConnection(port)` helper dials with Node's Happy Eyeballs (`autoSelectFamily`) over a fixed address list (`127.0.0.1` first, then `::1`), so no DNS lookup is involved and IPv4 stays the preferred family
- Both proxy dial sites use it via `http.request`'s `createConnection` option (request path and WebSocket upgrade path). The fallback happens at the transport layer before the request is written, so piped request bodies never need to be replayed
- `isPortListening` uses the same helper, so `portless list` and `doctor` no longer report a `::1`-only app as dead
- Updated the `injectFrameworkFlags` comment: the `--host 127.0.0.1` injection is belt-and-suspenders now, apps that ignore it and bind `::1` only still route

## Verification

- 2 new tests: the proxy routes to a `::1`-only backend (proxy.test.ts) and `isPortListening` detects a `::1`-only listener (cli-utils.test.ts); both skip gracefully on hosts without IPv6
- Falsified: with the fix reverted, exactly the two new tests fail; restored, 682/682 pass
- Local e2e against the built CLI: backend bound to `::1` only, proxy on a custom port, `curl` with the registered Host header returns 200 through to the backend (502 before the fix, as reported)
- `vitest` (682/682), `tsc --noEmit`, `eslint` all green

Fixes #320.
