### PR TITLE
Prepare v0.15.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,22 @@
 # Changelog
 
-## 0.15.1
+## 0.15.2
 
 <!-- release:start -->
+
+### Bug Fixes
+
+- **Tailscale funnel routing**: Proxy now routes requests addressed to a route's Tailscale funnel or serve hostname, so `--funnel` and `--tailscale` apps reached at `<device>.ts.net` no longer return a 404, including when several apps share one hostname on different ports. (#352)
+- **IPv6-only dev servers return 502**: Proxy now dials upstreams over both loopback families, fixing 502s when a dev server binds `::1` only, such as Vite on Node 17+. (#353)
+- **Worktree prefix in multi-app mode**: Bare `portless` in a monorepo worktree now applies the branch prefix in multi-app mode as it already did for single apps, so hostnames no longer collide across worktrees. (#355)
+
+### Contributors
+
+- @Railly
+- @ahfoysal
+<!-- release:end -->
+
+## 0.15.1
 
 ### New Features
 
@@ -11,7 +25,6 @@
 ### Contributors
 
 - @ctate
-<!-- release:end -->
 
 ## 0.15.0
 

--- a/apps/docs/src/app/changelog/page.mdx
+++ b/apps/docs/src/app/changelog/page.mdx
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.15.2
+
+### Bug Fixes
+
+- **Tailscale funnel routing**: Proxy now routes requests addressed to a route's Tailscale funnel or serve hostname, so `--funnel` and `--tailscale` apps reached at `<device>.ts.net` no longer return a 404, including when several apps share one hostname on different ports
+- **IPv6-only dev servers return 502**: Proxy now dials upstreams over both loopback families, fixing 502s when a dev server binds `::1` only, such as Vite on Node 17+
+- **Worktree prefix in multi-app mode**: Bare `portless` in a monorepo worktree now applies the branch prefix in multi-app mode as it already did for single apps, so hostnames no longer collide across worktrees
+
 ## 0.15.1
 
 ### New Features

--- a/packages/portless/package.json
+++ b/packages/portless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portless",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Replace port numbers with stable, named .localhost URLs. For humans and agents.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Patch release bundling the three fixes merged since v0.15.1.

### Included
- **Tailscale funnel routing** (#352) — funnel/serve hostnames no longer 404, including multiple apps on one `.ts.net` host across ports
- **IPv6-only dev servers return 502** (#353) — proxy dials both loopback families
- **Worktree prefix in multi-app mode** (#355) — bare `portless` in a monorepo worktree no longer collides across worktrees

### Changes
- Bump `packages/portless/package.json` to `0.15.2`
- Add the `0.15.2` entry to `CHANGELOG.md` (wrapped in the release markers) and `apps/docs/.../changelog/page.mdx`

On merge, the release workflow detects the version change, publishes to npm with provenance, and creates the `v0.15.2` GitHub release from the changelog markers.