### PR TITLE
fix(cli): apply worktree prefix in multi-app mode

### DIFF
--- a/packages/portless/src/auto.test.ts
+++ b/packages/portless/src/auto.test.ts
@@ -8,6 +8,7 @@ import {
   truncateLabel,
   inferProjectName,
   detectWorktreePrefix,
+  applyWorktreePrefix,
 } from "./auto.js";
 
 // ---------------------------------------------------------------------------
@@ -456,5 +457,27 @@ describe("detectWorktreePrefix (git CLI path)", { timeout: 15_000 }, () => {
     expect(result).not.toBeNull();
     expect(result!.prefix.length).toBeLessThanOrEqual(63);
     expect(result!.source).toBe("git branch");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyWorktreePrefix
+// ---------------------------------------------------------------------------
+
+describe("applyWorktreePrefix", () => {
+  it("returns the base name unchanged when not in a worktree", () => {
+    expect(applyWorktreePrefix("web.json-render", null)).toBe("web.json-render");
+  });
+
+  it("prepends the worktree prefix as a subdomain (issue #269)", () => {
+    expect(
+      applyWorktreePrefix("web.json-render", { prefix: "feature-x", source: "git branch" })
+    ).toBe("feature-x.web.json-render");
+  });
+
+  it("prefixes a single-label base name too", () => {
+    expect(applyWorktreePrefix("api", { prefix: "feature-x", source: "git branch" })).toBe(
+      "feature-x.api"
+    );
   });
 });

--- a/packages/portless/src/auto.ts
+++ b/packages/portless/src/auto.ts
@@ -159,6 +159,16 @@ export interface WorktreePrefix {
   source: string;
 }
 
+/**
+ * Prepend a worktree prefix to a base hostname, or return the base name
+ * unchanged when not in a worktree. Both single-app and multi-app modes
+ * use this so a bare `portless` in a git worktree produces the same
+ * `<prefix>.<name>` hostnames in either layout.
+ */
+export function applyWorktreePrefix(baseName: string, worktree: WorktreePrefix | null): string {
+  return worktree ? `${worktree.prefix}.${baseName}` : baseName;
+}
+
 /** Branch names that represent the default/primary checkout — no prefix needed. */
 const DEFAULT_BRANCHES = new Set(["main", "master"]);
 

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -1854,4 +1854,117 @@ describe("CLI", () => {
       }
     });
   });
