### PR TITLE
Bind proxy to loopback by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,8 @@ flowchart TD
 2. **Run apps**: `portless <name> <command>` assigns a free port and registers with the proxy
 3. **Access via URL**: `https://<name>.localhost` routes through the proxy to your app
 
+Outside LAN mode, the proxy and its HTTP redirect listener bind only to the IPv4 and IPv6 loopback addresses, `127.0.0.1` and `::1`. They do not accept connections through LAN, VPN, or other network interfaces.
+
 ## HTTP/2 + HTTPS
 
 HTTPS with HTTP/2 is enabled by default. Browsers limit HTTP/1.1 to 6 connections per host, which bottlenecks dev servers that serve many unbundled files (Vite, Nuxt, etc.). HTTP/2 multiplexes all requests over a single connection.
@@ -287,7 +289,7 @@ portless proxy start --lan --https
 portless proxy start --lan --ip 192.168.1.42
 ```
 
-`--lan` switches the proxy to mDNS discovery: services are advertised as `<name>.local` and reachable from any device on the same network. Portless auto-detects your LAN IP and follows Wi-Fi/IP changes automatically, but you can pin another address with `--ip <address>` or by exporting `PORTLESS_LAN_IP`. Set `PORTLESS_LAN=1` in your shell (0/1 boolean) to make LAN mode the default whenever the proxy starts.
+`--lan` explicitly binds the proxy to the IPv4 and IPv6 unspecified addresses, `0.0.0.0` and `::`, and switches to mDNS discovery. This makes services available as `<name>.local` to devices on the same network. Portless auto-detects your LAN IP and follows Wi-Fi/IP changes automatically, but you can pin another address with `--ip <address>` or by exporting `PORTLESS_LAN_IP`. Set `PORTLESS_LAN=1` in your shell (0/1 boolean) to make LAN mode the default whenever the proxy starts.
 
 Portless remembers LAN mode via `proxy.lan`, so if you stop a LAN proxy and start it again, it stays in LAN mode. All proxy settings (port, TLS, TLDs, LAN) are persisted and reused on auto-start unless overridden by explicit flags or env vars. Use `PORTLESS_LAN=0` for one start to switch back to `.localhost` mode. If a proxy is already running with different explicit LAN/TLS/TLD settings, portless warns and asks you to stop it first.
 

--- a/apps/docs/src/app/commands/page.mdx
+++ b/apps/docs/src/app/commands/page.mdx
@@ -238,6 +238,8 @@ portless proxy start --lan --https
 portless proxy start --lan --ip 192.168.1.42   # manual IP override
 ```
 
+Without LAN mode, the proxy and HTTP redirect listener bind only to `127.0.0.1` and `::1`. LAN mode explicitly binds them to `0.0.0.0` and `::`.
+
 Make it permanent by adding `export PORTLESS_LAN=1` to your shell profile. Portless also remembers LAN mode via `proxy.lan`, so a stopped LAN proxy starts in LAN mode again unless you override it with `PORTLESS_LAN=0` for that start.
 
 Uses `dns-sd` on macOS (built-in) and `avahi-publish-address` on Linux (`avahi-utils`). Not supported on Windows.

