### PR TITLE
fix(proxy): WebSocket over HTTP/2 extended CONNECT (RFC 8441)

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ Outside LAN mode, the proxy and its HTTP redirect listener bind only to the IPv4
 
 HTTPS with HTTP/2 is enabled by default. Browsers limit HTTP/1.1 to 6 connections per host, which bottlenecks dev servers that serve many unbundled files (Vite, Nuxt, etc.). HTTP/2 multiplexes all requests over a single connection.
 
+WebSockets work over both protocol versions, so dev server HMR (Next.js, Vite, etc.) works through the proxy: HTTP/1.1 `Upgrade` requests are forwarded as-is, and WebSockets opened over an HTTP/2 connection use extended CONNECT (RFC 8441).
+
 On first run, portless generates a local CA and adds it to your system trust store. No browser warnings. No manual setup.
 
 ```bash

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1825,6 +1825,8 @@ ${colors.bold("How it works:")}
 
 ${colors.bold("HTTP/2 + HTTPS (default):")}
   HTTPS with HTTP/2 multiplexing is enabled by default (faster page loads).
+  WebSockets work over both HTTP/1.1 (Upgrade) and HTTP/2 (RFC 8441
+  extended CONNECT), so dev server HMR works through the proxy.
   On first use, portless generates a local CA and adds it to your
   system trust store. No browser warnings. Disable with --no-tls.
   On WSL, portless also adds the CA to the Windows user certificate store.

--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -1551,6 +1551,260 @@ describe("createProxyServer with TLS (HTTP/2)", () => {
     expect(upgraded).toBe(true);
   });
 
+  /** Open an HTTP/2 client session to the proxy and wait for its SETTINGS frame. */
+  function h2Session(
+    server: AnyServer
+  ): Promise<{ client: http2.ClientHttp2Session; settings: http2.Settings }> {
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("no addr");
+    return new Promise((resolve, reject) => {
+      const client = http2.connect(`https://127.0.0.1:${addr.port}`, {
+        rejectUnauthorized: false,
+      });
+      client.on("error", reject);
+      client.on("remoteSettings", (settings) => resolve({ client, settings }));
+    });
+  }
+
+  it("proxies WebSocket over HTTP/2 extended CONNECT (RFC 8441)", async () => {
+    const received: http.IncomingHttpHeaders = {};
+    const backend = trackServer(http.createServer());
+    backend.on("upgrade", (req, socket) => {
+      Object.assign(received, req.headers);
+      socket.write(
+        "HTTP/1.1 101 Switching Protocols\r\n" +
+          "Upgrade: websocket\r\n" +
+          "Connection: Upgrade\r\n" +
+          "Sec-WebSocket-Accept: backend-answer\r\n" +
+          "\r\n"
+      );
+      socket.on("data", (d) => socket.write(`echo:${d}`));
+    });
+    await listen(backend);
+    const backendAddr = backend.address();
+    if (!backendAddr || typeof backendAddr === "string") throw new Error("no addr");
+
+    const routes: RouteInfo[] = [{ hostname: "ws.localhost", port: backendAddr.port }];
+    const server = trackServer(
+      createProxyServer({
+        getRoutes: () => routes,
+        proxyPort: TEST_PROXY_PORT,
+        tls: { cert: tlsCert, key: tlsKey },
+      })
+    );
+    await listen(server);
+
+    const { client, settings } = await h2Session(server);
+    try {
+      expect(settings.enableConnectProtocol).toBe(true);
+
+      const result = await new Promise<{
+        status: number;
+        accept?: string;
+        echoed: string;
+      }>((resolve, reject) => {
+        const req = client.request({
+          ":method": "CONNECT",
+          ":protocol": "websocket",
+          ":path": "/_next/webpack-hmr",
+          ":authority": "ws.localhost",
+          ":scheme": "https",
+          "sec-websocket-version": "13",
+        });
+        req.on("error", reject);
+        req.on("response", (headers) => {
+          req.write("ping");
+          req.on("data", (d: Buffer) => {
+            resolve({
+              status: headers[":status"] as number,
+              accept: headers["sec-websocket-accept"] as string | undefined,
+              echoed: d.toString(),
+            });
+            req.close();
+          });
+        });
+      });
+
+      // RFC 8441 handshake succeeds with :status 200 and no Accept header.
+      expect(result.status).toBe(200);
+      expect(result.accept).toBeUndefined();
+      expect(result.echoed).toBe("echo:ping");
+      // The backend saw a synthesized HTTP/1.1 handshake.
+      expect(received.connection).toBe("Upgrade");
+      expect(received.upgrade).toBe("websocket");
+      expect(received["sec-websocket-version"]).toBe("13");
+      expect(Buffer.from(String(received["sec-websocket-key"]), "base64")).toHaveLength(16);
+      expect(received.host).toBe("ws.localhost");
+      expect(received["x-portless-hops"]).toBe("1");
+      expect(received["x-forwarded-proto"]).toBe("https");
+    } finally {
+      client.close();
+    }
+  });
+
+  it("forwards backend rejection of an extended CONNECT as an HTTP response", async () => {
+    const backend = trackServer(http.createServer());
+    backend.on("upgrade", (_req, socket) => {
+      socket.write(
+        "HTTP/1.1 307 Temporary Redirect\r\n" +
+          "Location: /login\r\n" +
+          "Content-Length: 0\r\n" +
+          "\r\n"
+      );
+      socket.end();
+    });
+    await listen(backend);
+    const backendAddr = backend.address();
+    if (!backendAddr || typeof backendAddr === "string") throw new Error("no addr");
+
+    const routes: RouteInfo[] = [{ hostname: "ws.localhost", port: backendAddr.port }];
+    const server = trackServer(
+      createProxyServer({
+        getRoutes: () => routes,
+        proxyPort: TEST_PROXY_PORT,
+        tls: { cert: tlsCert, key: tlsKey },
+      })
+    );
+    await listen(server);
+
+    const { client } = await h2Session(server);
+    try {
+      const result = await new Promise<{ status: number; location?: string }>((resolve, reject) => {
+        const req = client.request({
+          ":method": "CONNECT",
+          ":protocol": "websocket",
+          ":path": "/_next/webpack-hmr",
+          ":authority": "ws.localhost",
+          ":scheme": "https",
+        });
+        req.on("error", reject);
+        req.on("response", (headers) => {
+          resolve({
+            status: headers[":status"] as number,
+            location: headers.location as string | undefined,
+          });
+          req.close();
+        });
+      });
+
+      expect(result.status).toBe(307);
+      expect(result.location).toBe("/login");
+    } finally {
+      client.close();
+    }
+  });
+
+  it("returns 404 for extended CONNECT to an unknown host", async () => {
+    const server = trackServer(
+      createProxyServer({
+        getRoutes: () => [],
+        proxyPort: TEST_PROXY_PORT,
+        tls: { cert: tlsCert, key: tlsKey },
+      })
+    );
+    await listen(server);
+
+    const { client } = await h2Session(server);
+    try {
+      const status = await new Promise<number>((resolve, reject) => {
+        const req = client.request({
+          ":method": "CONNECT",
+          ":protocol": "websocket",
+          ":path": "/",
+          ":authority": "unknown.localhost",
+          ":scheme": "https",
+        });
+        req.on("error", reject);
+        req.on("response", (headers) => {
+          resolve(headers[":status"] as number);
+          req.close();
+        });
+      });
+      expect(status).toBe(404);
+    } finally {
+      client.close();
+    }
+  });
+
+  it("returns 501 for a classic CONNECT without :protocol", async () => {
+    const server = trackServer(
+      createProxyServer({
+        getRoutes: () => [],
+        proxyPort: TEST_PROXY_PORT,
+        tls: { cert: tlsCert, key: tlsKey },
+      })
+    );
+    await listen(server);
+
+    const { client } = await h2Session(server);
+    try {
+      const status = await new Promise<number>((resolve, reject) => {
+        const req = client.request({
+          ":method": "CONNECT",
+          ":authority": "example.com:443",
+        });
+        req.on("error", reject);
+        req.on("response", (headers) => {
+          resolve(headers[":status"] as number);
+          req.close();
+        });
+      });
+      expect(status).toBe(501);
+    } finally {
+      client.close();
+    }
+  });
+
+  it("proxies plain-HTTP WebSocket upgrades on the TLS port instead of dropping them", async () => {
+    const backend = trackServer(http.createServer());
+    backend.on("upgrade", (_req, socket) => {
+      socket.write(
+        "HTTP/1.1 101 Switching Protocols\r\n" +
+          "Upgrade: websocket\r\n" +
+          "Connection: Upgrade\r\n" +
+          "\r\n"
+      );
+      socket.end();
+    });
+    await listen(backend);
+    const backendAddr = backend.address();
+    if (!backendAddr || typeof backendAddr === "string") throw new Error("no addr");
+
+    const routes: RouteInfo[] = [{ hostname: "ws.localhost", port: backendAddr.port }];
+    const server = trackServer(
+      createProxyServer({
+        getRoutes: () => routes,
+        proxyPort: TEST_PROXY_PORT,
+        tls: { cert: tlsCert, key: tlsKey },
+      })
+    );
+    await listen(server);
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("no addr");
+
+    const upgraded = await new Promise<boolean>((resolve) => {
+      const req = http.request({
+        hostname: "127.0.0.1",
+        port: addr.port,
+        path: "/",
+        headers: {
+          host: "ws.localhost",
+          connection: "Upgrade",
+          upgrade: "websocket",
+        },
+      });
+      req.on("error", () => resolve(false));
+      req.on("upgrade", () => resolve(true));
+      req.setTimeout(2000, () => {
+        req.destroy();
+        resolve(false);
+      });
+      req.end();
+    });
+
+    expect(upgraded).toBe(true);
+  });
+
   it("redirects plain HTTP to HTTPS on the TLS-enabled port", async () => {
     const routes: RouteInfo[] = [];
     const server = trackServer(

--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterAll, afterEach, beforeAll } from "vitest";
+import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as http from "node:http";
 import * as http2 from "node:http2";
@@ -1626,11 +1627,15 @@ describe("createProxyServer with TLS (HTTP/2)", () => {
     const backend = trackServer(http.createServer());
     backend.on("upgrade", (req, socket) => {
       Object.assign(received, req.headers);
+      const accept = crypto
+        .createHash("sha1")
+        .update(`${req.headers["sec-websocket-key"]}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+        .digest("base64");
       socket.write(
         "HTTP/1.1 101 Switching Protocols\r\n" +
           "Upgrade: websocket\r\n" +
           "Connection: Upgrade\r\n" +
-          "Sec-WebSocket-Accept: backend-answer\r\n" +
+          `Sec-WebSocket-Accept: ${accept}\r\n` +
           "\r\n"
       );
       socket.on("data", (d) => socket.write(`echo:${d}`));
@@ -1692,6 +1697,61 @@ describe("createProxyServer with TLS (HTTP/2)", () => {
       expect(received.host).toBe("ws.localhost");
       expect(received["x-portless-hops"]).toBe("1");
       expect(received["x-forwarded-proto"]).toBe("https");
+    } finally {
+      client.close();
+    }
+  });
+
+  it("answers 502 when the backend's Sec-WebSocket-Accept does not match", async () => {
+    const backend = trackServer(http.createServer());
+    backend.on("upgrade", (_req, socket) => {
+      socket.write(
+        "HTTP/1.1 101 Switching Protocols\r\n" +
+          "Upgrade: websocket\r\n" +
+          "Connection: Upgrade\r\n" +
+          "Sec-WebSocket-Accept: not-the-right-hash\r\n" +
+          "\r\n"
+      );
+      socket.on("data", (d) => socket.write(`leak:${d}`));
+    });
+    await listen(backend);
+    const backendAddr = backend.address();
+    if (!backendAddr || typeof backendAddr === "string") throw new Error("no addr");
+
+    const routes: RouteInfo[] = [{ hostname: "ws.localhost", port: backendAddr.port }];
+    const server = trackServer(
+      createProxyServer({
+        getRoutes: () => routes,
+        proxyPort: TEST_PROXY_PORT,
+        tls: { cert: tlsCert, key: tlsKey },
+        onError: () => {},
+      })
+    );
+    await listen(server);
+
+    const { client } = await h2Session(server);
+    try {
+      const result = await new Promise<{ status: number; body: string }>((resolve, reject) => {
+        const req = client.request({
+          ":method": "CONNECT",
+          ":protocol": "websocket",
+          ":path": "/_next/webpack-hmr",
+          ":authority": "ws.localhost",
+          ":scheme": "https",
+          "sec-websocket-version": "13",
+        });
+        req.on("error", reject);
+        req.on("response", (headers) => {
+          let body = "";
+          req.on("data", (d: Buffer) => (body += d.toString()));
+          req.on("end", () => resolve({ status: headers[":status"] as number, body }));
+        });
+      });
+
+      // The tunnel must not open: no payload from the backend leaks through.
+      expect(result.status).toBe(502);
+      expect(result.body).toContain("invalid response to the WebSocket handshake");
+      expect(result.body).not.toContain("leak:");
     } finally {
       client.close();
     }

--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -1105,6 +1105,61 @@ describe("createProxyServer", () => {
       expect(upgraded).toBe(true);
     });
 
+    it("responds 502 when the backend answers the handshake with a non-HTTP response", async () => {
+      const backend = trackServer(http.createServer());
+      backend.on("upgrade", (_req, socket) => {
+        // Next.js dev rejects a WebSocket whose Origin is not in
+        // allowedDevOrigins by writing a bare string with no status line.
+        socket.end("Unauthorized");
+      });
+      await listen(backend);
+      const backendAddr = backend.address();
+      if (!backendAddr || typeof backendAddr === "string") throw new Error("no addr");
+
+      const routes: RouteInfo[] = [{ hostname: "ws.localhost", port: backendAddr.port }];
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => routes,
+          proxyPort: TEST_PROXY_PORT,
+          onError: () => {},
+        })
+      );
+      await listen(server);
+
+      const addr = server.address();
+      if (!addr || typeof addr === "string") throw new Error("no addr");
+
+      const result = await new Promise<{ status?: number; failed: boolean }>((resolve) => {
+        const req = http.request({
+          hostname: "127.0.0.1",
+          port: addr.port,
+          path: "/_next/webpack-hmr",
+          headers: {
+            host: "ws.localhost",
+            connection: "Upgrade",
+            upgrade: "websocket",
+            "sec-websocket-version": "13",
+            "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+          },
+        });
+        req.on("response", (res) => {
+          res.resume();
+          resolve({ status: res.statusCode, failed: false });
+        });
+        req.on("upgrade", () => resolve({ failed: true }));
+        req.on("error", () => resolve({ failed: true }));
+        req.setTimeout(2000, () => {
+          req.destroy();
+          resolve({ failed: true });
+        });
+        req.end();
+      });
+
+      // The client gets a diagnosable 502 instead of an abrupt connection close.
+      expect(result.failed).toBe(false);
+      expect(result.status).toBe(502);
+    });
+
     it("forwards backend Sec-WebSocket-Accept and custom headers", async () => {
       const testAcceptValue = "dGhlIHNhbXBsZSBub25jZQ==";
       const testProtocol = "graphql-ws";

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -1,3 +1,4 @@
+import * as crypto from "node:crypto";
 import * as http from "node:http";
 import * as http2 from "node:http2";
 import * as net from "node:net";
@@ -138,7 +139,9 @@ export type ProxyServer = http.Server | net.Server;
  *
  * When `tls` is provided, creates an HTTP/2 secure server with HTTP/1.1
  * fallback (`allowHTTP1: true`). This enables HTTP/2 multiplexing for
- * browsers while keeping WebSocket upgrades working over HTTP/1.1.
+ * browsers. WebSockets work over both protocol versions: HTTP/1.1 Upgrade
+ * requests are forwarded as-is, and HTTP/2 extended CONNECT (RFC 8441) is
+ * bridged to an HTTP/1.1 handshake against the backend.
  */
 export function createProxyServer(options: ProxyServerOptions): ProxyServer {
   const {
@@ -408,11 +411,151 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
     proxyReq.end();
   };
 
+  /**
+   * Handle an RFC 8441 extended CONNECT request (WebSocket over HTTP/2).
+   * Browsers open WebSockets this way when the connection is HTTP/2 and the
+   * server advertises SETTINGS_ENABLE_CONNECT_PROTOCOL. The h2 stream is
+   * bridged to a regular HTTP/1.1 Upgrade handshake against the backend:
+   * the client never sends Sec-WebSocket-Key over h2, so one is synthesized
+   * for the backend hop and the backend's Accept answer is dropped.
+   */
+  const handleExtendedConnect = (req: http2.Http2ServerRequest, res: http2.Http2ServerResponse) => {
+    const compatReq = req as unknown as http.IncomingMessage;
+    req.stream.on("error", () => {});
+    res.setHeader(PORTLESS_HEADER, "1");
+
+    // Classic CONNECT tunneling is not a portless feature; only WebSocket
+    // bridging is supported.
+    if (req.headers[":protocol"] !== "websocket") {
+      res.writeHead(501, { "content-type": "text/plain" });
+      res.end("CONNECT is only supported for WebSockets (RFC 8441)\n");
+      return;
+    }
+
+    const hops = parseInt(req.headers[PORTLESS_HOPS_HEADER] as string, 10) || 0;
+    if (hops >= MAX_PROXY_HOPS) {
+      const host = getRequestHost(compatReq).split(":")[0];
+      onError(
+        `WebSocket loop detected for ${host}: request has passed through portless ${hops} times. ` +
+          `Set changeOrigin: true in your proxy config.`
+      );
+      res.writeHead(508, { "content-type": "text/plain" });
+      res.end(
+        "Loop Detected: request has passed through portless too many times.\n" +
+          "Add changeOrigin: true to your dev server proxy config.\n"
+      );
+      return;
+    }
+
+    const route = findRoute(getRoutes(), getRequestHost(compatReq), strict);
+    if (!route) {
+      res.writeHead(404, { "content-type": "text/plain" });
+      res.end(`No app registered for ${getRequestHost(compatReq)}\n`);
+      return;
+    }
+
+    const forwardedHeaders = buildForwardedHeaders(compatReq, isEncrypted(compatReq));
+    const proxyReqHeaders: http.OutgoingHttpHeaders = { ...req.headers };
+    for (const [key, value] of Object.entries(forwardedHeaders)) {
+      proxyReqHeaders[key] = value;
+    }
+    proxyReqHeaders[PORTLESS_HOPS_HEADER] = String(hops + 1);
+    // Remove HTTP/2 pseudo-headers before forwarding to HTTP/1.1 backend
+    for (const key of Object.keys(proxyReqHeaders)) {
+      if (key.startsWith(":")) {
+        delete proxyReqHeaders[key];
+      }
+    }
+    proxyReqHeaders.host = getRequestHost(compatReq);
+    // Translate the extended CONNECT into the HTTP/1.1 Upgrade handshake the
+    // backend expects. Sec-WebSocket-Protocol/-Extensions pass through from
+    // the copied headers so subprotocol and compression negotiation stay
+    // end-to-end between client and backend.
+    proxyReqHeaders.connection = "Upgrade";
+    proxyReqHeaders.upgrade = "websocket";
+    proxyReqHeaders["sec-websocket-key"] = crypto.randomBytes(16).toString("base64");
+    if (!proxyReqHeaders["sec-websocket-version"]) {
+      proxyReqHeaders["sec-websocket-version"] = "13";
+    }
+
+    const proxyReq = http.request({
+      // Dial via createLoopbackConnection so ::1-only backends work too.
+      createConnection: () => createLoopbackConnection(route.port),
+      path: req.url,
+      method: "GET",
+      headers: proxyReqHeaders,
+    });
+
+    proxyReq.on("upgrade", (proxyRes, proxySocket, proxyHead) => {
+      const responseHeaders: http.OutgoingHttpHeaders = { ...proxyRes.headers };
+      for (const h of HOP_BY_HOP_HEADERS) {
+        delete responseHeaders[h];
+      }
+      // The Accept answers the key this proxy synthesized, not anything the
+      // h2 client sent; RFC 8441 has no equivalent handshake header.
+      delete responseHeaders["sec-websocket-accept"];
+      // RFC 8441 signals a successful handshake with :status 200, not 101.
+      res.writeHead(200, responseHeaders);
+      if (proxyHead.length > 0) {
+        res.write(proxyHead);
+      }
+      proxySocket.pipe(res);
+      req.pipe(proxySocket);
+
+      // Tear down both sides when either disconnects. pipe() already
+      // propagates graceful ends; these catch aborts and errors. destroy()
+      // is idempotent, so duplicate calls are harmless.
+      const cleanup = () => {
+        proxySocket.destroy();
+        req.stream.destroy();
+      };
+      proxySocket.on("error", cleanup);
+      proxySocket.on("close", cleanup);
+      req.stream.on("close", cleanup);
+    });
+
+    proxyReq.on("response", (proxyRes) => {
+      // The backend answered with a normal HTTP response instead of
+      // upgrading (auth middleware redirects, 4xx, etc.). Forward it so the
+      // client sees the rejection instead of a hung handshake.
+      const responseHeaders: http.OutgoingHttpHeaders = { ...proxyRes.headers };
+      for (const h of HOP_BY_HOP_HEADERS) {
+        delete responseHeaders[h];
+      }
+      res.writeHead(proxyRes.statusCode || 502, responseHeaders);
+      proxyRes.on("error", () => req.stream.destroy());
+      proxyRes.pipe(res);
+    });
+
+    proxyReq.on("error", (err) => {
+      onError(`WebSocket proxy error for ${getRequestHost(compatReq)}: ${err.message}`);
+      if (!res.headersSent) {
+        res.writeHead(502, { "content-type": "text/plain" });
+        res.end("Bad Gateway: the target app is not responding\n");
+      } else {
+        req.stream.destroy();
+      }
+    });
+
+    // Abort the backend handshake if the client goes away first.
+    req.stream.on("close", () => {
+      if (!proxyReq.destroyed) {
+        proxyReq.destroy();
+      }
+    });
+
+    proxyReq.end();
+  };
+
   if (tls) {
     const h2Server = http2.createSecureServer({
       cert: tls.ca ? Buffer.concat([tls.cert, tls.ca]) : tls.cert,
       key: tls.key,
       allowHTTP1: true,
+      // Advertise RFC 8441 extended CONNECT so browsers can open WebSockets
+      // over the existing HTTP/2 session (handled below via the 'connect'
+      // event) instead of failing the wss:// handshake.
+      settings: { enableConnectProtocol: true },
       // Tolerate high rates of RST_STREAM from browsers during HMR and
       // page navigations. Without this, Node sends GOAWAY INTERNAL_ERROR
       // after ~1000 cumulative stream resets and kills the session,
@@ -438,6 +581,25 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
     h2Server.on("upgrade", (req: http.IncomingMessage, socket: net.Socket, head: Buffer) => {
       handleUpgrade(req, socket, head);
     });
+    // WebSocket-over-HTTP/2 arrives as an extended CONNECT stream, which the
+    // compat layer surfaces via the 'connect' event (never 'request'; without
+    // a listener Node auto-responds 405 and the handshake dies).
+    h2Server.on(
+      "connect",
+      (
+        req: http2.Http2ServerRequest | http.IncomingMessage,
+        resOrSocket: http2.Http2ServerResponse | net.Socket
+      ) => {
+        // With allowHTTP1, an HTTP/1.1 CONNECT fires this same event with a
+        // (req, socket, head) signature. Classic CONNECT tunneling is not
+        // supported on either protocol version.
+        if (resOrSocket instanceof net.Socket) {
+          resOrSocket.destroy();
+          return;
+        }
+        handleExtendedConnect(req as http2.Http2ServerRequest, resOrSocket);
+      }
+    );
 
     // Plain HTTP on a TLS-enabled port -> 302 redirect to HTTPS.
     // The redirect targets the same port because the wrapper net.Server
@@ -448,12 +610,10 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
       res.writeHead(302, { Location: location, [PORTLESS_HEADER]: "1" });
       res.end();
     });
-    plainServer.on("upgrade", (req: http.IncomingMessage, socket: net.Socket) => {
-      const host = getRequestHost(req);
-      console.warn(
-        `[portless] Dropped plain-HTTP WebSocket upgrade for ${host}; use wss:// instead`
-      );
-      socket.destroy();
+    // WebSocket clients cannot follow the 302 redirect a normal request
+    // gets, so proxy plain-HTTP upgrades directly instead of dropping them.
+    plainServer.on("upgrade", (req: http.IncomingMessage, socket: net.Socket, head: Buffer) => {
+      handleUpgrade(req, socket, head);
     });
 
     // Wrap both in a net.Server that peeks at the first byte to decide

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -355,7 +355,14 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
       headers: proxyReqHeaders,
     });
 
+    // Whether the backend's handshake answer (101 or a rejection) has been
+    // relayed to the client. Gates the error handler below: before relay a
+    // proper 502 can still be written; after it the stream may carry
+    // WebSocket frames, so the only safe reaction is to drop the socket.
+    let handshakeRelayed = false;
+
     proxyReq.on("upgrade", (proxyRes, proxySocket, proxyHead) => {
+      handshakeRelayed = true;
       // Forward the backend's actual 101 response including Sec-WebSocket-Accept,
       // subprotocol negotiation, and extension headers.
       let response = `HTTP/1.1 101 Switching Protocols\r\n`;
@@ -387,10 +394,26 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
 
     proxyReq.on("error", (err) => {
       onError(`WebSocket proxy error for ${getRequestHost(req)}: ${err.message}`);
-      socket.destroy();
+      // A dead backend (ECONNREFUSED) or a malformed rejection (e.g. Next.js
+      // dev writes a bare "Unauthorized" with no status line when an Origin
+      // is not allow-listed, which surfaces here as a parse error) would
+      // otherwise close the connection with no response, leaving the client
+      // nothing to diagnose. Answer with a real 502 while that is still safe.
+      if (!handshakeRelayed && socket.writable) {
+        socket.end(
+          "HTTP/1.1 502 Bad Gateway\r\n" +
+            "Content-Type: text/plain\r\n" +
+            "Connection: close\r\n" +
+            "\r\n" +
+            "Bad Gateway: the target app is not responding or sent an invalid response to the WebSocket handshake.\n"
+        );
+      } else {
+        socket.destroy();
+      }
     });
 
     proxyReq.on("response", (res) => {
+      handshakeRelayed = true;
       // The backend responded with a normal HTTP response instead of upgrading.
       // Forward the rejection to the client.
       if (!socket.destroyed) {

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -10,6 +10,12 @@ import { ARROW_SVG, renderPage } from "./pages.js";
 export const PORTLESS_HEADER = "X-Portless";
 
 /**
+ * RFC 6455 magic GUID: a compliant WebSocket backend answers an upgrade with
+ * Sec-WebSocket-Accept = base64(sha1(Sec-WebSocket-Key + WS_GUID)).
+ */
+const WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+/**
  * HTTP/1.1 hop-by-hop headers that are forbidden in HTTP/2 responses.
  * These must be stripped when proxying an HTTP/1.1 backend response
  * back to an HTTP/2 client.
@@ -496,7 +502,8 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
     // end-to-end between client and backend.
     proxyReqHeaders.connection = "Upgrade";
     proxyReqHeaders.upgrade = "websocket";
-    proxyReqHeaders["sec-websocket-key"] = crypto.randomBytes(16).toString("base64");
+    const wsKey = crypto.randomBytes(16).toString("base64");
+    proxyReqHeaders["sec-websocket-key"] = wsKey;
     if (!proxyReqHeaders["sec-websocket-version"]) {
       proxyReqHeaders["sec-websocket-version"] = "13";
     }
@@ -510,6 +517,25 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
     });
 
     proxyReq.on("upgrade", (proxyRes, proxySocket, proxyHead) => {
+      // The h2 client never sees the synthesized key, so this proxy is the
+      // only party that can verify the backend's accept hash. A 101 with the
+      // wrong hash is not a WebSocket server speaking RFC 6455; bridging it
+      // would hand the client a broken tunnel with nothing to diagnose.
+      const expectedAccept = crypto
+        .createHash("sha1")
+        .update(wsKey + WS_GUID)
+        .digest("base64");
+      if (proxyRes.headers["sec-websocket-accept"] !== expectedAccept) {
+        onError(
+          `WebSocket proxy error for ${getRequestHost(compatReq)}: backend answered the handshake with an invalid Sec-WebSocket-Accept`
+        );
+        proxySocket.destroy();
+        res.writeHead(502, { "content-type": "text/plain" });
+        res.end(
+          "Bad Gateway: the target app sent an invalid response to the WebSocket handshake.\n"
+        );
+        return;
+      }
       const responseHeaders: http.OutgoingHttpHeaders = { ...proxyRes.headers };
       for (const h of HOP_BY_HOP_HEADERS) {
         delete responseHeaders[h];

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -193,7 +193,7 @@ Portless stores its state (routes, PID file, port file) in `~/.portless`. When t
 
 ### HTTP/2 + HTTPS
 
-HTTPS with HTTP/2 is enabled by default (faster page loads for dev servers with many files). First run generates a local CA and adds it to the system trust store. After that, no prompts and no browser warnings.
+HTTPS with HTTP/2 is enabled by default (faster page loads for dev servers with many files). WebSockets work over both HTTP/1.1 (Upgrade) and HTTP/2 (RFC 8441 extended CONNECT), so dev server HMR works through the proxy. First run generates a local CA and adds it to the system trust store. After that, no prompts and no browser warnings.
 
 ```bash
 portless proxy start --cert ./c.pem --key ./k.pem  # Use custom certs


### PR DESCRIPTION
Browsers negotiate HTTP/2 with the HTTPS proxy, then open WebSockets with RFC 8441 extended CONNECT instead of an HTTP/1.1 upgrade. The proxy never advertised connect-protocol support, so the handshake died and HMR broke for every dev server behind it. Plain-HTTP upgrades on the TLS port were dropped too.

This picks up #360 by @erichurkman, rebased on main, plus the Sec-WebSocket-Accept check from #278 by @sanjevirau: the h2 client never sees the key the proxy synthesizes, so the proxy is the only one who can validate the backend's answer. A bad hash now gets a 502 instead of a silent broken tunnel.

Verified in a real browser: Next 16 (Turbopack) and Vite 7 behind the proxy both log HMR connected, and edits hot-reload without full page reloads.

Fixes #281.
