### PR TITLE
Prepare v0.15.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 # Changelog
 
-## 0.15.3
+## 0.15.4
 
 <!-- release:start -->
+
+### Bug Fixes
+
+- **Loopback-only proxy binding**: Outside LAN mode, the proxy and HTTP redirect listeners now bind only to `127.0.0.1` and `::1`, so Portless routes cannot be reached through LAN, VPN, or other network interfaces. LAN mode still binds to all interfaces explicitly. (#361)
+
+### Contributors
+
+- @ctate
+<!-- release:end -->
+
+## 0.15.3
 
 ### Bug Fixes
 
@@ -13,7 +24,6 @@
 
 - @ctate
 - @gerardbalaoro
-<!-- release:end -->
 
 ## 0.15.2
 

--- a/apps/docs/src/app/changelog/page.mdx
+++ b/apps/docs/src/app/changelog/page.mdx
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.15.4
+
+### Bug Fixes
+
+- **Loopback-only proxy binding**: Outside LAN mode, the proxy and HTTP redirect listeners now bind only to `127.0.0.1` and `::1`, so Portless routes cannot be reached through LAN, VPN, or other network interfaces. LAN mode still binds to all interfaces explicitly
+
 ## 0.15.3
 
 ### Bug Fixes

--- a/packages/portless/package.json
+++ b/packages/portless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portless",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "Replace port numbers with stable, named .localhost URLs. For humans and agents.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Bumps portless to v0.15.4 and adds matching release notes for the loopback-only proxy binding fix.