+
+  describe("multi-app worktree routing (issue #269)", () => {
+    // Skipped on Windows: multi-app mode spawns the package manager
+    // (`npm run dev`), and spawnChildProcess does not use a shell, so
+    // spawn("npm") fails with ENOENT on Windows (npm is npm.cmd there). That is
+    // a separate limitation of the multi-app spawn path, not the worktree-prefix
+    // logic under test here, which is platform-agnostic and covered
+    // cross-platform by the detectWorktreePrefix unit tests. Runs on macOS/Linux.
+    it.skipIf(process.platform === "win32")(
+      "prefixes every app hostname with the worktree branch",
+      async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), "portless-multi-wt-"));
+        const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-multi-state-"));
+        const proxyPort = await getFreePort();
+        const capFile = (name: string) => path.join(stateDir, `url-${name}.txt`);
+        const readCap = (name: string) => {
+          try {
+            return fs.readFileSync(capFile(name), "utf-8");
+          } catch {
+            return "";
+          }
+        };
+        let cli: ReturnType<typeof spawn> | undefined;
+
+        try {
+          fs.writeFileSync(
+            path.join(root, "package.json"),
+            JSON.stringify({
+              name: "myrepo",
+              private: true,
+              packageManager: "npm@10.0.0",
+              workspaces: ["packages/*"],
+            })
+          );
+
+          // Fake a git worktree on branch feature-x via the filesystem fallback
+          // (a .git file pointing at a gitdir whose HEAD is the branch ref).
+          const gitdir = path.join(root, "fake-bare.git", "worktrees", "wt");
+          fs.mkdirSync(gitdir, { recursive: true });
+          fs.writeFileSync(path.join(gitdir, "HEAD"), "ref: refs/heads/feature-x\n");
+          fs.writeFileSync(path.join(root, ".git"), `gitdir: ${gitdir}\n`);
+
+          // Each app's dev command records the URL portless assigned it via
+          // PORTLESS_URL, then exits. Reading the captured URL (not routes.json)
+          // is robust: a route is removed when its app exits, but the file stays.
+          for (const name of ["web", "api"]) {
+            const dir = path.join(root, "packages", name);
+            fs.mkdirSync(dir, { recursive: true });
+            fs.writeFileSync(
+              path.join(dir, "capture.cjs"),
+              `require("node:fs").writeFileSync(${JSON.stringify(capFile(name))}, process.env.PORTLESS_URL || "");\n`
+            );
+            fs.writeFileSync(
+              path.join(dir, "package.json"),
+              JSON.stringify({
+                name,
+                version: "0.0.0",
+                scripts: { dev: "node capture.cjs" },
+                portless: { proxy: true },
+              })
+            );
+          }
+
+          // Strip parent-only npm/pnpm vars so the spawned `npm run dev` is real
+          // npm, not the vitest runner's pnpm (npm_execpath).
+          const childEnv: Record<string, string | undefined> = { ...process.env };
+          for (const key of Object.keys(childEnv)) {
+            if (key.startsWith("npm_") || key.startsWith("PNPM_")) delete childEnv[key];
+          }
+          childEnv.PORTLESS_STATE_DIR = stateDir;
+          childEnv.PORTLESS_PORT = proxyPort.toString();
+          childEnv.PORTLESS_HTTPS = "0";
+          childEnv.NO_COLOR = "1";
+
+          let output = "";
+          cli = spawn(process.execPath, [CLI_PATH], {
+            cwd: root,
+            env: childEnv,
+            stdio: ["ignore", "pipe", "pipe"],
+          });
+          cli.stdout?.on("data", (chunk) => (output += chunk.toString()));
+          cli.stderr?.on("data", (chunk) => (output += chunk.toString()));
+
+          // Poll generously: on slow CI, proxy boot plus two sequential
+          // `npm run dev` spawns can take a while.
+          for (let i = 0; i < 60; i++) {
+            if (readCap("web") && readCap("api")) break;
+            await new Promise((resolve) => setTimeout(resolve, 500));
+          }
+
+          const webUrl = readCap("web");
+          const apiUrl = readCap("api");
+          if (!webUrl || !apiUrl) {
+            throw new Error(
+              `capture incomplete (web=${JSON.stringify(webUrl)}, api=${JSON.stringify(apiUrl)}). CLI output:\n${output}`
+            );
+          }
+          // Routed URL must carry the worktree prefix, in the full multi-app
+          // form <branch>.<pkg>.<project>.<tld>.
+          expect(webUrl).toContain("feature-x.web.myrepo.localhost");
+          expect(apiUrl).toContain("feature-x.api.myrepo.localhost");
+        } finally {
+          if (cli) await stopChild(cli);
+          run(["proxy", "stop"], {
+            env: { PORTLESS_STATE_DIR: stateDir, PORTLESS_HTTPS: "0" },
+          });
+          fs.rmSync(root, { recursive: true, force: true });
+          fs.rmSync(stateDir, { recursive: true, force: true });
+        }
+      },
+      60_000
+    );
+  });
 });

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -38,6 +38,7 @@ import { ensureNgrokAvailable, startNgrok, stopNgrok, stopNgrokProcess } from ".
 import {
   inferProjectName,
   detectWorktreePrefix,
+  applyWorktreePrefix,
   truncateLabel,
   sanitizeForHostname,
 } from "./auto.js";
@@ -3383,7 +3384,7 @@ async function handleDefaultSingle(
   }
 
   const worktree = detectWorktreePrefix(cwd);
-  const effectiveName = worktree ? `${worktree.prefix}.${baseName}` : baseName;
+  const effectiveName = applyWorktreePrefix(baseName, worktree);
 
   const { dir, port, tls, tlds, lanMode, lanIp } = await discoverState();
   const store = new RouteStore(dir, {
@@ -3612,6 +3613,11 @@ async function handleDefaultMulti(
 
   const apps: MultiAppEntry[] = [];
 
+  // In a git worktree, prefix every app's hostname with the branch name so
+  // parallel worktrees of the same monorepo don't collide on <name>.localhost.
+  // Mirrors handleDefaultSingle; single-app mode already does this.
+  const worktree = detectWorktreePrefix(wsRoot);
+
   for (const pkg of packages) {
     const rel = path.relative(wsRoot, pkg.dir).replace(/\\/g, "/");
     const rootOverride = loaded ? resolveAppConfig(loaded.config, loaded.configDir, pkg.dir) : null;
@@ -3663,6 +3669,8 @@ async function handleDefaultMulti(
       name = pkgLabel === projectName ? projectName : `${pkgLabel}.${projectName}`;
       label = pkg.scope ? `@${pkg.scope}/${pkg.name}` : (pkg.name ?? rel);
     }
+
+    name = applyWorktreePrefix(name, worktree);
 
     apps.push({ pkg, name, label, commandArgs, appPort: appOverride.appPort, proxied });
   }


### PR DESCRIPTION
## Bug

A bare `portless` from a monorepo root inside a git worktree produced the same `<name>.localhost` hostnames as the main checkout, so parallel worktrees collided. `handleDefaultSingle` applied the branch prefix; `handleDefaultMulti` did not.

## Fix

`handleDefaultMulti` now detects the worktree and prefixes each app's hostname, matching single-app mode (`<branch>.<name>.localhost`). Routed hostname only, not the display label. Non-worktree behavior is unchanged.

## Tests

- unit tests for `applyWorktreePrefix`
- an e2e that drives the CLI in multi-app mode inside a fake worktree and asserts each route hostname carries the branch prefix. Reverting the fix turns it red while the unit tests stay green, so the e2e is what guards the changed path.

Fixes #269.