### PR TITLE
fix: support multi-segment custom TLDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Recommended: `.test` (IANA-reserved, no collision risk). Avoid `.local` (conflic
 
 ### Multi-segment TLDs
 
-The `--tld` value accepts any valid DNS hostname, so a domain you own can be used as the "TLD". This gives local URLs the same structure as production, which keeps OAuth redirect URIs, cross-subdomain cookies, and host-based routing working the same way in both environments:
+The `--tld` value accepts a lowercase DNS name (one or more dot-separated labels, no trailing dot), so a domain you own can be used as the "TLD". This gives local URLs the same structure as production, which keeps OAuth redirect URIs, cross-subdomain cookies, and host-based routing working the same way in both environments:
 
 ```bash
 portless proxy start --tld dev.example.com
@@ -235,7 +235,7 @@ portless myapp next dev
 # -> https://myapp.dev.example.com
 ```
 
-Each label must follow DNS rules: lowercase letters, digits, and interior hyphens, with at most 63 characters per label and 253 characters total.
+Each label must follow DNS rules: lowercase letters, digits, and interior hyphens, with at most 63 characters per label and 253 characters total. The full hostname (`app.TLD`) is also subject to the 253-character DNS limit.
 
 The proxy auto-syncs `/etc/hosts` for registered hostnames, so `myapp.dev.example.com` resolves to `127.0.0.1` on your machine. To reach the proxy from other devices (a tailnet, LAN, or intranet), point a wildcard DNS record such as `*.dev.example.com` at the machine running the proxy and disable hosts sync with `PORTLESS_SYNC_HOSTS=0` if you prefer DNS-only resolution.
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,22 @@ When multiple TLDs are configured, `PORTLESS_URL` uses the first TLD. `PORTLESS_
 
 Recommended: `.test` (IANA-reserved, no collision risk). Avoid `.local` (conflicts with mDNS/Bonjour) and `.dev` (Google-owned, forces HTTPS via HSTS).
 
+### Multi-segment TLDs
+
+The `--tld` value accepts any valid DNS hostname, so a domain you own can be used as the "TLD". This gives local URLs the same structure as production, which keeps OAuth redirect URIs, cross-subdomain cookies, and host-based routing working the same way in both environments:
+
+```bash
+portless proxy start --tld dev.example.com
+portless myapp next dev
+# -> https://myapp.dev.example.com
+```
+
+Each label must follow DNS rules: lowercase letters, digits, and interior hyphens, with at most 63 characters per label and 253 characters total.
+
+The proxy auto-syncs `/etc/hosts` for registered hostnames, so `myapp.dev.example.com` resolves to `127.0.0.1` on your machine. To reach the proxy from other devices (a tailnet, LAN, or intranet), point a wildcard DNS record such as `*.dev.example.com` at the machine running the proxy and disable hosts sync with `PORTLESS_SYNC_HOSTS=0` if you prefer DNS-only resolution.
+
+Strict OAuth providers (Google, Apple) reject `.localhost` and `.test` redirect URIs but accept a real domain, so `https://myapp.dev.example.com/api/auth/callback/google` works as a redirect URI.
+
 ## How it works
 
 ```mermaid

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ portless myapp next dev
 
 Each label must follow DNS rules: lowercase letters, digits, and interior hyphens, with at most 63 characters per label and 253 characters total. The full hostname (`app.TLD`) is also subject to the 253-character DNS limit.
 
-The proxy auto-syncs `/etc/hosts` for registered hostnames, so `myapp.dev.example.com` resolves to `127.0.0.1` on your machine. To reach the proxy from other devices (a tailnet, LAN, or intranet), point a wildcard DNS record such as `*.dev.example.com` at the machine running the proxy and disable hosts sync with `PORTLESS_SYNC_HOSTS=0` if you prefer DNS-only resolution.
+The proxy auto-syncs `/etc/hosts` for registered hostnames, so `myapp.dev.example.com` resolves to `127.0.0.1` on your machine. This is a loopback-only setup: outside LAN mode the proxy binds only to `127.0.0.1` and `::1` (see below), so a custom TLD is reachable only from the machine running the proxy. Reaching the proxy from other devices requires LAN mode (`--lan`), but LAN mode serves apps under the `.local` TLD and ignores a custom `--tld`, so the two cannot be combined today.
 
 Strict OAuth providers (Google, Apple) reject `.localhost` and `.test` redirect URIs but accept a real domain, so `https://myapp.dev.example.com/api/auth/callback/google` works as a redirect URI.
 

--- a/apps/docs/src/app/commands/page.mdx
+++ b/apps/docs/src/app/commands/page.mdx
@@ -190,7 +190,7 @@ portless proxy start
     </tr>
     <tr>
       <td>`--tld <tld>`</td>
-      <td>Use a custom TLD instead of `.localhost` (e.g. `test`). Repeat for more TLDs. Hostnames still sync to `/etc/hosts` by default.</td>
+      <td>Use a custom TLD instead of `.localhost` (e.g. `test`, `dev.example.com`). Repeat for more TLDs. Hostnames still sync to `/etc/hosts` by default.</td>
     </tr>
     <tr>
       <td>`--cert <path>`</td>

--- a/apps/docs/src/app/configuration/page.mdx
+++ b/apps/docs/src/app/configuration/page.mdx
@@ -177,7 +177,7 @@ For `appPort`: CLI `--app-port` flag > `PORTLESS_APP_PORT` env var > `package.js
     </tr>
     <tr>
       <td>`PORTLESS_TLD`</td>
-      <td>Use one or more TLDs (e.g. `localhost,test`)</td>
+      <td>Use one or more TLDs, single or multi-segment (e.g. `localhost,dev.example.com`)</td>
       <td>`localhost`</td>
     </tr>
     <tr>

--- a/apps/docs/src/app/page.mdx
+++ b/apps/docs/src/app/page.mdx
@@ -124,6 +124,16 @@ portless myapp next dev
 
 When multiple TLDs are configured, `PORTLESS_URL` uses the first TLD. `PORTLESS_TLD` accepts the same comma separated list format, e.g. `PORTLESS_TLD=localhost,test`.
 
+The `--tld` value accepts a lowercase DNS name such as `dev.example.com`, so a domain you own can be used as the "TLD":
+
+```bash
+portless proxy start --tld dev.example.com
+portless myapp next dev
+# -> https://myapp.dev.example.com
+```
+
+This gives local URLs the same structure as production, which keeps OAuth redirect URIs, cross-subdomain cookies, and host-based routing working the same way in both environments. Each label must follow DNS rules: lowercase letters, digits, and interior hyphens, with at most 63 characters per label and 253 characters total.
+
 Recommended: `.test` (IANA-reserved, no collision risk). Avoid `.local` (conflicts with mDNS/Bonjour) and `.dev` (Google-owned, forces HTTPS via HSTS).
 
 ## How it works

--- a/packages/portless/src/certs.test.ts
+++ b/packages/portless/src/certs.test.ts
@@ -276,6 +276,26 @@ describe("createSNICallback", () => {
     expect(cert.subjectAltName).toContain("DNS:chat.myapp.localhost");
   });
 
+  it("generates per-hostname cert for multi-segment TLDs (issue #260)", async () => {
+    const sniCallback = createSNICallback(tmpDir, defaultCert, defaultKey, "local.example.dev");
+    const ctx = await new Promise<tls.SecureContext | undefined>((resolve, reject) => {
+      sniCallback("myapp.local.example.dev", (err, ctx) => {
+        if (err) reject(err);
+        else resolve(ctx);
+      });
+    });
+
+    expect(ctx).toBeDefined();
+
+    const hostCertPath = path.join(tmpDir, "host-certs", "myapp_local_example_dev.pem");
+    expect(fs.existsSync(hostCertPath)).toBe(true);
+
+    const cert = new crypto.X509Certificate(fs.readFileSync(hostCertPath));
+    expect(cert.subjectAltName).toContain("DNS:myapp.local.example.dev");
+    // A sibling wildcard at the TLD level covers other apps under the same TLD
+    expect(cert.subjectAltName).toContain("DNS:*.local.example.dev");
+  });
+
   it("generates cert for a hostname longer than 64 characters (X.509 CN limit)", async () => {
     // Construct a hostname that exceeds the 64-char CN limit:
     // "inngest.ap.very-long-branch-name-that-exceeds-the-cn-limit.dev" = 63+ chars

--- a/packages/portless/src/certs.test.ts
+++ b/packages/portless/src/certs.test.ts
@@ -9,6 +9,7 @@ import {
   createSNICallback,
   ensureCerts,
   isCATrusted,
+  sanitizeHostForFilename,
   trustCA,
   untrustCA,
   untrustCALinux,
@@ -26,6 +27,40 @@ function getCertSignatureAlgo(certPath: string): string {
   const match = text.match(/Signature Algorithm:\s*(\S+)/i);
   return match ? match[1].toLowerCase() : "";
 }
+
+describe("sanitizeHostForFilename", () => {
+  // Longest suffix the cert cache appends to the sanitized base.
+  const SUFFIX_LEN = "-key.pem".length;
+  const NAME_MAX = 255;
+
+  it("keeps short hostnames readable and unchanged apart from dots", () => {
+    expect(sanitizeHostForFilename("myapp.dev.example.com")).toBe("myapp_dev_example_com");
+  });
+
+  it("bounds the composed cert filename under NAME_MAX for a max-length hostname", () => {
+    // A 253-char hostname is valid DNS (multi-segment TLD) but its naive
+    // sanitized filename would overflow NAME_MAX and fail with ENAMETOOLONG.
+    const label = "a".repeat(63);
+    const hostname = `x.${label}.${label}.${label}.${"b".repeat(57)}`;
+    expect(hostname.length).toBeGreaterThan(NAME_MAX - SUFFIX_LEN);
+    const safe = sanitizeHostForFilename(hostname);
+    expect(safe.length + SUFFIX_LEN).toBeLessThanOrEqual(NAME_MAX);
+  });
+
+  it("is deterministic so the cert cache still hits for the same host", () => {
+    const label = "a".repeat(63);
+    const hostname = `x.${label}.${label}.${label}.${"b".repeat(57)}`;
+    expect(sanitizeHostForFilename(hostname)).toBe(sanitizeHostForFilename(hostname));
+  });
+
+  it("maps distinct overflowing hostnames to distinct filenames", () => {
+    const label = "a".repeat(63);
+    const base = `${label}.${label}.${label}`;
+    const a = sanitizeHostForFilename(`app1.${base}.${"b".repeat(57)}`);
+    const b = sanitizeHostForFilename(`app2.${base}.${"b".repeat(57)}`);
+    expect(a).not.toBe(b);
+  });
+});
 
 describe("ensureCerts", () => {
   let tmpDir: string;

--- a/packages/portless/src/certs.ts
+++ b/packages/portless/src/certs.ts
@@ -630,11 +630,38 @@ function isCATrustedLinux(
 const HOST_CERTS_DIR = "host-certs";
 
 /**
+ * Longest suffix appended to a sanitized host when composing a cert cache
+ * filename (`-key.pem` and `-ext.cnf` are both 8 bytes). The sanitized base
+ * must leave room for it under the filesystem's per-component limit.
+ */
+const CERT_FILENAME_SUFFIX_LEN = "-key.pem".length;
+
+/**
+ * Conservative per-component filename limit. Most POSIX filesystems cap
+ * NAME_MAX at 255 bytes; the sanitized base is bounded so the longest
+ * composed filename (`${base}-key.pem`) never exceeds it.
+ */
+const MAX_FILENAME_BASE = 255 - CERT_FILENAME_SUFFIX_LEN;
+
+/**
  * Sanitize a hostname for use as a filename.
  * Replaces dots with underscores and removes non-alphanumeric chars (except - and _).
+ *
+ * Multi-segment TLDs allow hostnames up to the 253-char DNS limit, whose
+ * composed cert filenames would exceed NAME_MAX and fail generation with
+ * ENAMETOOLONG. When the sanitized base would overflow, its readable prefix is
+ * truncated and a hash of the full hostname is appended, keeping the mapping
+ * deterministic (same host -> same file, so the cache still hits) and
+ * collision-resistant (distinct hosts -> distinct files).
  */
-function sanitizeHostForFilename(hostname: string): string {
-  return hostname.replace(/\./g, "_").replace(/[^a-z0-9_-]/gi, "");
+export function sanitizeHostForFilename(hostname: string): string {
+  const safe = hostname.replace(/\./g, "_").replace(/[^a-z0-9_-]/gi, "");
+  if (safe.length <= MAX_FILENAME_BASE) {
+    return safe;
+  }
+  const hash = crypto.createHash("sha256").update(hostname).digest("hex").slice(0, 16);
+  const prefix = safe.slice(0, MAX_FILENAME_BASE - hash.length - 1);
+  return `${prefix}_${hash}`;
 }
 
 /**

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -21,6 +21,7 @@ import {
   getDefaultTlds,
   getProtocolPort,
   getProxyBindTargets,
+  getRiskyTldReason,
   isHttpsEnvDisabled,
   injectFrameworkFlags,
   isPortListening,
@@ -1116,6 +1117,39 @@ describe("readTldFromDir / writeTldFile", () => {
   it("handles removing the default TLD file when it does not exist", () => {
     writeTldFile(tmpDir, DEFAULT_TLD);
     expect(readTldFromDir(tmpDir)).toBe(DEFAULT_TLD);
+  });
+
+  it("skips invalid persisted entries instead of resetting the whole list", () => {
+    const tooLong = "a".repeat(70);
+    fs.writeFileSync(
+      path.join(tmpDir, "proxy.tlds"),
+      JSON.stringify(["test", tooLong, "internal"])
+    );
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(readTldsFromDir(tmpDir)).toEqual(["test", "internal"]);
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
+
+describe("getRiskyTldReason", () => {
+  it("matches exact risky TLDs", () => {
+    expect(getRiskyTldReason("dev")).toMatch(/HSTS/);
+    expect(getRiskyTldReason("com")).toMatch(/public TLD/);
+  });
+
+  it("matches multi-segment TLDs with a risky suffix", () => {
+    expect(getRiskyTldReason("example.dev")).toMatch(/HSTS/);
+    expect(getRiskyTldReason("dev.example.com")).toMatch(/public TLD/);
+  });
+
+  it("returns undefined for safe TLDs", () => {
+    expect(getRiskyTldReason("test")).toBeUndefined();
+    expect(getRiskyTldReason("dev.internal")).toBeUndefined();
+    expect(getRiskyTldReason("devx")).toBeUndefined();
   });
 });
 

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -1138,12 +1138,19 @@ describe("readTldFromDir / writeTldFile", () => {
 describe("getRiskyTldReason", () => {
   it("matches exact risky TLDs", () => {
     expect(getRiskyTldReason("dev")).toMatch(/HSTS/);
+    expect(getRiskyTldReason("app")).toMatch(/HSTS/);
     expect(getRiskyTldReason("com")).toMatch(/public TLD/);
   });
 
-  it("matches multi-segment TLDs with a risky suffix", () => {
+  it("matches multi-segment TLDs under tree-wide risky suffixes", () => {
     expect(getRiskyTldReason("example.dev")).toMatch(/HSTS/);
-    expect(getRiskyTldReason("dev.example.com")).toMatch(/public TLD/);
+    expect(getRiskyTldReason("myapp.app")).toMatch(/HSTS/);
+    expect(getRiskyTldReason("foo.local")).toMatch(/mDNS/);
+  });
+
+  it("does not suffix-match ownership-class TLDs", () => {
+    expect(getRiskyTldReason("dev.example.com")).toBeUndefined();
+    expect(getRiskyTldReason("internal.example.org")).toBeUndefined();
   });
 
   it("returns undefined for safe TLDs", () => {

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -942,6 +942,10 @@ describe("parseTldList", () => {
   it("rejects empty list entries", () => {
     expect(() => parseTldList("test,")).toThrow("TLD cannot be empty");
   });
+
+  it("accepts a mix of single- and multi-segment TLDs", () => {
+    expect(parseTldList("localhost,dev.example.com")).toEqual(["localhost", "dev.example.com"]);
+  });
 });
 
 describe("buildProxyStartConfig", () => {
@@ -1127,10 +1131,41 @@ describe("validateTld", () => {
   });
 
   it("rejects TLDs with invalid characters", () => {
-    expect(validateTld("my-tld")).toMatch(/must contain only/);
-    expect(validateTld("my.tld")).toMatch(/must contain only/);
     expect(validateTld("MY_TLD")).toMatch(/must contain only/);
     expect(validateTld("tld!")).toMatch(/must contain only/);
+    expect(validateTld("my tld")).toMatch(/must contain only/);
+  });
+
+  it("accepts multi-segment TLDs", () => {
+    expect(validateTld("dev.example.com")).toBeNull();
+    expect(validateTld("local.example.dev")).toBeNull();
+    expect(validateTld("a.b.c.d.e")).toBeNull();
+  });
+
+  it("accepts hyphens inside labels", () => {
+    expect(validateTld("my-tld")).toBeNull();
+    expect(validateTld("dev.my-network.com")).toBeNull();
+  });
+
+  it("rejects empty labels", () => {
+    expect(validateTld(".example.com")).toMatch(/labels cannot be empty/);
+    expect(validateTld("example.com.")).toMatch(/labels cannot be empty/);
+    expect(validateTld("example..com")).toMatch(/labels cannot be empty/);
+  });
+
+  it("rejects hyphens at label edges", () => {
+    expect(validateTld("-bad.example.com")).toMatch(/must contain only/);
+    expect(validateTld("bad-.example.com")).toMatch(/must contain only/);
+  });
+
+  it("rejects labels over 63 characters", () => {
+    expect(validateTld(`${"a".repeat(64)}.example.com`)).toMatch(/63-character/);
+  });
+
+  it("rejects TLDs over 253 characters", () => {
+    const label = "a".repeat(63);
+    const long = [label, label, label, label, "example"].join(".");
+    expect(validateTld(long)).toMatch(/253-character/);
   });
 
   it("allows public TLDs (they produce warnings elsewhere)", () => {

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -306,6 +306,20 @@ export const RISKY_TLDS = new Map<string, string>([
 ]);
 
 /**
+ * Look up the risky-TLD warning for a configured TLD. Matches exact entries
+ * ("dev") and multi-segment TLDs whose public suffix is risky ("example.dev"),
+ * since HSTS preload and public-DNS pitfalls apply to the whole suffix tree.
+ */
+export function getRiskyTldReason(tld: string): string | undefined {
+  const exact = RISKY_TLDS.get(tld);
+  if (exact) return exact;
+  for (const [risky, reason] of RISKY_TLDS) {
+    if (tld.endsWith(`.${risky}`)) return reason;
+  }
+  return undefined;
+}
+
+/**
  * Validate a TLD string. Returns an error message if invalid, or null if OK.
  * Does not check for risky TLDs (those produce warnings, not errors).
  */
@@ -375,7 +389,19 @@ export function readTldsFromDir(dir: string): string[] {
           .map((line) => line.trim())
           .filter(Boolean);
     if (!Array.isArray(parsed)) return [readLegacyTldFromDir(dir)];
-    const tlds = parsed.flatMap((value) => (typeof value === "string" ? parseTldList(value) : []));
+    // Skip invalid persisted entries individually so one bad TLD (e.g. written
+    // before validation tightened) does not silently reset the whole list.
+    const tlds = parsed.flatMap((value) => {
+      if (typeof value !== "string") return [];
+      try {
+        return parseTldList(value);
+      } catch (err) {
+        console.warn(
+          `Warning: ignoring invalid TLD entry in ${TLDS_FILE}: ${err instanceof Error ? err.message : String(err)}`
+        );
+        return [];
+      }
+    });
     return tlds.length > 0 ? [...new Set(tlds)] : [DEFAULT_TLD];
   } catch {
     return [readLegacyTldFromDir(dir)];

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -294,11 +294,11 @@ export const DEFAULT_TLD = "localhost";
 export const RISKY_TLDS = new Map<string, string>([
   ["local", "conflicts with mDNS/Bonjour on macOS"],
   ["dev", "Google-owned; browsers force HTTPS via preloaded HSTS"],
+  ["app", "Google-owned; browsers force HTTPS via preloaded HSTS"],
   ["com", "public TLD; DNS requests will leak to the internet"],
   ["org", "public TLD; DNS requests will leak to the internet"],
   ["net", "public TLD; DNS requests will leak to the internet"],
   ["io", "public TLD; DNS requests will leak to the internet"],
-  ["app", "public TLD; DNS requests will leak to the internet"],
   ["edu", "public TLD; DNS requests will leak to the internet"],
   ["gov", "public TLD; DNS requests will leak to the internet"],
   ["mil", "public TLD; DNS requests will leak to the internet"],
@@ -306,15 +306,25 @@ export const RISKY_TLDS = new Map<string, string>([
 ]);
 
 /**
+ * Risky TLDs whose failure mode applies to the whole suffix tree, so
+ * multi-segment TLDs under them inherit the risk: mDNS claims all of
+ * `*.local`, and the `.dev`/`.app` HSTS preload entries carry
+ * includeSubDomains. Ownership-class entries (com, org, ...) only matter
+ * for a bare TLD — a multi-segment TLD under a domain the user owns is
+ * the recommended setup, not a pitfall.
+ */
+const SUFFIX_RISKY_TLDS = new Set(["local", "dev", "app"]);
+
+/**
  * Look up the risky-TLD warning for a configured TLD. Matches exact entries
- * ("dev") and multi-segment TLDs whose public suffix is risky ("example.dev"),
- * since HSTS preload and public-DNS pitfalls apply to the whole suffix tree.
+ * ("dev"), plus multi-segment TLDs whose suffix carries a tree-wide risk
+ * ("example.dev" inherits the HSTS preload).
  */
 export function getRiskyTldReason(tld: string): string | undefined {
   const exact = RISKY_TLDS.get(tld);
   if (exact) return exact;
-  for (const [risky, reason] of RISKY_TLDS) {
-    if (tld.endsWith(`.${risky}`)) return reason;
+  for (const risky of SUFFIX_RISKY_TLDS) {
+    if (tld.endsWith(`.${risky}`)) return RISKY_TLDS.get(risky);
   }
   return undefined;
 }

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -311,8 +311,22 @@ export const RISKY_TLDS = new Map<string, string>([
  */
 export function validateTld(tld: string): string | null {
   if (!tld) return "TLD cannot be empty";
-  if (!/^[a-z0-9]+$/.test(tld)) {
-    return `Invalid TLD "${tld}": must contain only lowercase letters and digits`;
+  if (tld.length > 253) {
+    return `Invalid TLD "${tld}": exceeds 253-character DNS limit`;
+  }
+
+  const labelRe = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+  const labels = tld.split(".");
+  for (const label of labels) {
+    if (!label) {
+      return `Invalid TLD "${tld}": labels cannot be empty`;
+    }
+    if (label.length > 63) {
+      return `Invalid TLD "${tld}": label "${label}" exceeds 63-character DNS limit`;
+    }
+    if (!labelRe.test(label)) {
+      return `Invalid TLD "${tld}": labels must contain only lowercase letters, digits, and interior hyphens`;
+    }
   }
   return null;
 }

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1878,7 +1878,7 @@ ${colors.bold("Options:")}
   --cert <path>                 Use a custom TLS certificate
   --key <path>                  Use a custom TLS private key
   --foreground                  Run proxy in foreground (for debugging)
-  --tld <tld>                   Use a custom TLD instead of .localhost; repeat for more
+  --tld <tld>                   Use a custom TLD instead of .localhost (e.g. test, dev.example.com); repeat for more
   --wildcard                    Allow unregistered subdomains to fall back to parent route
   --state-dir <path>            Use a custom state directory with service install
   --app-port <number>           Use a fixed port for the app (skip auto-assignment)
@@ -1895,7 +1895,7 @@ ${colors.bold("Environment variables:")}
   PORTLESS_HTTPS=0              Disable HTTPS (same as --no-tls)
   PORTLESS_LAN=1                Enable LAN mode when set to 1 (set in .bashrc / .zshrc)
   PORTLESS_LAN_IP=<address>     Pin a specific LAN IP for LAN mode
-  PORTLESS_TLD=<tld>[,<tld>]    Use one or more TLDs (e.g. localhost,test)
+  PORTLESS_TLD=<tld>[,<tld>]    Use one or more TLDs (e.g. localhost,test,dev.example.com)
   PORTLESS_WILDCARD=1           Allow unregistered subdomains to fall back to parent route
   PORTLESS_SYNC_HOSTS=0         Disable auto-sync of ${HOSTS_DISPLAY} (on by default)
   PORTLESS_TAILSCALE=1          Share apps on your Tailscale network (same as --tailscale)
@@ -2864,6 +2864,7 @@ ${colors.bold("Usage:")}
   ${colors.cyan("portless proxy start -p 1355")}        Start on a custom port (no sudo)
   ${colors.cyan("portless proxy start --tld test")}     Use .test instead of .localhost
   ${colors.cyan("portless proxy start --tld localhost --tld test")}  Serve both TLDs
+  ${colors.cyan("portless proxy start --tld dev.example.com")}  Use a multi-segment TLD (production parity)
   ${colors.cyan("portless proxy start --wildcard")}     Allow unregistered subdomains to fall back to parent
   ${colors.cyan("portless proxy stop")}                 Stop the proxy
 
@@ -2951,7 +2952,9 @@ ${colors.bold("LAN mode (--lan):")}
     if (args[i] === "--tld") {
       const tldValue = args[i + 1];
       if (!tldValue || tldValue.startsWith("-")) {
-        console.error(colors.red("Error: --tld requires a TLD value (e.g. test, localhost)."));
+        console.error(
+          colors.red("Error: --tld requires a TLD value (e.g. test, dev.example.com).")
+        );
         process.exit(1);
       }
       tldFlagValues.push(tldValue);

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -49,7 +49,6 @@ import {
   INTERNAL_LAN_IP_ENV,
   INTERNAL_LAN_IP_FLAG,
   PRIVILEGED_PORT_THRESHOLD,
-  RISKY_TLDS,
   WAIT_FOR_PROXY_INTERVAL_MS,
   WAIT_FOR_PROXY_MAX_ATTEMPTS,
   discoverState,
@@ -59,6 +58,7 @@ import {
   getDefaultPort,
   getDefaultTlds,
   getProxyBindTargets,
+  getRiskyTldReason,
   injectFrameworkFlags,
   isHttpsEnvDisabled,
   isPortListening,
@@ -3041,7 +3041,7 @@ ${colors.bold("LAN mode (--lan):")}
   }
 
   for (const configuredTld of tlds) {
-    const riskyReason = RISKY_TLDS.get(configuredTld);
+    const riskyReason = getRiskyTldReason(configuredTld);
     if (riskyReason && !lanMode) {
       console.warn(colors.yellow(`Warning: .${configuredTld}: ${riskyReason}`));
     }

--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -1025,6 +1025,32 @@ describe("createProxyServer", () => {
       expect(res.status).toBe(200);
       expect(res.body).toBe("custom tld hit");
     });
+
+    it("routes requests with multi-segment custom TLD hostnames (issue #260)", async () => {
+      const backend = trackServer(
+        http.createServer((_req, res) => {
+          res.writeHead(200, { "Content-Type": "text/plain" });
+          res.end("multi-segment tld hit");
+        })
+      );
+      await listen(backend);
+      const backendAddr = backend.address();
+      if (!backendAddr || typeof backendAddr === "string") throw new Error("no addr");
+
+      const routes: RouteInfo[] = [{ hostname: "myapp.dev.example.com", port: backendAddr.port }];
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => routes,
+          proxyPort: TEST_PROXY_PORT,
+          tlds: ["dev.example.com"],
+        })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "myapp.dev.example.com" });
+      expect(res.status).toBe(200);
+      expect(res.body).toBe("multi-segment tld hit");
+    });
   });
 
   describe("XSS safety", () => {

--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -1728,6 +1728,65 @@ describe("createProxyServer with TLS (HTTP/2)", () => {
     }
   });
 
+  it("proxies WS-over-H2 extended CONNECT with a multi-segment custom TLD (issue #260)", async () => {
+    const backend = trackServer(http.createServer());
+    backend.on("upgrade", (req, socket) => {
+      const accept = crypto
+        .createHash("sha1")
+        .update(`${req.headers["sec-websocket-key"]}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+        .digest("base64");
+      socket.write(
+        "HTTP/1.1 101 Switching Protocols\r\n" +
+          "Upgrade: websocket\r\n" +
+          "Connection: Upgrade\r\n" +
+          `Sec-WebSocket-Accept: ${accept}\r\n` +
+          "\r\n"
+      );
+      socket.on("data", (d) => socket.write(`echo:${d}`));
+    });
+    await listen(backend);
+    const backendAddr = backend.address();
+    if (!backendAddr || typeof backendAddr === "string") throw new Error("no addr");
+
+    const routes: RouteInfo[] = [{ hostname: "myapp.dev.example.com", port: backendAddr.port }];
+    const server = trackServer(
+      createProxyServer({
+        getRoutes: () => routes,
+        proxyPort: TEST_PROXY_PORT,
+        tlds: ["dev.example.com"],
+        tls: { cert: tlsCert, key: tlsKey },
+      })
+    );
+    await listen(server);
+
+    const { client } = await h2Session(server);
+    try {
+      const result = await new Promise<{ status: number; echoed: string }>((resolve, reject) => {
+        const req = client.request({
+          ":method": "CONNECT",
+          ":protocol": "websocket",
+          ":path": "/ws",
+          ":authority": "myapp.dev.example.com",
+          ":scheme": "https",
+          "sec-websocket-version": "13",
+        });
+        req.on("error", reject);
+        req.on("response", (headers) => {
+          req.write("ping");
+          req.on("data", (d: Buffer) => {
+            resolve({ status: headers[":status"] as number, echoed: d.toString() });
+            req.close();
+          });
+        });
+      });
+
+      expect(result.status).toBe(200);
+      expect(result.echoed).toBe("echo:ping");
+    } finally {
+      client.close();
+    }
+  });
+
   it("answers 502 when the backend's Sec-WebSocket-Accept does not match", async () => {
     const backend = trackServer(http.createServer());
     backend.on("upgrade", (_req, socket) => {

--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -1051,6 +1051,22 @@ describe("createProxyServer", () => {
       expect(res.status).toBe(200);
       expect(res.body).toBe("multi-segment tld hit");
     });
+
+    it("suggests the longest matching overlapping TLD in 404 page (issue #260)", async () => {
+      const routes: RouteInfo[] = [];
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => routes,
+          proxyPort: TEST_PROXY_PORT,
+          tlds: ["example.com", "dev.example.com"],
+        })
+      );
+      await listen(server);
+
+      const res = await request(server, { host: "missing.dev.example.com" });
+      expect(res.status).toBe(404);
+      expect(res.body).toContain("portless missing your-command");
+    });
   });
 
   describe("XSS safety", () => {

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -203,8 +203,13 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
 
     if (!route) {
       const safeHost = escapeHtml(host);
-      const matchedSuffix = tldSuffixes.find((suffix) => host.endsWith(suffix));
-      const strippedHost = matchedSuffix ? host.slice(0, -matchedSuffix.length) : host;
+      const matchedSuffix = tldSuffixes
+        .filter((suffix) => host.endsWith(suffix))
+        .sort((a, b) => b.length - a.length)[0];
+      const strippedHost =
+        matchedSuffix && matchedSuffix.length < host.length
+          ? host.slice(0, -matchedSuffix.length)
+          : host;
       const safeSuggestion = escapeHtml(strippedHost);
       const routesList =
         routes.length > 0

--- a/packages/portless/src/utils.test.ts
+++ b/packages/portless/src/utils.test.ts
@@ -269,6 +269,20 @@ describe("parseHostname", () => {
       expect(parseHostname("api.myapp", "test")).toBe("api.myapp.test");
     });
 
+    it("handles multi-segment custom TLDs", () => {
+      expect(parseHostname("myapp", "local.example.dev")).toBe("myapp.local.example.dev");
+      expect(parseHostname("api.myapp", "local.example.dev")).toBe("api.myapp.local.example.dev");
+      expect(parseHostname("myapp.local.example.dev", "local.example.dev")).toBe(
+        "myapp.local.example.dev"
+      );
+    });
+
+    it("rejects a final hostname over 253 characters", () => {
+      const label = "a".repeat(63);
+      const tld = [label, label, label, "b".repeat(60)].join(".");
+      expect(() => parseHostname("myapp", tld)).toThrow("exceeds 253-character DNS limit");
+    });
+
     it("throws on empty input with custom TLD", () => {
       expect(() => parseHostname("", "test")).toThrow("Hostname cannot be empty");
     });
@@ -299,6 +313,13 @@ describe("parseHostnames", () => {
     expect(parseHostnames("api.myapp.test", ["localhost", "test"])).toEqual([
       "api.myapp.localhost",
       "api.myapp.test",
+    ]);
+  });
+
+  it("strips the longest matching TLD when configured TLDs overlap", () => {
+    expect(parseHostnames("app.dev.example.com", ["example.com", "dev.example.com"])).toEqual([
+      "app.example.com",
+      "app.dev.example.com",
     ]);
   });
 

--- a/packages/portless/src/utils.test.ts
+++ b/packages/portless/src/utils.test.ts
@@ -326,4 +326,20 @@ describe("parseHostnames", () => {
   it("deduplicates TLDs", () => {
     expect(parseHostnames("myapp", ["test", "test"])).toEqual(["myapp.test"]);
   });
+
+  it("skips a TLD that pushes the hostname past 253 chars and keeps the rest", () => {
+    const label = "a".repeat(62);
+    const longTld = [label, label, label, label].join("."); // 251 chars, valid TLD
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(parseHostnames("myapp", ["localhost", longTld])).toEqual(["myapp.localhost"]);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining(longTld));
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("still throws when no TLD survives", () => {
+    expect(() => parseHostnames("my..app", ["localhost", "test"])).toThrow(/consecutive dots/);
+  });
 });

--- a/packages/portless/src/utils.ts
+++ b/packages/portless/src/utils.ts
@@ -199,6 +199,10 @@ export function parseHostname(input: string, tld = "localhost"): string {
     }
   }
 
+  if (hostname.length > 253) {
+    throw new Error(`Invalid hostname "${hostname}": exceeds 253-character DNS limit`);
+  }
+
   return hostname;
 }
 
@@ -214,7 +218,7 @@ export function parseHostnames(input: string, tlds: readonly string[] = ["localh
     .split("/")[0]
     .toLowerCase();
 
-  for (const tld of uniqueTlds) {
+  for (const tld of [...uniqueTlds].sort((a, b) => b.length - a.length)) {
     const suffix = `.${tld}`;
     if (baseInput.endsWith(suffix)) {
       baseInput = baseInput.slice(0, -suffix.length);

--- a/packages/portless/src/utils.ts
+++ b/packages/portless/src/utils.ts
@@ -226,5 +226,23 @@ export function parseHostnames(input: string, tlds: readonly string[] = ["localh
     }
   }
 
-  return uniqueTlds.map((tld) => parseHostname(baseInput, tld));
+  // Skip a TLD that fails for TLD-specific reasons (e.g. app.TLD exceeds the
+  // 253-char DNS limit) instead of losing the valid TLDs in the same list.
+  // Throw only when no TLD survives, so input-wide errors still surface.
+  const hostnames: string[] = [];
+  const skipped: string[] = [];
+  let firstError: unknown;
+  for (const tld of uniqueTlds) {
+    try {
+      hostnames.push(parseHostname(baseInput, tld));
+    } catch (err) {
+      firstError ??= err;
+      skipped.push(`"${tld}": ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  if (hostnames.length === 0) throw firstError;
+  for (const detail of skipped) {
+    console.warn(`Warning: skipping TLD ${detail}`);
+  }
+  return hostnames;
 }

--- a/skills/oauth/SKILL.md
+++ b/skills/oauth/SKILL.md
@@ -35,15 +35,15 @@ Any TLD in the Public Suffix List works: `.dev`, `.app`, `.com`, `.io`, etc.
 
 ### Use a domain you own
 
-Bare TLDs like `.dev` mean `myapp.dev` could collide with a real domain. Use a subdomain of a domain you control:
+Bare TLDs like `.dev` mean `myapp.dev` could collide with a real domain. Use a multi-segment TLD under a domain you control, so the app name stays clean and the domain structure lives in the TLD:
 
 ```bash
-portless proxy start --tld dev
-portless myapp.local.yourcompany next dev
+portless proxy start --tld local.yourcompany.dev
+portless myapp next dev
 # -> https://myapp.local.yourcompany.dev
 ```
 
-This ensures no outbound traffic reaches something you don't own. For teams, set a wildcard DNS record (`*.local.yourcompany.dev -> 127.0.0.1`) so every developer gets resolution without `/etc/hosts`.
+This ensures no outbound traffic reaches something you don't own. For teams, set a wildcard DNS record (`*.local.yourcompany.dev -> 127.0.0.1`) so every developer gets resolution without `/etc/hosts`, and every developer shares the same redirect URIs in the provider console.
 
 ## Provider Setup
 

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -167,6 +167,8 @@ Outside LAN mode, the proxy and its HTTP redirect listener bind only to the IPv4
 
 Use `portless proxy start --tld localhost --tld test` to serve the same app names under multiple TLDs from one proxy. `PORTLESS_URL` uses the first configured TLD. `PORTLESS_TLD` accepts the same comma separated list format, e.g. `PORTLESS_TLD=localhost,test`.
 
+TLDs can be multi-segment DNS names such as `dev.example.com`, so local URLs can mirror production structure (`myapp.dev.example.com`). Each label follows DNS rules: lowercase letters, digits, interior hyphens, 63 characters per label, 253 total. Strict OAuth providers that reject `.localhost` redirect URIs accept a real domain like `https://myapp.dev.example.com/api/auth/callback/google`.
+
 Most frameworks (Next.js, Express, Nuxt, etc.) respect the `PORT` env var automatically. For frameworks that ignore `PORT` (Vite, VitePlus, Astro, React Router, Angular, Expo, React Native), portless auto-injects the correct `--port` flag and, when needed, a matching `--host` CLI flag.
 
 ### State directory
@@ -175,21 +177,21 @@ Portless stores its state (routes, PID file, port file) in `~/.portless`. When t
 
 ### Environment variables
 
-| Variable              | Description                                                                 |
-| --------------------- | --------------------------------------------------------------------------- |
-| `PORTLESS_PORT`       | Override the default proxy port (default: 443 with HTTPS, 80 without)       |
-| `PORTLESS_APP_PORT`   | Use a fixed port for the app (skip auto-assignment)                         |
-| `PORTLESS_HTTPS`      | HTTPS on by default; set to `0` to disable (same as `--no-tls`)             |
-| `PORTLESS_LAN`        | Set to `1` to always enable LAN mode (auto-detects LAN IP)                  |
-| `PORTLESS_LAN_IP`     | Pin a specific LAN IP for LAN mode                                          |
-| `PORTLESS_TLD`        | Use one or more TLDs (e.g. localhost,test)                                  |
-| `PORTLESS_WILDCARD`   | Set to `1` to allow unregistered subdomains to fall back to parent          |
-| `PORTLESS_SYNC_HOSTS` | Set to `0` to disable auto-sync of /etc/hosts (on by default)               |
-| `PORTLESS_TAILSCALE`  | Set to `1` to share apps on your Tailscale network (same as `--tailscale`)  |
-| `PORTLESS_FUNNEL`     | Set to `1` to share apps publicly via Tailscale Funnel (same as `--funnel`) |
-| `PORTLESS_NGROK`      | Set to `1` to share apps publicly via ngrok (same as `--ngrok`)             |
-| `PORTLESS_STATE_DIR`  | Override the state directory                                                |
-| `PORTLESS=0`          | Bypass the proxy, run the command directly                                  |
+| Variable              | Description                                                                    |
+| --------------------- | ------------------------------------------------------------------------------ |
+| `PORTLESS_PORT`       | Override the default proxy port (default: 443 with HTTPS, 80 without)          |
+| `PORTLESS_APP_PORT`   | Use a fixed port for the app (skip auto-assignment)                            |
+| `PORTLESS_HTTPS`      | HTTPS on by default; set to `0` to disable (same as `--no-tls`)                |
+| `PORTLESS_LAN`        | Set to `1` to always enable LAN mode (auto-detects LAN IP)                     |
+| `PORTLESS_LAN_IP`     | Pin a specific LAN IP for LAN mode                                             |
+| `PORTLESS_TLD`        | Use one or more TLDs, single or multi-segment (e.g. localhost,dev.example.com) |
+| `PORTLESS_WILDCARD`   | Set to `1` to allow unregistered subdomains to fall back to parent             |
+| `PORTLESS_SYNC_HOSTS` | Set to `0` to disable auto-sync of /etc/hosts (on by default)                  |
+| `PORTLESS_TAILSCALE`  | Set to `1` to share apps on your Tailscale network (same as `--tailscale`)     |
+| `PORTLESS_FUNNEL`     | Set to `1` to share apps publicly via Tailscale Funnel (same as `--funnel`)    |
+| `PORTLESS_NGROK`      | Set to `1` to share apps publicly via ngrok (same as `--ngrok`)                |
+| `PORTLESS_STATE_DIR`  | Override the state directory                                                   |
+| `PORTLESS=0`          | Bypass the proxy, run the command directly                                     |
 
 ### HTTP/2 + HTTPS
 
@@ -299,6 +301,7 @@ The chosen service configuration is written into launchd, systemd, or Task Sched
 | `portless proxy start -p <number>`                | Start the proxy on a custom port                               |
 | `portless proxy start --tld test`                 | Use .test instead of .localhost                                |
 | `portless proxy start --tld localhost --tld test` | Serve both TLDs from one proxy                                 |
+| `portless proxy start --tld dev.example.com`      | Use a multi-segment TLD for production-parity URLs             |
 | `portless proxy start --foreground`               | Start the proxy in foreground (for debugging)                  |
 | `portless proxy start --wildcard`                 | Allow unregistered subdomains to fall back to parent route     |
 | `portless proxy stop`                             | Stop the proxy                                                 |

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -165,7 +165,7 @@ Outside LAN mode, the proxy and its HTTP redirect listener bind only to the IPv4
 
 `.localhost` domains resolve to `127.0.0.1` natively in Chrome, Firefox, and Edge. Safari relies on the system DNS resolver, which may not handle `.localhost` subdomains on all configurations. Run `portless hosts sync` to add entries to `/etc/hosts` if needed.
 
-Use `portless proxy start --tld localhost --tld test` to serve the same app names under multiple TLDs from one proxy. `PORTLESS_URL` uses the first configured TLD. `PORTLESS_TLD` accepts the same comma separated list format, e.g. `PORTLESS_TLD=localhost,test`.
+Use `portless proxy start --tld localhost --tld test` to serve the same app names under multiple TLDs from one proxy. `PORTLESS_URL` uses the first configured TLD. When configured TLDs overlap (e.g. `example.com` and `dev.example.com`), hostnames are matched against the longest TLD first, regardless of configuration order. `PORTLESS_TLD` accepts the same comma separated list format, e.g. `PORTLESS_TLD=localhost,test`.
 
 TLDs can be multi-segment DNS names such as `dev.example.com`, so local URLs can mirror production structure (`myapp.dev.example.com`). Each label follows DNS rules: lowercase letters, digits, interior hyphens, 63 characters per label, 253 total. Strict OAuth providers that reject `.localhost` redirect URIs accept a real domain like `https://myapp.dev.example.com/api/auth/callback/google`.
 


### PR DESCRIPTION
`--tld` and `PORTLESS_TLD` rejected any value containing a dot, so a team running production at `*.example.com` could not use `dev.example.com` locally. Routing, hostname construction, hosts sync, and per-host SNI certs already handle dotted TLDs; the validator was the only blocker. `validateTld` now checks per-label DNS rules (lowercase letters, digits, interior hyphens, 63 characters per label, 253 total).

This picks up the validation approach from #277 by @KingPsychopath, re-applied on current main since that branch predates the multi-TLD list refactor and no longer rebases cleanly. The cert and hostname regression tests are adapted from the same PR. The run-mode `--tld` flag from #277 is left out on purpose: with TLD lists on main it needs new semantics, and it is separable.

Unblocks OAuth providers that reject `.localhost` redirect URIs (#58) and own-domain resolution over tailnet or LAN DNS, the use case behind the `@abumalick/portless` fork on npm. With this change `myapp.dev.example.com` routes correctly and gets a cert with SANs `DNS:myapp.dev.example.com` and `DNS:*.dev.example.com`, verified by regression tests across validation, TLD lists, hostname construction, proxy routing, and SNI SAN generation.

Fixes #260.

Follow-up commit hardens two edges found in review: risky-TLD warnings now suffix-match, so `--tld example.dev` warns about preloaded HSTS the same as `--tld dev`; and an invalid persisted entry in `proxy.tlds` (e.g. written before validation tightened) is skipped with a warning instead of silently resetting the whole list to `localhost`. Docs scope `--tld` to lowercase DNS names and document longest-match resolution for overlapping TLDs.
