### PR TITLE
fix(cli): escape Windows command arguments

### DIFF
--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -906,6 +906,15 @@ describe("cmdEscape", () => {
   it("handles the empty argument", () => {
     expect(cmdEscape("")).toBe('^"^"');
   });
+
+  it("escapes long backslash runs in linear time (regex form is quadratic)", () => {
+    const arg = "a " + "\\".repeat(64 * 1024);
+    const start = performance.now();
+    const escaped = cmdEscape(arg);
+    // The old /(\\*)"/g implementation takes >10s here; allow generous CI jitter.
+    expect(performance.now() - start).toBeLessThan(1000);
+    expect(escaped).toBe('^"a^ ' + "\\".repeat(128 * 1024) + '^"');
+  });
 });
 
 describe("cmdEscapeCommand", () => {

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -7,6 +7,8 @@ import * as path from "node:path";
 import {
   buildProxyStartConfig,
   BLOCKED_PORTS,
+  cmdEscape,
+  cmdEscapeCommand,
   DEFAULT_TLD,
   FALLBACK_PROXY_PORT,
   INTERNAL_LAN_IP_FLAG,
@@ -865,6 +867,57 @@ describe("parseTldList", () => {
 
   it("rejects empty list entries", () => {
     expect(() => parseTldList("test,")).toThrow("TLD cannot be empty");
+  });
+});
+
+describe("cmdEscape", () => {
+  it("quotes a plain argument", () => {
+    expect(cmdEscape("dev")).toBe('^"dev^"');
+  });
+
+  it("preserves paths with spaces as a single argument", () => {
+    expect(cmdEscape("C:\\Program Files\\nodejs\\node.exe")).toBe(
+      '^"C:\\Program^ Files\\nodejs\\node.exe^"'
+    );
+  });
+
+  it("caret-escapes cmd metacharacters", () => {
+    expect(cmdEscape("console.log(1)")).toBe('^"console.log^(1^)^"');
+    expect(cmdEscape("a&&b")).toBe('^"a^&^&b^"');
+    expect(cmdEscape("%PATH%")).toBe('^"^%PATH^%^"');
+  });
+
+  it("escapes embedded double quotes", () => {
+    expect(cmdEscape('say "hi"')).toBe('^"say^ \\^"hi\\^"^"');
+  });
+
+  it("doubles backslashes before quotes and at the end", () => {
+    expect(cmdEscape('dir\\"x')).toBe('^"dir\\\\\\^"x^"');
+    expect(cmdEscape("trailing\\")).toBe('^"trailing\\\\^"');
+  });
+
+  it("handles the empty argument", () => {
+    expect(cmdEscape("")).toBe('^"^"');
+  });
+});
+
+describe("cmdEscapeCommand", () => {
+  it("leaves bare PATH-resolved names untouched (quoting breaks %~dp0 in .cmd shims)", () => {
+    expect(cmdEscapeCommand("npm")).toBe("npm");
+    expect(cmdEscapeCommand("pnpm")).toBe("pnpm");
+    expect(cmdEscapeCommand("node")).toBe("node");
+    expect(cmdEscapeCommand("C:\\tools\\node.exe")).toBe("C:\\tools\\node.exe");
+  });
+
+  it("plain-quotes (no carets) paths with spaces", () => {
+    expect(cmdEscapeCommand("C:\\Program Files\\nodejs\\node.exe")).toBe(
+      '"C:\\Program Files\\nodejs\\node.exe"'
+    );
+  });
+
+  it("plain-quotes names containing cmd metacharacters", () => {
+    expect(cmdEscapeCommand("foo&bar")).toBe('"foo&bar"');
+    expect(cmdEscapeCommand("a(b)c")).toBe('"a(b)c"');
   });
 });
 

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -871,8 +871,11 @@ describe("parseTldList", () => {
 });
 
 describe("cmdEscape", () => {
-  it("quotes a plain argument", () => {
-    expect(cmdEscape("dev")).toBe('^"dev^"');
+  it("leaves safe arguments bare (cmd built-ins print added quotes literally)", () => {
+    expect(cmdEscape("dev")).toBe("dev");
+    expect(cmdEscape("--force")).toBe("--force");
+    expect(cmdEscape("--port=3000")).toBe("--port=3000");
+    expect(cmdEscape("C:\\tools\\script.js")).toBe("C:\\tools\\script.js");
   });
 
   it("preserves paths with spaces as a single argument", () => {
@@ -891,9 +894,13 @@ describe("cmdEscape", () => {
     expect(cmdEscape('say "hi"')).toBe('^"say^ \\^"hi\\^"^"');
   });
 
-  it("doubles backslashes before quotes and at the end", () => {
+  it("doubles backslashes before quotes and before the added closing quote", () => {
     expect(cmdEscape('dir\\"x')).toBe('^"dir\\\\\\^"x^"');
-    expect(cmdEscape("trailing\\")).toBe('^"trailing\\\\^"');
+    expect(cmdEscape("trailing \\")).toBe('^"trailing^ \\\\^"');
+  });
+
+  it("leaves a bare trailing backslash alone (no quote added, so no doubling)", () => {
+    expect(cmdEscape("trailing\\")).toBe("trailing\\");
   });
 
   it("handles the empty argument", () => {
@@ -918,6 +925,11 @@ describe("cmdEscapeCommand", () => {
   it("plain-quotes names containing cmd metacharacters", () => {
     expect(cmdEscapeCommand("foo&bar")).toBe('"foo&bar"');
     expect(cmdEscapeCommand("a(b)c")).toBe('"a(b)c"');
+  });
+
+  it("caret-escapes % in bare names (quotes cannot suppress %VAR% expansion)", () => {
+    expect(cmdEscapeCommand("probe%PATH%.cmd")).toBe("probe^%PATH^%.cmd");
+    expect(cmdEscapeCommand("100%.exe")).toBe("100^%.exe");
   });
 });
 

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -853,13 +853,24 @@ function shellEscape(arg: string): string {
 const CMD_META_CHARS = /([()\][%!^"`<>&|;, *?])/g;
 
 /**
+ * Arguments matching this need no escaping for cmd.exe: non-empty, no
+ * whitespace, no quotes, and no cmd metacharacters. `=` is deliberately
+ * allowed (e.g. --port=3000) — cmd only treats it specially in the command
+ * token, not in arguments.
+ */
+const CMD_SAFE_ARG = /^[^\s()\][%!^"`<>&|;,*?]+$/;
+
+/**
  * Escape a string so cmd.exe passes it to the child as a single literal
- * argument (the Windows counterpart of shellEscape). Algorithm from
+ * argument (the Windows counterpart of shellEscape). Safe arguments stay
+ * bare: cmd built-ins (echo, etc.) don't parse an argv and would print any
+ * added quotes literally. Everything else uses the algorithm from
  * https://qntm.org/cmd, as used by cross-spawn: quote per Windows argv
  * rules, then caret-escape cmd.exe metacharacters (including the quotes
  * themselves) so cmd's own parser leaves them intact.
  */
 export function cmdEscape(arg: string): string {
+  if (CMD_SAFE_ARG.test(arg)) return arg;
   return (
     `"${arg
       // A quote preceded by N backslashes needs 2N+1 backslashes.
@@ -870,15 +881,28 @@ export function cmdEscape(arg: string): string {
 }
 
 /**
- * Escape the command token (first word) of a cmd.exe command line. Unlike
- * arguments, the command must NOT be caret-escaped or unnecessarily quoted:
- * quoting a bare PATH-resolved name (e.g. "npm") makes cmd resolve %~dp0 to
- * the current directory inside .cmd shims, which breaks npm/pnpm/yarn.
- * Bare names stay bare; anything with whitespace or cmd metacharacters gets
- * plain double quotes (fine for absolute paths, including .cmd files).
+ * Escape the command token (first word) of a cmd.exe command line. The
+ * command needs different treatment from arguments, all verified on Windows:
+ *
+ * - Quoting a bare PATH-resolved name (e.g. "npm") makes cmd resolve %~dp0
+ *   to the current directory inside .cmd shims, breaking npm/pnpm/yarn — so
+ *   bare names must stay bare.
+ * - Caret-escaping spaces (cross-spawn style, C:\Program^ Files\...) makes
+ *   cmd launch the right file, but the child re-parses its argv from the raw
+ *   command line where the space is unquoted, corrupting argv[0] — so paths
+ *   with whitespace need real double quotes.
+ * - Quotes cannot suppress %VAR% expansion, but caret-escaping % can, and it
+ *   keeps both PATH resolution and %~dp0 intact for bare names.
+ *
+ * Unsolved corner: a path containing both whitespace and a %VAR% pattern
+ * matching a defined variable (quotes are required but can't stop the
+ * expansion). The pre-escaping code failed identically.
  */
 export function cmdEscapeCommand(command: string): string {
-  return /[\s()\][%!^"`<>&|;,=*?]/.test(command) ? `"${command}"` : command;
+  if (/[\s()\][!^"`<>&|;,=*?]/.test(command)) {
+    return `"${command}"`;
+  }
+  return command.replace(/%/g, "^%");
 }
 
 /**

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -861,6 +861,34 @@ const CMD_META_CHARS = /([()\][%!^"`<>&|;, *?])/g;
 const CMD_SAFE_ARG = /^[^\s()\][%!^"`<>&|;,*?]+$/;
 
 /**
+ * Quote a string per Windows argv rules in a single linear scan: a quote
+ * preceded by N backslashes becomes 2N+1 backslashes plus an escaped quote,
+ * and N trailing backslashes (which precede the closing quote we append)
+ * become 2N. The equivalent regex, /(\\*)"/g, backtracks quadratically on
+ * long backslash runs (cf. cross-spawn's CVE-2024-21538) — and cross-spawn's
+ * patched regex is linear but under-doubles the runs (JS lookaheads are
+ * atomic, so its lazy quantifier captures a single backslash), so neither
+ * regex form is usable here.
+ */
+function windowsArgvQuote(arg: string): string {
+  let out = "";
+  let backslashes = 0;
+  for (const ch of arg) {
+    if (ch === "\\") {
+      backslashes++;
+      continue;
+    }
+    if (ch === '"') {
+      out += "\\".repeat(2 * backslashes + 1) + '"';
+    } else {
+      out += "\\".repeat(backslashes) + ch;
+    }
+    backslashes = 0;
+  }
+  return `"${out}${"\\".repeat(2 * backslashes)}"`;
+}
+
+/**
  * Escape a string so cmd.exe passes it to the child as a single literal
  * argument (the Windows counterpart of shellEscape). Safe arguments stay
  * bare: cmd built-ins (echo, etc.) don't parse an argv and would print any
@@ -871,13 +899,7 @@ const CMD_SAFE_ARG = /^[^\s()\][%!^"`<>&|;,*?]+$/;
  */
 export function cmdEscape(arg: string): string {
   if (CMD_SAFE_ARG.test(arg)) return arg;
-  return (
-    `"${arg
-      // A quote preceded by N backslashes needs 2N+1 backslashes.
-      .replace(/(\\*)"/g, '$1$1\\"')
-      // Trailing backslashes precede the closing quote we add: double them.
-      .replace(/(\\*)$/, "$1$1")}"`.replace(CMD_META_CHARS, "^$1")
-  );
+  return windowsArgvQuote(arg).replace(CMD_META_CHARS, "^$1");
 }
 
 /**

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -849,6 +849,38 @@ function shellEscape(arg: string): string {
   return `'${arg.replace(/'/g, "'\\''")}'`;
 }
 
+/** cmd.exe metacharacters that require caret-escaping. */
+const CMD_META_CHARS = /([()\][%!^"`<>&|;, *?])/g;
+
+/**
+ * Escape a string so cmd.exe passes it to the child as a single literal
+ * argument (the Windows counterpart of shellEscape). Algorithm from
+ * https://qntm.org/cmd, as used by cross-spawn: quote per Windows argv
+ * rules, then caret-escape cmd.exe metacharacters (including the quotes
+ * themselves) so cmd's own parser leaves them intact.
+ */
+export function cmdEscape(arg: string): string {
+  return (
+    `"${arg
+      // A quote preceded by N backslashes needs 2N+1 backslashes.
+      .replace(/(\\*)"/g, '$1$1\\"')
+      // Trailing backslashes precede the closing quote we add: double them.
+      .replace(/(\\*)$/, "$1$1")}"`.replace(CMD_META_CHARS, "^$1")
+  );
+}
+
+/**
+ * Escape the command token (first word) of a cmd.exe command line. Unlike
+ * arguments, the command must NOT be caret-escaped or unnecessarily quoted:
+ * quoting a bare PATH-resolved name (e.g. "npm") makes cmd resolve %~dp0 to
+ * the current directory inside .cmd shims, which breaks npm/pnpm/yarn.
+ * Bare names stay bare; anything with whitespace or cmd metacharacters gets
+ * plain double quotes (fine for absolute paths, including .cmd files).
+ */
+export function cmdEscapeCommand(command: string): string {
+  return /[\s()\][%!^"`<>&|;,=*?]/.test(command) ? `"${command}"` : command;
+}
+
 /**
  * Walk up from `cwd` to the filesystem root, collecting all
  * `node_modules/.bin` directories that exist. Returns them in
@@ -919,11 +951,28 @@ export function spawnCommand(
   // On Unix, spawn detached so the child gets its own process group. This
   // lets us kill the entire tree (shell + grandchild dev server) with a
   // single process.kill(-pid, signal) instead of only the immediate child.
+  // On Windows, build the cmd.exe line ourselves (escaping each argument and
+  // wrapping the whole command in quotes for /s) and pass it verbatim.
+  // Without windowsVerbatimArguments, libuv would re-quote the payload and
+  // backslash-escape the quote characters our escaping relies on. This
+  // mirrors what Node's own `shell: true` does for cmd.exe.
   const child = isWindows
-    ? spawn("cmd.exe", ["/d", "/s", "/c", commandArgs.join(" ")], {
-        stdio: "inherit",
-        env,
-      })
+    ? spawn(
+        "cmd.exe",
+        [
+          "/d",
+          "/s",
+          "/c",
+          `"${[cmdEscapeCommand(commandArgs[0]), ...commandArgs.slice(1).map(cmdEscape)].join(
+            " "
+          )}"`,
+        ],
+        {
+          stdio: "inherit",
+          env,
+          windowsVerbatimArguments: true,
+        }
+      )
     : spawn("/bin/sh", ["-c", commandArgs.map(shellEscape).join(" ")], {
         stdio: "inherit",
         env,


### PR DESCRIPTION
- Build cmd.exe invocations with Windows-specific escaping and verbatim argument forwarding.
- Cover command tokens, spaces, metacharacters, quotes, backslashes, and empty values.

Closes #354