--- a/apps/docs/src/app/page.mdx
+++ b/apps/docs/src/app/page.mdx
@@ -130,6 +130,8 @@ Recommended: `.test` (IANA-reserved, no collision risk). Avoid `.local` (conflic
 
 Portless runs an HTTPS reverse proxy on port 443 by default. Each app registers a route mapping its hostname to an assigned port. Requests to `https://<name>.localhost` are proxied to the app.
 
+The proxy listens only on the IPv4 and IPv6 loopback addresses, `127.0.0.1` and `::1`, by default. Network interfaces are exposed only when LAN mode is explicitly enabled.
+
 ```
 Browser (myapp.localhost) -> proxy (port 443) -> App (random port)
 ```

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -20,10 +20,12 @@ import {
   getDefaultTld,
   getDefaultTlds,
   getProtocolPort,
+  getProxyBindTargets,
   isHttpsEnvDisabled,
   injectFrameworkFlags,
   isPortListening,
   isProxyRunning,
+  listenOnProxyInterface,
   parsePidFromNetstat,
   parseTldList,
   readLanMarker,
@@ -37,6 +39,80 @@ import {
   writeTldsFile,
   writeTlsMarker,
 } from "./cli-utils.js";
+
+describe("proxy listener interface", () => {
+  it("uses only IPv4 and IPv6 loopback outside LAN mode", () => {
+    expect(getProxyBindTargets(false)).toEqual([
+      { host: "127.0.0.1" },
+      { host: "::1", ipv6Only: true },
+    ]);
+  });
+
+  it("uses IPv4 and IPv6 unspecified addresses in LAN mode", () => {
+    expect(getProxyBindTargets(true)).toEqual([
+      { host: "0.0.0.0" },
+      { host: "::", ipv6Only: true },
+    ]);
+  });
+
+  it("binds IPv4 loopback outside LAN mode", async () => {
+    const target = getProxyBindTargets(false)[0]!;
+
+    const server = net.createServer();
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      listenOnProxyInterface(server, 0, target, resolve);
+    });
+
+    try {
+      const address = server.address();
+      expect(address && typeof address !== "string" ? address.address : null).toBe("127.0.0.1");
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("binds IPv6 loopback outside LAN mode when available", async (ctx) => {
+    const target = getProxyBindTargets(false)[1]!;
+
+    const server = net.createServer();
+    const ipv6Available = await new Promise<boolean>((resolve, reject) => {
+      server.once("error", (err: NodeJS.ErrnoException) => {
+        if (err.code === "EAFNOSUPPORT" || err.code === "EADDRNOTAVAIL") {
+          resolve(false);
+        } else {
+          reject(err);
+        }
+      });
+      listenOnProxyInterface(server, 0, target, () => resolve(true));
+    });
+    if (!ipv6Available) return ctx.skip();
+
+    try {
+      const address = server.address();
+      expect(address && typeof address !== "string" ? address.address : null).toBe("::1");
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("binds the IPv4 unspecified address in LAN mode", async () => {
+    const target = getProxyBindTargets(true)[0]!;
+
+    const server = net.createServer();
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      listenOnProxyInterface(server, 0, target, resolve);
+    });
+
+    try {
+      const address = server.address();
+      expect(address && typeof address !== "string" ? address.address : null).toBe("0.0.0.0");
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});
 
 describe("findFreePort", () => {
   it("returns a port in the default range", async () => {

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -34,6 +34,23 @@ export const INTERNAL_LAN_IP_ENV = "PORTLESS_INTERNAL_LAN_IP";
 /** Internal-only flag used to pass an auto-detected LAN IP through re-exec. */
 export const INTERNAL_LAN_IP_FLAG = "--lan-ip-auto";
 
+/** Listener address used when the proxy is only accessible from this machine. */
+export const IPV4_LOOPBACK_PROXY_HOST = "127.0.0.1";
+
+/** IPv6 listener address used when the proxy is only accessible from this machine. */
+export const IPV6_LOOPBACK_PROXY_HOST = "::1";
+
+/** IPv4 listener address used when LAN mode explicitly exposes the proxy. */
+export const IPV4_LAN_PROXY_HOST = "0.0.0.0";
+
+/** IPv6 listener address used when LAN mode explicitly exposes the proxy. */
+export const IPV6_LAN_PROXY_HOST = "::";
+
+export type ProxyBindTarget = {
+  host: string;
+  ipv6Only?: boolean;
+};
+
 /**
  * @deprecated No longer used. All state now lives in USER_STATE_DIR.
  * Kept as a read-only reference for migration and cleanup of old installs.
@@ -91,6 +108,26 @@ export const SIGNAL_CODES: Record<string, number> = {
   SIGKILL: 9,
   SIGTERM: 15,
 };
+
+/** Return explicit IPv4 and IPv6 listener targets for the effective proxy mode. */
+export function getProxyBindTargets(lanMode: boolean): ProxyBindTarget[] {
+  return lanMode
+    ? [{ host: IPV4_LAN_PROXY_HOST }, { host: IPV6_LAN_PROXY_HOST, ipv6Only: true }]
+    : [{ host: IPV4_LOOPBACK_PROXY_HOST }, { host: IPV6_LOOPBACK_PROXY_HOST, ipv6Only: true }];
+}
+
+/**
+ * Start a proxy listener on loopback unless LAN mode explicitly enables
+ * access through the machine's network interfaces.
+ */
+export function listenOnProxyInterface(
+  server: net.Server,
+  port: number,
+  target: ProxyBindTarget,
+  listener?: () => void
+): void {
+  server.listen({ port, host: target.host, ipv6Only: target.ipv6Only }, listener);
+}
 
 /**
  * Kill a child process and its entire process tree. On Unix, when the child

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -107,13 +107,14 @@ async function getFreePort(): Promise<number> {
 async function waitForHttpHeader(
   port: number,
   headerName: string,
-  expectedValue: string
+  expectedValue: string,
+  hostname = "127.0.0.1"
 ): Promise<void> {
   for (let i = 0; i < 50; i++) {
     const matched = await new Promise<boolean>((resolve) => {
       const req = http.request(
         {
-          hostname: "127.0.0.1",
+          hostname,
           port,
           method: "HEAD",
           timeout: 200,
@@ -133,7 +134,7 @@ async function waitForHttpHeader(
     if (matched) return;
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
-  throw new Error(`Timed out waiting for ${headerName} on port ${port}`);
+  throw new Error(`Timed out waiting for ${headerName} on ${hostname}:${port}`);
 }
 
 async function stopChild(child: ReturnType<typeof spawn>): Promise<void> {
@@ -1502,6 +1503,26 @@ describe("CLI", () => {
       expect(stop.stdout).toContain("Proxy stopped");
     });
 
+    it("accepts connections on IPv6 loopback when available", async (ctx) => {
+      const ipv6Probe = http.createServer();
+      const ipv6Available = await new Promise<boolean>((resolve, reject) => {
+        ipv6Probe.once("error", (err: NodeJS.ErrnoException) => {
+          if (err.code === "EAFNOSUPPORT" || err.code === "EADDRNOTAVAIL") {
+            resolve(false);
+          } else {
+            reject(err);
+          }
+        });
+        ipv6Probe.listen(0, "::1", () => resolve(true));
+      });
+      if (!ipv6Available) return ctx.skip();
+      await new Promise<void>((resolve) => ipv6Probe.close(() => resolve()));
+
+      const start = run(["proxy", "start"], { env: proxyEnv() });
+      expect(start.status).toBe(0);
+      await waitForHttpHeader(testPort, "X-Portless", "1", "::1");
+    });
+
     it("reports not running when stopped twice", () => {
       const start = run(["proxy", "start"], { env: proxyEnv() });
       expect(start.status).toBe(0);
@@ -1583,7 +1604,7 @@ describe("CLI", () => {
         // Before the fix, the daemon would re-run the failing trust flow,
         // potentially stalling long enough for waitForProxy to time out.
         // After the fix, the parent passes --skip-trust to the daemon.
-        expect(start.status).toBe(0);
+        expect(start.status, start.stdout + start.stderr).toBe(0);
         expect(start.stdout).toContain(`proxy started on port ${testPort}`);
 
         // Parent should warn that trust failed

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -58,6 +58,7 @@ import {
   findPidsOnPort,
   getDefaultPort,
   getDefaultTlds,
+  getProxyBindTargets,
   injectFrameworkFlags,
   isHttpsEnvDisabled,
   isPortListening,
@@ -66,6 +67,7 @@ import {
   isProxyRunning,
   isWindows,
   killTree,
+  listenOnProxyInterface,
   parseTldList,
   readLanMarker,
   readCustomCertMarker,
@@ -478,6 +480,14 @@ function formatViteAllowedHosts(tlds: readonly string[]): string {
   return tlds.map((configuredTld) => `.${configuredTld}`).join(",");
 }
 
+function formatBindEndpoint(host: string, port: number): string {
+  return host.includes(":") ? `[${host}]:${port}` : `${host}:${port}`;
+}
+
+function isUnavailableIpv6Bind(err: NodeJS.ErrnoException, host: string): boolean {
+  return host.includes(":") && (err.code === "EAFNOSUPPORT" || err.code === "EADDRNOTAVAIL");
+}
+
 function addRoutes(
   store: RouteStore,
   hostnames: readonly string[],
@@ -537,6 +547,9 @@ function startProxyServer(
   const isTls = !!tlsOptions;
   const mdnsSupport = isMdnsSupported();
   let activeLanIp = lanIp && mdnsSupport.supported ? lanIp : null;
+  const lanModeActive = activeLanIp !== null;
+  const bindTargets = getProxyBindTargets(lanModeActive);
+  const primaryBindTarget = bindTargets[0]!;
   const lanIpPinned = !!process.env.PORTLESS_LAN_IP;
   let lanMonitor: ReturnType<typeof startLanIpMonitor> | null = null;
   if (lanIp && !mdnsSupport.supported) {
@@ -642,15 +655,29 @@ function startProxyServer(
   // Publish mDNS for routes that already exist at startup
   publishCachedRoutes();
 
-  const server = createProxyServer({
-    getRoutes: () => cachedRoutes,
-    proxyPort,
-    tld,
-    tlds,
-    strict,
-    onError: (msg) => console.error(colors.red(msg)),
-    tls: tlsOptions,
-  });
+  const createServer = () =>
+    createProxyServer({
+      getRoutes: () => cachedRoutes,
+      proxyPort,
+      tld,
+      tlds,
+      strict,
+      onError: (msg) => console.error(colors.red(msg)),
+      tls: tlsOptions,
+    });
+  const server = createServer();
+  const additionalServers = new Set<ReturnType<typeof createProxyServer>>();
+  const redirectServers = new Set<ReturnType<typeof createHttpRedirectServer>>();
+
+  const closeAuxiliaryServers = () => {
+    for (const auxiliaryServer of [...additionalServers, ...redirectServers]) {
+      try {
+        auxiliaryServer.close();
+      } catch {
+        // The listener may have failed before it started; nothing to close.
+      }
+    }
+  };
 
   server.on("error", (err: NodeJS.ErrnoException) => {
     if (err.code === "EADDRINUSE") {
@@ -670,23 +697,57 @@ function startProxyServer(
     } else {
       console.error(colors.red(`Proxy error: ${err.message}`));
     }
-    if (redirectServer) redirectServer.close();
+    closeAuxiliaryServers();
     process.exit(1);
   });
+
+  const proto = isTls ? "HTTPS/2" : "HTTP";
+  const tldLabel = tlds.length > 1 || tld !== DEFAULT_TLD ? ` (TLDs: ${formatTldList(tlds)})` : "";
+  const modeLabel = strict === false ? " (wildcard)" : "";
+
+  for (const bindTarget of bindTargets.slice(1)) {
+    const additionalServer = createServer();
+    additionalServers.add(additionalServer);
+    additionalServer.on("error", (err: NodeJS.ErrnoException) => {
+      additionalServers.delete(additionalServer);
+      if (!isUnavailableIpv6Bind(err, bindTarget.host)) {
+        console.warn(
+          colors.yellow(
+            `Could not listen on ${formatBindEndpoint(bindTarget.host, proxyPort)}: ${err.message}`
+          )
+        );
+      }
+    });
+    listenOnProxyInterface(additionalServer, proxyPort, bindTarget, () => {
+      console.log(
+        colors.green(
+          `${proto} proxy listening on ${formatBindEndpoint(bindTarget.host, proxyPort)}${tldLabel}${modeLabel}`
+        )
+      );
+    });
+  }
 
   // When TLS is enabled, start a plain HTTP server on port 80 that redirects
   // to HTTPS. Best-effort: if port 80 is unavailable, skip silently (the main
   // proxy on 443 still works; users just won't get automatic redirects).
-  let redirectServer: ReturnType<typeof createHttpRedirectServer> | null = null;
   if (isTls && proxyPort !== 80) {
-    redirectServer = createHttpRedirectServer(proxyPort);
-    redirectServer.on("error", () => {
-      redirectServer = null;
-    });
-    redirectServer.listen(80);
+    for (const bindTarget of bindTargets) {
+      const redirectServer = createHttpRedirectServer(proxyPort);
+      redirectServers.add(redirectServer);
+      redirectServer.on("error", () => {
+        redirectServers.delete(redirectServer);
+      });
+      listenOnProxyInterface(redirectServer, 80, bindTarget, () => {
+        console.log(
+          colors.green(
+            `HTTP-to-HTTPS redirect listening on ${formatBindEndpoint(bindTarget.host, 80)}`
+          )
+        );
+      });
+    }
   }
 
-  server.listen(proxyPort, () => {
+  listenOnProxyInterface(server, proxyPort, primaryBindTarget, () => {
     // Save PID and port once the server is actually listening
     fs.writeFileSync(store.pidPath, process.pid.toString(), { mode: FILE_MODE });
     fs.writeFileSync(store.portFilePath, proxyPort.toString(), { mode: FILE_MODE });
@@ -695,12 +756,10 @@ function startProxyServer(
     writeTldsFile(store.dir, tlds);
     writeLanMarker(store.dir, activeLanIp);
     fixOwnership(store.dir, store.pidPath, store.portFilePath);
-    const proto = isTls ? "HTTPS/2" : "HTTP";
-    const tldLabel =
-      tlds.length > 1 || tld !== DEFAULT_TLD ? ` (TLDs: ${formatTldList(tlds)})` : "";
-    const modeLabel = strict === false ? " (wildcard)" : "";
     console.log(
-      colors.green(`${proto} proxy listening on port ${proxyPort}${tldLabel}${modeLabel}`)
+      colors.green(
+        `${proto} proxy listening on ${formatBindEndpoint(primaryBindTarget.host, proxyPort)}${tldLabel}${modeLabel}`
+      )
     );
     if (activeLanIp) {
       console.log(chalk.green(`LAN mode: ${activeLanIp}`));
@@ -720,9 +779,6 @@ function startProxyServer(
         });
       }
     }
-    if (redirectServer) {
-      console.log(colors.green("HTTP-to-HTTPS redirect listening on port 80"));
-    }
   });
 
   // Cleanup on exit
@@ -737,9 +793,7 @@ function startProxyServer(
       watcher.close();
     }
     if (activeLanIp) cleanupMdns();
-    if (redirectServer) {
-      redirectServer.close();
-    }
+    closeAuxiliaryServers();
     try {
       fs.unlinkSync(store.pidPath);
     } catch {
@@ -1766,6 +1820,7 @@ ${colors.bold("How it works:")}
   5. Frameworks that ignore PORT (Vite, VitePlus, Astro, React Router, Angular,
      Expo, React Native) get --port and, when needed, --host flags
      injected automatically
+  6. The proxy listens only on 127.0.0.1 and ::1 unless LAN mode is enabled
   Elevated proxy processes keep the invoking user's ~/.portless state directory.
 
 ${colors.bold("HTTP/2 + HTTPS (default):")}
@@ -1777,6 +1832,8 @@ ${colors.bold("HTTP/2 + HTTPS (default):")}
 ${colors.bold("LAN mode:")}
   Use --lan to make services accessible from other devices (phones,
   tablets) on the same WiFi network via mDNS (.local domains).
+  Normal mode binds only to 127.0.0.1 and ::1.
+  LAN mode binds to 0.0.0.0 and ::.
   Useful for testing React Native / Expo apps on real devices.
   Expo keeps Metro's default LAN host behavior in this mode.
   Auto-detected LAN IPs follow network changes automatically.
@@ -2809,6 +2866,8 @@ ${colors.bold("Usage:")}
   ${colors.cyan("portless proxy stop")}                 Stop the proxy
 
 ${colors.bold("LAN mode (--lan):")}
+  Without LAN mode, the proxy listens only on 127.0.0.1 and ::1.
+  LAN mode explicitly binds the proxy to 0.0.0.0 and ::.
   Makes services accessible from other devices on the same WiFi network
   via mDNS (.local domains). Useful for testing on real mobile devices.
   Auto-detects your LAN IP and follows changes automatically, or use

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -161,6 +161,8 @@ PORTLESS=0 pnpm dev   # Bypasses proxy, uses default port
 2. `portless <name> <cmd>` assigns a random free port (4000-4999) via the `PORT` env var and registers the app with the proxy
 3. The browser hits `https://<name>.localhost`; the proxy forwards to the app's assigned port
 
+Outside LAN mode, the proxy and its HTTP redirect listener bind only to the IPv4 and IPv6 loopback addresses, `127.0.0.1` and `::1`. They do not accept connections through LAN, VPN, or other network interfaces.
+
 `.localhost` domains resolve to `127.0.0.1` natively in Chrome, Firefox, and Edge. Safari relies on the system DNS resolver, which may not handle `.localhost` subdomains on all configurations. Run `portless hosts sync` to add entries to `/etc/hosts` if needed.
 
 Use `portless proxy start --tld localhost --tld test` to serve the same app names under multiple TLDs from one proxy. `PORTLESS_URL` uses the first configured TLD. `PORTLESS_TLD` accepts the same comma separated list format, e.g. `PORTLESS_TLD=localhost,test`.
@@ -209,7 +211,7 @@ portless proxy start --lan --https
 portless proxy start --lan --ip 192.168.1.42
 ```
 
-`--lan` advertises `<name>.local` hostnames over mDNS so any device on the same Wi-Fi can reach your apps. Portless auto-detects your LAN IP and follows network changes automatically, but you can pin a specific address with `--ip <address>` or the `PORTLESS_LAN_IP` environment variable. Set `PORTLESS_LAN=1` to default to LAN mode every time the proxy starts.
+`--lan` explicitly binds the proxy to the IPv4 and IPv6 unspecified addresses, `0.0.0.0` and `::`, and advertises `<name>.local` hostnames over mDNS so devices on the same Wi-Fi can reach your apps. Portless auto-detects your LAN IP and follows network changes automatically, but you can pin a specific address with `--ip <address>` or the `PORTLESS_LAN_IP` environment variable. Set `PORTLESS_LAN=1` to default to LAN mode every time the proxy starts.
 
 Portless remembers LAN mode via `proxy.lan`, so if you stop a LAN proxy and start again, it stays in LAN mode. All proxy settings (port, TLS, TLDs, LAN) are persisted and reused on auto-start unless overridden by explicit flags or env vars. Use `PORTLESS_LAN=0` for one start to switch back to `.localhost` mode. If a proxy is already running with different explicit LAN/TLS/TLD settings, portless warns and asks you to stop it first.
 


### PR DESCRIPTION
- Limit proxy and redirect listeners to loopback outside LAN mode
- Preserve explicit LAN exposure and document listener behavior
- Add socket-level regression coverage