### PR TITLE
fix WSL sudo state and Windows CA trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ To remove portless data from your machine (proxy state under `~/.portless` and t
 portless clean
 ```
 
-macOS/Linux may prompt for `sudo`. Custom certificate paths passed with `--cert` and `--key` are not deleted.
+macOS/Linux may prompt for `sudo`. Custom certificate paths passed with `--cert` and `--key` are not deleted. If trust-store removal fails, portless retains its CA certificate and key so a later `portless clean` can safely retry.
 
 ## Safari / DNS
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The proxy auto-starts when you run an app. A random port (4000-4999) is assigned
 
 When auto-starting, portless reuses the configuration (port, TLS, TLDs) from the most recent proxy run, so a restart or reboot does not silently revert to defaults. Explicit env vars (`PORTLESS_PORT`, `PORTLESS_HTTPS`, etc.) always take priority.
 
+Portless stores per-user state in `~/.portless`. When the proxy runs under sudo, it resolves this path from the invoking user's home so the proxy and unprivileged app processes share the same route registrations.
+
 In non-interactive environments (no TTY, or `CI=1`), portless exits with a descriptive error instead of prompting, so task runners like turborepo and CI scripts fail early with a clear message.
 
 ## Configuration
@@ -258,7 +260,7 @@ portless proxy start --no-tls
 portless trust
 ```
 
-On Linux, `portless trust` supports Debian/Ubuntu, Arch, Fedora/RHEL/CentOS, and openSUSE (via `update-ca-certificates` or `update-ca-trust`). On Windows, it uses `certutil` to add the CA to the system trust store.
+On Linux, `portless trust` supports Debian/Ubuntu, Arch, Fedora/RHEL/CentOS, and openSUSE (via `update-ca-certificates` or `update-ca-trust`). On Windows, it uses `certutil` to add the CA to the system trust store. On WSL, it updates both the Linux trust store and the Windows current-user Root store so Windows browsers trust portless HTTPS certificates.
 
 ## Start at OS startup
 

--- a/apps/docs/src/app/https/page.mdx
+++ b/apps/docs/src/app/https/page.mdx
@@ -4,6 +4,8 @@ HTTP/2 + TLS is enabled by default for faster dev server page loads. Browsers li
 
 First run generates a local CA and server certs, then adds the CA to your system trust store. After that, no prompts, no browser warnings.
 
+On WSL, portless updates both the Linux trust store and the Windows current-user Root store. Windows browsers can then verify portless HTTPS certificates served from WSL.
+
 ## Custom certificates
 
 Use your own certs (e.g., from mkcert):

--- a/packages/portless/src/certs.test.ts
+++ b/packages/portless/src/certs.test.ts
@@ -1,11 +1,18 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as crypto from "node:crypto";
 import * as tls from "node:tls";
 import { execFileSync } from "node:child_process";
-import { createSNICallback, ensureCerts, isCATrusted, trustCA, untrustCA } from "./certs.js";
+import {
+  createSNICallback,
+  ensureCerts,
+  isCATrusted,
+  trustCA,
+  untrustCA,
+  untrustCALinux,
+} from "./certs.js";
 
 /**
  * Return the signature algorithm string for a PEM cert file using openssl.
@@ -410,5 +417,59 @@ describe("untrustCA", () => {
 
   it("returns removed when ca.pem is missing", () => {
     expect(untrustCA(tmpDir)).toEqual({ removed: true });
+  });
+
+  it("retries a failed Linux trust refresh after the source certificate is gone", () => {
+    const { caPath } = ensureCerts(tmpDir);
+    const trustDir = path.join(tmpDir, "linux-trust");
+    const installedCA = path.join(trustDir, "portless-ca.crt");
+    const config = { certDir: trustDir, updateCommand: "refresh-linux-trust" };
+    fs.mkdirSync(trustDir);
+    fs.copyFileSync(caPath, installedCA);
+
+    const runUpdate = vi
+      .fn<(command: string) => void>()
+      .mockImplementationOnce(() => {
+        throw new Error("trust refresh failed");
+      })
+      .mockImplementationOnce(() => undefined);
+
+    const first = untrustCALinux(tmpDir, {
+      configs: [config],
+      activeConfig: config,
+      runUpdate,
+    });
+
+    expect(first).toEqual({ removed: false, error: "trust refresh failed" });
+    expect(fs.existsSync(installedCA)).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, "ca.pem"))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, "ca-key.pem"))).toBe(true);
+
+    const second = untrustCALinux(tmpDir, {
+      configs: [config],
+      activeConfig: config,
+      runUpdate,
+    });
+
+    expect(second).toEqual({ removed: true });
+    expect(runUpdate).toHaveBeenNthCalledWith(1, "refresh-linux-trust");
+    expect(runUpdate).toHaveBeenNthCalledWith(2, "refresh-linux-trust");
+  });
+
+  it("does not refresh Linux trust when the CA was never installed", () => {
+    ensureCerts(tmpDir);
+    const trustDir = path.join(tmpDir, "linux-trust");
+    const config = { certDir: trustDir, updateCommand: "refresh-linux-trust" };
+    const runUpdate = vi.fn<(command: string) => void>();
+    fs.mkdirSync(trustDir);
+
+    expect(
+      untrustCALinux(tmpDir, {
+        configs: [config],
+        activeConfig: config,
+        runUpdate,
+      })
+    ).toEqual({ removed: true });
+    expect(runUpdate).not.toHaveBeenCalled();
   });
 });

--- a/packages/portless/src/certs.ts
+++ b/packages/portless/src/certs.ts
@@ -944,11 +944,6 @@ export function untrustCA(stateDir: string): { removed: boolean; error?: string 
   }
 
   const runningInWSL = isWSL();
-  if (!runningInWSL && !isCATrusted(stateDir)) {
-    clearTrustMarker(stateDir);
-    return { removed: true };
-  }
-
   try {
     let result: { removed: boolean; error?: string };
     if (process.platform === "darwin") {

--- a/packages/portless/src/certs.ts
+++ b/packages/portless/src/certs.ts
@@ -5,6 +5,13 @@ import * as tls from "node:tls";
 import { execFile as execFileCb, execFileSync } from "node:child_process";
 import { promisify } from "node:util";
 import { fixOwnership } from "./utils.js";
+import {
+  isWSL,
+  isWindowsCATrusted,
+  trustWindowsCA,
+  untrustWindowsCA,
+  wslWindowsCAStoreOptions,
+} from "./windows-ca.js";
 
 /** How long the CA certificate is valid (10 years, in days). */
 const CA_VALIDITY_DAYS = 3650;
@@ -87,7 +94,8 @@ function readTrustMarker(stateDir: string): string | null {
 function writeTrustMarker(stateDir: string): void {
   const fp = caFingerprint(stateDir);
   if (fp) {
-    fs.writeFileSync(path.join(stateDir, CA_TRUST_MARKER), fp + "\n");
+    const marker = isWSL() ? `wsl:${fp}` : fp;
+    fs.writeFileSync(path.join(stateDir, CA_TRUST_MARKER), marker + "\n");
     fixOwnership(path.join(stateDir, CA_TRUST_MARKER));
   }
 }
@@ -442,35 +450,24 @@ export function isCATrusted(stateDir: string): boolean {
   const marker = readTrustMarker(stateDir);
   if (marker) {
     const fp = caFingerprint(stateDir);
-    if (fp && marker === fp) return true;
+    const expected = fp && isWSL() ? `wsl:${fp}` : fp;
+    if (expected && marker === expected) return true;
   }
 
   if (process.platform === "darwin") {
     return isCATrustedMacOS(caCertPath);
   } else if (process.platform === "linux") {
-    return isCATrustedLinux(stateDir);
+    if (!isCATrustedLinux(stateDir)) return false;
+    if (!isWSL()) return true;
+    try {
+      return isWindowsCATrusted(caCertPath, wslWindowsCAStoreOptions());
+    } catch {
+      return false;
+    }
   } else if (process.platform === "win32") {
-    return isCATrustedWindows(caCertPath);
+    return isWindowsCATrusted(caCertPath);
   }
   return false;
-}
-
-function isCATrustedWindows(caCertPath: string): boolean {
-  try {
-    const fingerprint = openssl(["x509", "-in", caCertPath, "-noout", "-fingerprint", "-sha1"])
-      .trim()
-      .replace(/^.*=/, "")
-      .replace(/:/g, "")
-      .toLowerCase();
-    const result = execFileSync("certutil", ["-store", "-user", "Root"], {
-      encoding: "utf-8",
-      timeout: 10_000,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    return result.replace(/\s/g, "").toLowerCase().includes(fingerprint);
-  } catch {
-    return false;
-  }
 }
 
 function isCATrustedMacOS(caCertPath: string): boolean {
@@ -849,7 +846,8 @@ export function createSNICallback(
  *
  * On macOS, adds to the login keychain (no sudo required; the OS shows a
  * GUI authorization prompt to confirm). On Linux, copies to the distro-specific
- * CA directory and runs the appropriate update command (requires sudo).
+ * CA directory and runs the appropriate update command (requires sudo). WSL
+ * also adds the CA to the Windows current-user Root store.
  *
  * Supported Linux distros: Debian/Ubuntu, Arch, Fedora/RHEL/CentOS, openSUSE.
  */
@@ -897,13 +895,13 @@ export function trustCA(stateDir: string): { trusted: boolean; error?: string } 
       const dest = path.join(config.certDir, "portless-ca.crt");
       fs.copyFileSync(caCertPath, dest);
       execFileSync(config.updateCommand, [], { stdio: "pipe", timeout: 30_000 });
+      if (isWSL()) {
+        trustWindowsCA(caCertPath, wslWindowsCAStoreOptions());
+      }
       writeTrustMarker(stateDir);
       return { trusted: true };
     } else if (process.platform === "win32") {
-      execFileSync("certutil", ["-addstore", "-user", "Root", caCertPath], {
-        stdio: "pipe",
-        timeout: 30_000,
-      });
+      trustWindowsCA(caCertPath);
       writeTrustMarker(stateDir);
       return { trusted: true };
     }
@@ -945,7 +943,8 @@ export function untrustCA(stateDir: string): { removed: boolean; error?: string 
     return { removed: true };
   }
 
-  if (!isCATrusted(stateDir)) {
+  const runningInWSL = isWSL();
+  if (!runningInWSL && !isCATrusted(stateDir)) {
     clearTrustMarker(stateDir);
     return { removed: true };
   }
@@ -955,9 +954,9 @@ export function untrustCA(stateDir: string): { removed: boolean; error?: string 
     if (process.platform === "darwin") {
       result = untrustCAMacOS(caCertPath);
     } else if (process.platform === "linux") {
-      result = untrustCALinux(stateDir);
+      result = runningInWSL ? untrustCAWSL(stateDir, caCertPath) : untrustCALinux(stateDir);
     } else if (process.platform === "win32") {
-      result = untrustCAWindows(caCertPath);
+      result = untrustWindowsCA(caCertPath);
     } else {
       result = { removed: false, error: `Unsupported platform: ${process.platform}` };
     }
@@ -1052,7 +1051,7 @@ function untrustCALinux(stateDir: string): { removed: boolean; error?: string } 
     }
   }
 
-  if (isCATrusted(stateDir)) {
+  if (isCATrustedLinux(stateDir)) {
     return {
       removed: false,
       error:
@@ -1063,35 +1062,24 @@ function untrustCALinux(stateDir: string): { removed: boolean; error?: string } 
   return { removed: true };
 }
 
-function untrustCAWindows(caCertPath: string): { removed: boolean; error?: string } {
+function untrustCAWSL(stateDir: string, caCertPath: string): { removed: boolean; error?: string } {
+  const linuxResult = untrustCALinux(stateDir);
+  let windowsResult: { removed: boolean; error?: string };
+
   try {
-    const fingerprint = openssl(["x509", "-in", caCertPath, "-noout", "-fingerprint", "-sha1"])
-      .trim()
-      .replace(/^.*=/, "")
-      .replace(/:/g, "")
-      .toLowerCase();
-
-    const storeListing = execFileSync("certutil", ["-store", "-user", "Root"], {
-      encoding: "utf-8",
-      timeout: 10_000,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-
-    const normalized = storeListing.replace(/\s/g, "").toLowerCase();
-    if (!normalized.includes(fingerprint)) {
-      return { removed: true };
-    }
-
-    execFileSync("certutil", ["-delstore", "-user", "Root", "portless Local CA"], {
-      stdio: "pipe",
-      timeout: 30_000,
-    });
-
-    if (isCATrustedWindows(caCertPath)) {
-      return { removed: false, error: "certutil could not remove the portless CA from Root" };
-    }
-    return { removed: true };
+    windowsResult = untrustWindowsCA(caCertPath, wslWindowsCAStoreOptions());
   } catch (err: unknown) {
-    return { removed: false, error: err instanceof Error ? err.message : String(err) };
+    windowsResult = {
+      removed: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
   }
+
+  if (linuxResult.removed && windowsResult.removed) return { removed: true };
+
+  const errors = [linuxResult.error, windowsResult.error].filter(Boolean);
+  return {
+    removed: false,
+    error: errors.join("; ") || "Could not remove the portless CA from every WSL trust store",
+  };
 }

--- a/packages/portless/src/certs.ts
+++ b/packages/portless/src/certs.ts
@@ -58,6 +58,7 @@ const CA_CERT_FILE = "ca.pem";
 const SERVER_KEY_FILE = "server-key.pem";
 const SERVER_CERT_FILE = "server.pem";
 const CA_TRUST_MARKER = "ca.trusted";
+const CA_TRUST_REFRESH_PENDING = "ca.trust-refresh-pending";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -91,9 +92,18 @@ function readTrustMarker(stateDir: string): string | null {
   }
 }
 
+function clearTrustRefreshPending(stateDir: string): void {
+  try {
+    fs.unlinkSync(path.join(stateDir, CA_TRUST_REFRESH_PENDING));
+  } catch {
+    // A trust refresh may not be pending; ignore.
+  }
+}
+
 function writeTrustMarker(stateDir: string): void {
   const fp = caFingerprint(stateDir);
   if (fp) {
+    clearTrustRefreshPending(stateDir);
     const marker = isWSL() ? `wsl:${fp}` : fp;
     fs.writeFileSync(path.join(stateDir, CA_TRUST_MARKER), marker + "\n");
     fixOwnership(path.join(stateDir, CA_TRUST_MARKER));
@@ -522,9 +532,15 @@ function loginKeychainPath(): string {
  * Linux distro CA trust configuration.
  * Each entry maps a distro family to its CA certificate directory and update command.
  */
-interface LinuxCATrustConfig {
+export interface LinuxCATrustConfig {
   certDir: string;
   updateCommand: string;
+}
+
+export interface LinuxCATrustRemovalOptions {
+  configs?: LinuxCATrustConfig[];
+  activeConfig?: LinuxCATrustConfig;
+  runUpdate?: (command: string) => void;
 }
 
 const LINUX_CA_TRUST_CONFIGS: Record<string, LinuxCATrustConfig> = {
@@ -589,8 +605,10 @@ function getLinuxCATrustConfig(): LinuxCATrustConfig {
  * Check if the CA is trusted on Linux.
  * Supports Debian/Ubuntu, Arch, Fedora/RHEL, and openSUSE.
  */
-function isCATrustedLinux(stateDir: string): boolean {
-  const config = getLinuxCATrustConfig();
+function isCATrustedLinux(
+  stateDir: string,
+  config: LinuxCATrustConfig = getLinuxCATrustConfig()
+): boolean {
   const systemCertPath = path.join(config.certDir, "portless-ca.crt");
   if (!fileExists(systemCertPath)) return false;
 
@@ -1017,19 +1035,34 @@ function isCATrustedMacOSAfterAttempt(caCertPath: string): boolean {
   }
 }
 
-function untrustCALinux(stateDir: string): { removed: boolean; error?: string } {
+export function untrustCALinux(
+  stateDir: string,
+  options: LinuxCATrustRemovalOptions = {}
+): { removed: boolean; error?: string } {
   const errors: string[] = [];
-  let deletedAny = false;
+  const pendingRefreshPath = path.join(stateDir, CA_TRUST_REFRESH_PENDING);
+  let refreshNeeded = fileExists(pendingRefreshPath);
+  const configs = options.configs ?? Object.values(LINUX_CA_TRUST_CONFIGS);
+  const activeConfig = options.activeConfig ?? getLinuxCATrustConfig();
+  const runUpdate =
+    options.runUpdate ??
+    ((command: string) => {
+      execFileSync(command, [], { stdio: "pipe", timeout: 30_000 });
+    });
 
-  for (const config of Object.values(LINUX_CA_TRUST_CONFIGS)) {
+  for (const config of configs) {
     const dest = path.join(config.certDir, "portless-ca.crt");
     try {
       if (fileExists(dest)) {
         const ours = fs.readFileSync(path.join(stateDir, CA_CERT_FILE), "utf-8").trim();
         const installed = fs.readFileSync(dest, "utf-8").trim();
         if (ours === installed) {
+          if (!refreshNeeded) {
+            fs.writeFileSync(pendingRefreshPath, "1\n");
+            fixOwnership(pendingRefreshPath);
+            refreshNeeded = true;
+          }
           fs.unlinkSync(dest);
-          deletedAny = true;
         }
       }
     } catch (err: unknown) {
@@ -1037,16 +1070,15 @@ function untrustCALinux(stateDir: string): { removed: boolean; error?: string } 
     }
   }
 
-  if (deletedAny) {
+  if (refreshNeeded) {
     try {
-      const config = getLinuxCATrustConfig();
-      execFileSync(config.updateCommand, [], { stdio: "pipe", timeout: 30_000 });
+      runUpdate(activeConfig.updateCommand);
     } catch (err: unknown) {
       errors.push(err instanceof Error ? err.message : String(err));
     }
   }
 
-  if (isCATrustedLinux(stateDir)) {
+  if (errors.length > 0 || isCATrustedLinux(stateDir, activeConfig)) {
     return {
       removed: false,
       error:
@@ -1054,6 +1086,8 @@ function untrustCALinux(stateDir: string): { removed: boolean; error?: string } 
         "CA still trusted (remove portless-ca.crt and run the distro CA update command, often with sudo)",
     };
   }
+
+  clearTrustRefreshPending(stateDir);
   return { removed: true };
 }
 

--- a/packages/portless/src/clean-utils.test.ts
+++ b/packages/portless/src/clean-utils.test.ts
@@ -1,8 +1,12 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { collectStateDirsForCleanup, removePortlessStateFiles } from "./clean-utils.js";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  attemptCATrustRemovalForCleanup,
+  collectStateDirsForCleanup,
+  removePortlessStateFiles,
+} from "./clean-utils.js";
 
 describe("collectStateDirsForCleanup", () => {
   const prevState = process.env.PORTLESS_STATE_DIR;
@@ -35,6 +39,7 @@ describe("removePortlessStateFiles", () => {
   it("removes allowlisted files and host-certs directory", () => {
     fs.writeFileSync(path.join(tmpDir, "routes.json"), "[]");
     fs.writeFileSync(path.join(tmpDir, "ca.pem"), "pem");
+    fs.writeFileSync(path.join(tmpDir, "ca.trusted"), "fingerprint");
     fs.writeFileSync(path.join(tmpDir, "proxy.port"), "443");
     fs.writeFileSync(path.join(tmpDir, "proxy.custom-cert"), "1");
     fs.writeFileSync(path.join(tmpDir, "proxy.tlds"), "localhost\ntest\n");
@@ -47,6 +52,7 @@ describe("removePortlessStateFiles", () => {
 
     expect(fs.existsSync(path.join(tmpDir, "routes.json"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, "ca.pem"))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, "ca.trusted"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, "proxy.custom-cert"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, "proxy.tlds"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, "host-certs"))).toBe(false);
@@ -55,5 +61,45 @@ describe("removePortlessStateFiles", () => {
 
   it("does not throw when paths are missing", () => {
     expect(() => removePortlessStateFiles(tmpDir)).not.toThrow();
+  });
+
+  it("retains the CA identity when trust removal must be retried", () => {
+    fs.writeFileSync(path.join(tmpDir, "routes.json"), "[]");
+    fs.writeFileSync(path.join(tmpDir, "ca.pem"), "certificate");
+    fs.writeFileSync(path.join(tmpDir, "ca-key.pem"), "private key");
+    fs.writeFileSync(path.join(tmpDir, "ca.trusted"), "stale marker");
+    fs.writeFileSync(path.join(tmpDir, "server.pem"), "server certificate");
+
+    removePortlessStateFiles(tmpDir, { preserveCAIdentity: true });
+
+    expect(fs.readFileSync(path.join(tmpDir, "ca.pem"), "utf-8")).toBe("certificate");
+    expect(fs.readFileSync(path.join(tmpDir, "ca-key.pem"), "utf-8")).toBe("private key");
+    expect(fs.existsSync(path.join(tmpDir, "ca.trusted"))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, "routes.json"))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, "server.pem"))).toBe(false);
+  });
+});
+
+describe("attemptCATrustRemovalForCleanup", () => {
+  it("attempts removal even when only one WSL trust store may contain the CA", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-clean-trust-"));
+    const untrust = vi.fn(() => ({
+      removed: false,
+      error: "Windows CA query failed after Linux trust removal",
+    }));
+
+    try {
+      fs.writeFileSync(path.join(tmpDir, "ca.pem"), "certificate");
+
+      const results = attemptCATrustRemovalForCleanup([tmpDir], untrust);
+
+      expect(untrust).toHaveBeenCalledWith(tmpDir);
+      expect(results.get(tmpDir)).toEqual({
+        removed: false,
+        error: "Windows CA query failed after Linux trust removal",
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/portless/src/clean-utils.test.ts
+++ b/packages/portless/src/clean-utils.test.ts
@@ -40,6 +40,7 @@ describe("removePortlessStateFiles", () => {
     fs.writeFileSync(path.join(tmpDir, "routes.json"), "[]");
     fs.writeFileSync(path.join(tmpDir, "ca.pem"), "pem");
     fs.writeFileSync(path.join(tmpDir, "ca.trusted"), "fingerprint");
+    fs.writeFileSync(path.join(tmpDir, "ca.trust-refresh-pending"), "1");
     fs.writeFileSync(path.join(tmpDir, "proxy.port"), "443");
     fs.writeFileSync(path.join(tmpDir, "proxy.custom-cert"), "1");
     fs.writeFileSync(path.join(tmpDir, "proxy.tlds"), "localhost\ntest\n");
@@ -53,6 +54,7 @@ describe("removePortlessStateFiles", () => {
     expect(fs.existsSync(path.join(tmpDir, "routes.json"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, "ca.pem"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, "ca.trusted"))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, "ca.trust-refresh-pending"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, "proxy.custom-cert"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, "proxy.tlds"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, "host-certs"))).toBe(false);
@@ -68,6 +70,7 @@ describe("removePortlessStateFiles", () => {
     fs.writeFileSync(path.join(tmpDir, "ca.pem"), "certificate");
     fs.writeFileSync(path.join(tmpDir, "ca-key.pem"), "private key");
     fs.writeFileSync(path.join(tmpDir, "ca.trusted"), "stale marker");
+    fs.writeFileSync(path.join(tmpDir, "ca.trust-refresh-pending"), "1");
     fs.writeFileSync(path.join(tmpDir, "server.pem"), "server certificate");
 
     removePortlessStateFiles(tmpDir, { preserveCAIdentity: true });
@@ -75,6 +78,7 @@ describe("removePortlessStateFiles", () => {
     expect(fs.readFileSync(path.join(tmpDir, "ca.pem"), "utf-8")).toBe("certificate");
     expect(fs.readFileSync(path.join(tmpDir, "ca-key.pem"), "utf-8")).toBe("private key");
     expect(fs.existsSync(path.join(tmpDir, "ca.trusted"))).toBe(false);
+    expect(fs.readFileSync(path.join(tmpDir, "ca.trust-refresh-pending"), "utf-8")).toBe("1");
     expect(fs.existsSync(path.join(tmpDir, "routes.json"))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, "server.pem"))).toBe(false);
   });

--- a/packages/portless/src/clean-utils.ts
+++ b/packages/portless/src/clean-utils.ts
@@ -15,6 +15,7 @@ const PORTLESS_STATE_FILES = [
   "proxy.tlds",
   "proxy.lan",
   "ca.trusted",
+  "ca.trust-refresh-pending",
   "ca-key.pem",
   "ca.pem",
   "server-key.pem",
@@ -25,7 +26,7 @@ const PORTLESS_STATE_FILES = [
 ] as const;
 
 const HOST_CERTS_DIR = "host-certs";
-const CA_IDENTITY_FILES = new Set(["ca-key.pem", "ca.pem"]);
+const CA_IDENTITY_FILES = new Set(["ca-key.pem", "ca.pem", "ca.trust-refresh-pending"]);
 
 export type RemovePortlessStateFilesOptions = {
   preserveCAIdentity?: boolean;

--- a/packages/portless/src/clean-utils.ts
+++ b/packages/portless/src/clean-utils.ts
@@ -14,6 +14,7 @@ const PORTLESS_STATE_FILES = [
   "proxy.tld",
   "proxy.tlds",
   "proxy.lan",
+  "ca.trusted",
   "ca-key.pem",
   "ca.pem",
   "server-key.pem",
@@ -24,6 +25,16 @@ const PORTLESS_STATE_FILES = [
 ] as const;
 
 const HOST_CERTS_DIR = "host-certs";
+const CA_IDENTITY_FILES = new Set(["ca-key.pem", "ca.pem"]);
+
+export type RemovePortlessStateFilesOptions = {
+  preserveCAIdentity?: boolean;
+};
+
+export type CATrustRemovalResult = {
+  removed: boolean;
+  error?: string;
+};
 
 /**
  * Unique existing state directories to consider for cleanup: user dir, system
@@ -43,12 +54,29 @@ export function collectStateDirsForCleanup(): string[] {
   return [...dirs];
 }
 
+/** Attempt CA trust removal wherever cleanup finds a CA certificate. */
+export function attemptCATrustRemovalForCleanup(
+  stateDirs: string[],
+  untrust: (stateDir: string) => CATrustRemovalResult
+): Map<string, CATrustRemovalResult> {
+  const results = new Map<string, CATrustRemovalResult>();
+  for (const stateDir of stateDirs) {
+    if (!fs.existsSync(path.join(stateDir, "ca.pem"))) continue;
+    results.set(stateDir, untrust(stateDir));
+  }
+  return results;
+}
+
 /**
  * Best-effort removal of portless state files under dir. Only known filenames
  * are deleted; other files in the directory are left intact.
  */
-export function removePortlessStateFiles(dir: string): void {
+export function removePortlessStateFiles(
+  dir: string,
+  options: RemovePortlessStateFilesOptions = {}
+): void {
   for (const f of PORTLESS_STATE_FILES) {
+    if (options.preserveCAIdentity && CA_IDENTITY_FILES.has(f)) continue;
     try {
       fs.unlinkSync(path.join(dir, f));
     } catch {

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import * as fs from "node:fs";
 import * as http from "node:http";
 import * as net from "node:net";
@@ -181,6 +181,31 @@ describe("resolveStateDir", () => {
     expect(resolveStateDir(8080)).toBe(USER_STATE_DIR);
     expect(resolveStateDir(3000)).toBe(USER_STATE_DIR);
   });
+
+  it.skipIf(process.platform === "win32")(
+    "uses the invoking user's home when loaded under sudo",
+    async () => {
+      const originalHome = process.env.HOME;
+      const originalSudoUser = process.env.SUDO_USER;
+      const expectedHome = process.platform === "darwin" ? "/Users/alice" : "/home/alice";
+
+      try {
+        process.env.HOME = process.platform === "darwin" ? "/var/root" : "/root";
+        process.env.SUDO_USER = "alice";
+        vi.resetModules();
+
+        const sudoModule = await import("./cli-utils.js");
+        expect(sudoModule.USER_STATE_DIR).toBe(path.join(expectedHome, ".portless"));
+        expect(sudoModule.resolveStateDir(443)).toBe(path.join(expectedHome, ".portless"));
+      } finally {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+        if (originalSudoUser === undefined) delete process.env.SUDO_USER;
+        else process.env.SUDO_USER = originalSudoUser;
+        vi.resetModules();
+      }
+    }
+  );
 });
 
 describe("constants", () => {

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -7,7 +7,7 @@ import * as path from "node:path";
 import * as readline from "node:readline";
 import { execSync, spawn } from "node:child_process";
 import { PORTLESS_HEADER } from "./proxy.js";
-import { createLoopbackConnection } from "./utils.js";
+import { createLoopbackConnection, resolveUserHome } from "./utils.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -43,7 +43,7 @@ export const LEGACY_SYSTEM_STATE_DIR = isWindows
   : "/tmp/portless";
 
 /** Per-user state directory. All proxy state lives here regardless of port. */
-export const USER_STATE_DIR = path.join(os.homedir(), ".portless");
+export const USER_STATE_DIR = path.join(resolveUserHome(), ".portless");
 
 /** Minimum app port when finding a free port. */
 const MIN_APP_PORT = 4000;

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -807,6 +807,7 @@ describe("CLI", () => {
       expect(status).toBe(0);
       expect(stdout).toContain("portless clean");
       expect(stdout).toContain("trust store");
+      expect(stdout).toContain("retained so clean can safely retry");
     });
 
     it("prints help with -h", () => {

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1762,11 +1762,13 @@ ${colors.bold("How it works:")}
   5. Frameworks that ignore PORT (Vite, VitePlus, Astro, React Router, Angular,
      Expo, React Native) get --port and, when needed, --host flags
      injected automatically
+  Elevated proxy processes keep the invoking user's ~/.portless state directory.
 
 ${colors.bold("HTTP/2 + HTTPS (default):")}
   HTTPS with HTTP/2 multiplexing is enabled by default (faster page loads).
   On first use, portless generates a local CA and adds it to your
   system trust store. No browser warnings. Disable with --no-tls.
+  On WSL, portless also adds the CA to the Windows user certificate store.
 
 ${colors.bold("LAN mode:")}
   Use --lan to make services accessible from other devices (phones,

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -82,7 +82,11 @@ import {
   writeTldsFile,
   writeTlsMarker,
 } from "./cli-utils.js";
-import { collectStateDirsForCleanup, removePortlessStateFiles } from "./clean-utils.js";
+import {
+  attemptCATrustRemovalForCleanup,
+  collectStateDirsForCleanup,
+  removePortlessStateFiles,
+} from "./clean-utils.js";
 import {
   getLocalNetworkIp,
   isMdnsSupported,
@@ -1932,7 +1936,8 @@ directory, and PORTLESS_STATE_DIR when set), and removes the portless block
 from ${HOSTS_DISPLAY}.
 
 Only allowlisted filenames under each state directory are deleted. Custom
-certificate paths from --cert and --key are never removed.
+certificate paths from --cert and --key are never removed. If trust removal
+fails, the CA certificate and key are retained so clean can safely retry.
 
 macOS/Linux may prompt for sudo when the proxy, trust store, or ${HOSTS_DISPLAY}
 require elevated privileges. On Windows, run as Administrator if needed.
@@ -1997,18 +2002,16 @@ ${colors.bold("Options:")}
   }
 
   const stateDirs = collectStateDirsForCleanup();
-  for (const stateDir of stateDirs) {
-    const caPath = path.join(stateDir, "ca.pem");
-    if (!fs.existsSync(caPath)) continue;
-    const wasTrusted = isCATrusted(stateDir);
-    if (!wasTrusted) continue;
-    const untrustResult = untrustCA(stateDir);
+  const failedCAStateDirs = new Set<string>();
+  const caRemovalResults = attemptCATrustRemovalForCleanup(stateDirs, untrustCA);
+  for (const [stateDir, untrustResult] of caRemovalResults) {
     if (untrustResult.removed) {
       console.log(colors.green("Removed local CA from the system trust store."));
-    } else if (untrustResult.error) {
+    } else {
+      failedCAStateDirs.add(stateDir);
       console.warn(
         colors.yellow(
-          `Could not remove CA from trust store: ${untrustResult.error}\n` +
+          `Could not remove CA from trust store: ${untrustResult.error ?? "unknown error"}\n` +
             `Try: sudo portless clean (Linux), or delete the certificate manually.`
         )
       );
@@ -2016,9 +2019,16 @@ ${colors.bold("Options:")}
   }
 
   for (const stateDir of stateDirs) {
-    removePortlessStateFiles(stateDir);
+    removePortlessStateFiles(stateDir, {
+      preserveCAIdentity: failedCAStateDirs.has(stateDir),
+    });
   }
   console.log(colors.green("Removed portless state files from known state directories."));
+  if (failedCAStateDirs.size > 0) {
+    console.warn(
+      colors.yellow("Retained CA identity files so trust removal can be retried safely.")
+    );
+  }
 
   if (cleanHostsFile()) {
     console.log(colors.green(`Removed portless entries from ${HOSTS_DISPLAY}.`));

--- a/packages/portless/src/service.test.ts
+++ b/packages/portless/src/service.test.ts
@@ -31,9 +31,13 @@ vi.mock("./certs.js", () => ({
   trustCA: vi.fn(() => ({ trusted: true })),
 }));
 
-vi.mock("./utils.js", () => ({
-  fixOwnership: vi.fn(),
-}));
+vi.mock("./utils.js", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("./utils.js")>();
+  return {
+    ...mod,
+    fixOwnership: vi.fn(),
+  };
+});
 
 vi.mock("./mdns.js", () => ({
   isMdnsSupported: vi.fn(() => ({ supported: true })),

--- a/packages/portless/src/service.ts
+++ b/packages/portless/src/service.ts
@@ -13,7 +13,7 @@ import {
   parseTldList,
 } from "./cli-utils.js";
 import { isMdnsSupported } from "./mdns.js";
-import { fixOwnership } from "./utils.js";
+import { fixOwnership, resolveUserHome } from "./utils.js";
 
 const DEFAULT_SERVICE_PORT = getProtocolPort(true);
 const SERVICE_LABEL = "sh.portless.proxy";
@@ -366,24 +366,9 @@ function parseServiceInstallConfig(
   return config;
 }
 
-function readPasswdHome(username: string): string | null {
-  try {
-    const passwd = fs.readFileSync("/etc/passwd", "utf-8");
-    for (const line of passwd.split("\n")) {
-      const fields = line.split(":");
-      if (fields[0] === username && fields[5]) {
-        return fields[5];
-      }
-    }
-  } catch {
-    // Ignore and fall back to platform conventions.
-  }
-  return null;
-}
-
 function resolveUserContext(platform: SupportedPlatform): UserContext {
   if (platform === "win32") {
-    const home = process.env.USERPROFILE || os.homedir();
+    const home = resolveUserHome({ platform });
     return { home, username: process.env.USERNAME };
   }
 
@@ -391,13 +376,7 @@ function resolveUserContext(platform: SupportedPlatform): UserContext {
   const sudoUid = process.env.SUDO_UID;
   const sudoGid = process.env.SUDO_GID;
   if (sudoUser && sudoUser !== "root") {
-    const home =
-      process.env.HOME && process.env.HOME !== "/var/root" && process.env.HOME !== "/root"
-        ? process.env.HOME
-        : readPasswdHome(sudoUser) ||
-          (platform === "darwin"
-            ? path.posix.join("/Users", sudoUser)
-            : path.posix.join("/home", sudoUser));
+    const home = resolveUserHome({ platform });
     return { home, uid: sudoUid, gid: sudoGid, username: sudoUser };
   }
 

--- a/packages/portless/src/utils.test.ts
+++ b/packages/portless/src/utils.test.ts
@@ -6,10 +6,55 @@ import {
   isProcessAlive,
   parseHostname,
   parseHostnames,
+  resolveUserHome,
 } from "./utils.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
+});
+
+describe("resolveUserHome", () => {
+  it("uses the invoking user's home under sudo", () => {
+    expect(
+      resolveUserHome({
+        platform: "linux",
+        env: { SUDO_USER: "alice", HOME: "/root" },
+        homedir: "/root",
+        passwdHome: () => "/home/alice",
+      })
+    ).toBe("/home/alice");
+  });
+
+  it("keeps a preserved non-root home under sudo", () => {
+    expect(
+      resolveUserHome({
+        platform: "darwin",
+        env: { SUDO_USER: "alice", HOME: "/Users/alice" },
+        homedir: "/var/root",
+      })
+    ).toBe("/Users/alice");
+  });
+
+  it("uses the effective user's home without sudo", () => {
+    expect(
+      resolveUserHome({
+        platform: "linux",
+        env: { HOME: "/root" },
+        homedir: "/root",
+      })
+    ).toBe("/root");
+  });
+
+  it("falls back to the platform convention when passwd lookup fails", () => {
+    expect(
+      resolveUserHome({
+        platform: "linux",
+        env: { SUDO_USER: "alice", HOME: "/root" },
+        homedir: "/root",
+        passwdHome: () => null,
+      })
+    ).toBe("/home/alice");
+  });
 });
 
 describe("escapeHtml", () => {

--- a/packages/portless/src/utils.ts
+++ b/packages/portless/src/utils.ts
@@ -1,5 +1,53 @@
 import * as fs from "node:fs";
 import * as net from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+
+type UserHomeOptions = {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  homedir?: string;
+  passwdHome?: (username: string) => string | null;
+};
+
+function readPasswdHome(username: string): string | null {
+  try {
+    const passwd = fs.readFileSync("/etc/passwd", "utf-8");
+    for (const line of passwd.split("\n")) {
+      const fields = line.split(":");
+      if (fields[0] === username && fields[5]) return fields[5];
+    }
+  } catch {
+    // Fall back to the platform's conventional home directory.
+  }
+  return null;
+}
+
+/**
+ * Resolve the home directory that owns portless state. When sudo changes the
+ * effective user to root, retain the invoking user's home so elevated proxy
+ * processes and unprivileged app processes share the same route store.
+ */
+export function resolveUserHome(options: UserHomeOptions = {}): string {
+  const platform = options.platform ?? process.platform;
+  const env = options.env ?? process.env;
+  const homedir = options.homedir ?? os.homedir();
+
+  if (platform === "win32") return env.USERPROFILE || homedir;
+
+  const sudoUser = env.SUDO_USER;
+  if (!sudoUser || sudoUser === "root") return homedir;
+
+  const home = env.HOME;
+  if (home && home !== "/root" && home !== "/var/root") return home;
+
+  const passwdHome = (options.passwdHome ?? readPasswdHome)(sudoUser);
+  if (passwdHome) return passwdHome;
+
+  return platform === "darwin"
+    ? path.posix.join("/Users", sudoUser)
+    : path.posix.join("/home", sudoUser);
+}
 
 /**
  * Both loopback families, tried in order. Dev servers that bind `localhost`

--- a/packages/portless/src/windows-ca.test.ts
+++ b/packages/portless/src/windows-ca.test.ts
@@ -84,7 +84,7 @@ describe("Windows CA store", () => {
     );
   });
 
-  it("removes a trusted certificate from the Windows user Root store", () => {
+  it("removes the exact certificate by SHA-1 fingerprint", () => {
     let trusted = true;
     const run = vi.fn<WindowsCACommandRunner>((_command, args) => {
       if (args[0] === "-store") return trusted ? fingerprint : "";
@@ -97,7 +97,41 @@ describe("Windows CA store", () => {
     });
     expect(run).toHaveBeenCalledWith(
       "certutil.exe",
-      ["-delstore", "-user", "Root", "portless Local CA"],
+      ["-delstore", "-user", "Root", fingerprint.toLowerCase()],
+      expect.any(Object)
+    );
+  });
+
+  it("reports a Root store query failure instead of successful removal", () => {
+    const run = vi.fn<WindowsCACommandRunner>(() => {
+      throw new Error("certutil query timed out");
+    });
+
+    expect(untrustWindowsCA(caPath, { command: "certutil.exe", run })).toEqual({
+      removed: false,
+      error: "certutil query timed out",
+    });
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a verification query failure after deletion", () => {
+    let storeQueries = 0;
+    const run = vi.fn<WindowsCACommandRunner>((_command, args) => {
+      if (args[0] === "-store") {
+        storeQueries += 1;
+        if (storeQueries === 1) return fingerprint;
+        throw new Error("certutil verification failed");
+      }
+      return "";
+    });
+
+    expect(untrustWindowsCA(caPath, { command: "certutil.exe", run })).toEqual({
+      removed: false,
+      error: "certutil verification failed",
+    });
+    expect(run).toHaveBeenCalledWith(
+      "certutil.exe",
+      ["-delstore", "-user", "Root", fingerprint.toLowerCase()],
       expect.any(Object)
     );
   });

--- a/packages/portless/src/windows-ca.test.ts
+++ b/packages/portless/src/windows-ca.test.ts
@@ -1,0 +1,104 @@
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ensureCerts } from "./certs.js";
+import {
+  isWSL,
+  isWindowsCATrusted,
+  trustWindowsCA,
+  untrustWindowsCA,
+  wslWindowsCAStoreOptions,
+  type WindowsCACommandRunner,
+} from "./windows-ca.js";
+
+describe("isWSL", () => {
+  it("detects the WSL environment variables", () => {
+    expect(isWSL({ platform: "linux", env: { WSL_DISTRO_NAME: "Ubuntu" }, release: "linux" })).toBe(
+      true
+    );
+    expect(
+      isWSL({ platform: "linux", env: { WSL_INTEROP: "/run/WSL/1_interop" }, release: "linux" })
+    ).toBe(true);
+  });
+
+  it("detects a Microsoft WSL kernel release", () => {
+    expect(
+      isWSL({ platform: "linux", env: {}, release: "5.15.90.1-microsoft-standard-WSL2" })
+    ).toBe(true);
+  });
+
+  it("does not classify native Linux or Windows as WSL", () => {
+    expect(isWSL({ platform: "linux", env: {}, release: "6.8.0-generic" })).toBe(false);
+    expect(
+      isWSL({ platform: "win32", env: { WSL_DISTRO_NAME: "Ubuntu" }, release: "microsoft" })
+    ).toBe(false);
+  });
+});
+
+describe("Windows CA store", () => {
+  let tmpDir: string;
+  let caPath: string;
+  let fingerprint: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-windows-ca-test-"));
+    caPath = ensureCerts(tmpDir).caPath;
+    fingerprint = new crypto.X509Certificate(fs.readFileSync(caPath)).fingerprint.replace(/:/g, "");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("checks the Windows user Root store by certificate fingerprint", () => {
+    const run = vi.fn<WindowsCACommandRunner>(() => `Cert Hash(sha1): ${fingerprint}`);
+
+    expect(isWindowsCATrusted(caPath, { command: "certutil.exe", run })).toBe(true);
+    expect(run).toHaveBeenCalledWith(
+      "certutil.exe",
+      ["-store", "-user", "Root"],
+      expect.objectContaining({ encoding: "utf-8" })
+    );
+  });
+
+  it("adds a WSL certificate through the Windows certutil executable", () => {
+    const run = vi.fn<WindowsCACommandRunner>((command, args) => {
+      if (command === "wslpath" && args[0] === "-u") {
+        return "/mnt/c/Windows/System32/certutil.exe\n";
+      }
+      if (command === "wslpath" && args[0] === "-w") {
+        return "\\\\wsl.localhost\\Ubuntu\\home\\alice\\.portless\\ca.pem\n";
+      }
+      return "";
+    });
+    const options = wslWindowsCAStoreOptions(run);
+
+    trustWindowsCA(caPath, options);
+
+    expect(run).toHaveBeenCalledWith(
+      "/mnt/c/Windows/System32/certutil.exe",
+      ["-addstore", "-user", "Root", "\\\\wsl.localhost\\Ubuntu\\home\\alice\\.portless\\ca.pem"],
+      expect.objectContaining({ timeout: 30_000 })
+    );
+  });
+
+  it("removes a trusted certificate from the Windows user Root store", () => {
+    let trusted = true;
+    const run = vi.fn<WindowsCACommandRunner>((_command, args) => {
+      if (args[0] === "-store") return trusted ? fingerprint : "";
+      if (args[0] === "-delstore") trusted = false;
+      return "";
+    });
+
+    expect(untrustWindowsCA(caPath, { command: "certutil.exe", run })).toEqual({
+      removed: true,
+    });
+    expect(run).toHaveBeenCalledWith(
+      "certutil.exe",
+      ["-delstore", "-user", "Root", "portless Local CA"],
+      expect.any(Object)
+    );
+  });
+});

--- a/packages/portless/src/windows-ca.ts
+++ b/packages/portless/src/windows-ca.ts
@@ -1,0 +1,133 @@
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import { execFileSync, type ExecFileSyncOptionsWithStringEncoding } from "node:child_process";
+
+const WINDOWS_CA_COMMON_NAME = "portless Local CA";
+const WINDOWS_COMMAND_TIMEOUT_MS = 30_000;
+
+export type WindowsCACommandRunner = (
+  command: string,
+  args: string[],
+  options: ExecFileSyncOptionsWithStringEncoding
+) => string;
+
+export type WindowsCAStoreOptions = {
+  command?: string;
+  certificatePath?: (certificatePath: string) => string;
+  run?: WindowsCACommandRunner;
+};
+
+type WSLDetectionOptions = {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  release?: string;
+};
+
+const commandOptions: ExecFileSyncOptionsWithStringEncoding = {
+  encoding: "utf-8",
+  timeout: WINDOWS_COMMAND_TIMEOUT_MS,
+  stdio: ["pipe", "pipe", "pipe"],
+};
+
+const defaultRunner: WindowsCACommandRunner = (command, args, options) =>
+  execFileSync(command, args, options);
+
+/** Return whether the current Linux process is running inside WSL. */
+export function isWSL(options: WSLDetectionOptions = {}): boolean {
+  const platform = options.platform ?? process.platform;
+  if (platform !== "linux") return false;
+
+  const env = options.env ?? process.env;
+  if (env.WSL_DISTRO_NAME || env.WSL_INTEROP) return true;
+
+  const release = options.release ?? os.release();
+  return release.toLowerCase().includes("microsoft");
+}
+
+/**
+ * Build Windows CA store options for WSL. The absolute executable path avoids
+ * relying on Windows PATH entries that sudo may remove, while wslpath exposes
+ * the Linux certificate path to certutil.
+ */
+export function wslWindowsCAStoreOptions(
+  run: WindowsCACommandRunner = defaultRunner
+): WindowsCAStoreOptions {
+  const command = run(
+    "wslpath",
+    ["-u", String.raw`C:\Windows\System32\certutil.exe`],
+    commandOptions
+  ).trim();
+
+  return {
+    command,
+    certificatePath: (certificatePath) =>
+      run("wslpath", ["-w", certificatePath], commandOptions).trim(),
+    run,
+  };
+}
+
+function certificateFingerprint(certificatePath: string): string {
+  const certificate = new crypto.X509Certificate(fs.readFileSync(certificatePath));
+  return certificate.fingerprint.replace(/:/g, "").toLowerCase();
+}
+
+function storeOptions(options: WindowsCAStoreOptions): {
+  command: string;
+  certificatePath: (certificatePath: string) => string;
+  run: WindowsCACommandRunner;
+} {
+  return {
+    command: options.command ?? "certutil",
+    certificatePath: options.certificatePath ?? ((certificatePath) => certificatePath),
+    run: options.run ?? defaultRunner,
+  };
+}
+
+/** Return whether the certificate is present in the Windows user Root store. */
+export function isWindowsCATrusted(
+  caCertPath: string,
+  options: WindowsCAStoreOptions = {}
+): boolean {
+  try {
+    const resolved = storeOptions(options);
+    const fingerprint = certificateFingerprint(caCertPath);
+    const listing = resolved.run(resolved.command, ["-store", "-user", "Root"], commandOptions);
+    return listing.replace(/\s/g, "").toLowerCase().includes(fingerprint);
+  } catch {
+    return false;
+  }
+}
+
+/** Add the certificate to the Windows user Root store. */
+export function trustWindowsCA(caCertPath: string, options: WindowsCAStoreOptions = {}): void {
+  const resolved = storeOptions(options);
+  resolved.run(
+    resolved.command,
+    ["-addstore", "-user", "Root", resolved.certificatePath(caCertPath)],
+    commandOptions
+  );
+}
+
+/** Remove the certificate from the Windows user Root store. */
+export function untrustWindowsCA(
+  caCertPath: string,
+  options: WindowsCAStoreOptions = {}
+): { removed: boolean; error?: string } {
+  try {
+    if (!isWindowsCATrusted(caCertPath, options)) return { removed: true };
+
+    const resolved = storeOptions(options);
+    resolved.run(
+      resolved.command,
+      ["-delstore", "-user", "Root", WINDOWS_CA_COMMON_NAME],
+      commandOptions
+    );
+
+    return isWindowsCATrusted(caCertPath, options)
+      ? { removed: false, error: "certutil could not remove the portless CA from Root" }
+      : { removed: true };
+  } catch (error: unknown) {
+    return { removed: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}

--- a/packages/portless/src/windows-ca.ts
+++ b/packages/portless/src/windows-ca.ts
@@ -3,7 +3,6 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import { execFileSync, type ExecFileSyncOptionsWithStringEncoding } from "node:child_process";
 
-const WINDOWS_CA_COMMON_NAME = "portless Local CA";
 const WINDOWS_COMMAND_TIMEOUT_MS = 30_000;
 
 export type WindowsCACommandRunner = (
@@ -84,6 +83,16 @@ function storeOptions(options: WindowsCAStoreOptions): {
   };
 }
 
+type ResolvedWindowsCAStoreOptions = ReturnType<typeof storeOptions>;
+
+function storeContainsFingerprint(
+  fingerprint: string,
+  resolved: ResolvedWindowsCAStoreOptions
+): boolean {
+  const listing = resolved.run(resolved.command, ["-store", "-user", "Root"], commandOptions);
+  return listing.replace(/\s/g, "").toLowerCase().includes(fingerprint);
+}
+
 /** Return whether the certificate is present in the Windows user Root store. */
 export function isWindowsCATrusted(
   caCertPath: string,
@@ -92,8 +101,7 @@ export function isWindowsCATrusted(
   try {
     const resolved = storeOptions(options);
     const fingerprint = certificateFingerprint(caCertPath);
-    const listing = resolved.run(resolved.command, ["-store", "-user", "Root"], commandOptions);
-    return listing.replace(/\s/g, "").toLowerCase().includes(fingerprint);
+    return storeContainsFingerprint(fingerprint, resolved);
   } catch {
     return false;
   }
@@ -115,16 +123,13 @@ export function untrustWindowsCA(
   options: WindowsCAStoreOptions = {}
 ): { removed: boolean; error?: string } {
   try {
-    if (!isWindowsCATrusted(caCertPath, options)) return { removed: true };
-
     const resolved = storeOptions(options);
-    resolved.run(
-      resolved.command,
-      ["-delstore", "-user", "Root", WINDOWS_CA_COMMON_NAME],
-      commandOptions
-    );
+    const fingerprint = certificateFingerprint(caCertPath);
+    if (!storeContainsFingerprint(fingerprint, resolved)) return { removed: true };
 
-    return isWindowsCATrusted(caCertPath, options)
+    resolved.run(resolved.command, ["-delstore", "-user", "Root", fingerprint], commandOptions);
+
+    return storeContainsFingerprint(fingerprint, resolved)
       ? { removed: false, error: "certutil could not remove the portless CA from Root" }
       : { removed: true };
   } catch (error: unknown) {

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -169,7 +169,7 @@ Most frameworks (Next.js, Express, Nuxt, etc.) respect the `PORT` env var automa
 
 ### State directory
 
-Portless stores its state (routes, PID file, port file) in `~/.portless`. Override with the `PORTLESS_STATE_DIR` environment variable.
+Portless stores its state (routes, PID file, port file) in `~/.portless`. When the proxy runs under sudo, this remains the invoking user's home directory so unprivileged apps and the proxy share route registrations. Override with the `PORTLESS_STATE_DIR` environment variable.
 
 ### Environment variables
 
@@ -199,7 +199,7 @@ portless proxy start --no-tls                       # Disable HTTPS (plain HTTP)
 portless trust                                      # Add CA to trust store later
 ```
 
-On Linux, `portless trust` supports Debian/Ubuntu, Arch, Fedora/RHEL/CentOS, and openSUSE (via `update-ca-certificates` or `update-ca-trust`). On Windows, it uses `certutil` to add the CA to the system trust store.
+On Linux, `portless trust` supports Debian/Ubuntu, Arch, Fedora/RHEL/CentOS, and openSUSE (via `update-ca-certificates` or `update-ca-trust`). On Windows, it uses `certutil` to add the CA to the system trust store. On WSL, it updates both the Linux trust store and the Windows current-user Root store so Windows browsers trust portless HTTPS certificates.
 
 ### LAN mode
 

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -424,7 +424,7 @@ This adds the portless local CA to your system trust store. After that, restart 
 portless clean
 ```
 
-Stops the proxy if needed, removes the portless CA from the trust store (when portless added it), deletes known files under state directories, and removes the portless `/etc/hosts` block. May require `sudo` on macOS/Linux.
+Stops the proxy if needed, removes the portless CA from the trust store (when portless added it), deletes known files under state directories, and removes the portless `/etc/hosts` block. May require `sudo` on macOS/Linux. If trust-store removal fails, portless retains its CA certificate and key so a later `portless clean` can safely retry.
 
 ### Proxy loop (508 Loop Detected)
 


### PR DESCRIPTION
- Resolve state paths from the original sudo user home.
- Trust the local CA in both Linux and Windows stores under WSL.
- Add coverage and user-facing documentation.

Fixes #283 
 
Closes #286 