### PR TITLE
fix: report automatic hosts-sync failures on the CLI, not only in proxy.log

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ portless hosts sync    # Add current routes to /etc/hosts
 portless hosts clean   # Clean up later
 ```
 
-Auto-syncs `/etc/hosts` for route hostnames by default (`.localhost`, custom TLDs, LAN `.local`). Set `PORTLESS_SYNC_HOSTS=0` to disable.
+Auto-syncs `/etc/hosts` for route hostnames by default (`.localhost`, custom TLDs, LAN `.local`). Set `PORTLESS_SYNC_HOSTS=0` to disable. If it cannot write the file, it warns once and points you to `portless hosts sync`.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ portless hosts sync    # Add current routes to /etc/hosts
 portless hosts clean   # Clean up later
 ```
 
-Auto-syncs `/etc/hosts` for route hostnames by default (`.localhost`, custom TLDs, LAN `.local`). Set `PORTLESS_SYNC_HOSTS=0` to disable. If it cannot write the file, it warns once and points you to `portless hosts sync`.
+Auto-syncs `/etc/hosts` for route hostnames by default (`.localhost`, custom TLDs, LAN `.local`). Set `PORTLESS_SYNC_HOSTS=0` to disable. If it cannot write the file, the command that registered the route warns and points you to `portless hosts sync`.
 
 ## Troubleshooting
 

--- a/apps/docs/src/app/commands/page.mdx
+++ b/apps/docs/src/app/commands/page.mdx
@@ -271,7 +271,7 @@ portless hosts sync     # add current routes to /etc/hosts
 portless hosts clean    # remove portless entries from /etc/hosts
 ```
 
-Auto-sync is on by default. Set `PORTLESS_SYNC_HOSTS=0` to disable.
+Auto-sync is on by default. Set `PORTLESS_SYNC_HOSTS=0` to disable. If it cannot write the file, it warns once and points you to `portless hosts sync`.
 
 ## Bypass portless
 

--- a/apps/docs/src/app/commands/page.mdx
+++ b/apps/docs/src/app/commands/page.mdx
@@ -271,7 +271,7 @@ portless hosts sync     # add current routes to /etc/hosts
 portless hosts clean    # remove portless entries from /etc/hosts
 ```
 
-Auto-sync is on by default. Set `PORTLESS_SYNC_HOSTS=0` to disable. If it cannot write the file, it warns once and points you to `portless hosts sync`.
+Auto-sync is on by default. Set `PORTLESS_SYNC_HOSTS=0` to disable. If it cannot write the file, the command that registered the route warns and points you to `portless hosts sync`.
 
 ## Bypass portless
 

--- a/apps/docs/src/app/page.mdx
+++ b/apps/docs/src/app/page.mdx
@@ -111,7 +111,7 @@ portless myapp next dev
 # -> https://myapp.test
 ```
 
-The proxy auto-syncs `/etc/hosts` for route hostnames, so `.test` and other dev hostnames resolve on your machine.
+The proxy auto-syncs `/etc/hosts` for route hostnames, so `.test` and other dev hostnames resolve on your machine. If it cannot write the hosts file (for example, running unprivileged on a high port), it warns once instead of failing silently and points you to `portless hosts sync`.
 
 Repeat `--tld` to serve the same app names under multiple TLDs from one proxy:
 

--- a/apps/docs/src/app/page.mdx
+++ b/apps/docs/src/app/page.mdx
@@ -111,7 +111,7 @@ portless myapp next dev
 # -> https://myapp.test
 ```
 
-The proxy auto-syncs `/etc/hosts` for route hostnames, so `.test` and other dev hostnames resolve on your machine. If it cannot write the hosts file (for example, running unprivileged on a high port), it warns once instead of failing silently and points you to `portless hosts sync`.
+The proxy auto-syncs `/etc/hosts` for route hostnames, so `.test` and other dev hostnames resolve on your machine. If it cannot write the hosts file (for example, running unprivileged on a high port), the command that registered the route warns instead of failing silently and points you to `portless hosts sync`.
 
 Repeat `--tld` to serve the same app names under multiple TLDs from one proxy:
 

--- a/packages/portless/src/clean-utils.test.ts
+++ b/packages/portless/src/clean-utils.test.ts
@@ -7,6 +7,12 @@ import {
   collectStateDirsForCleanup,
   removePortlessStateFiles,
 } from "./clean-utils.js";
+import {
+  HOSTS_SYNC_PROTOCOL,
+  HOSTS_SYNC_STATUS_FILE,
+  hostsSyncStatusTempPath,
+  writeHostsSyncStatus,
+} from "./cli-utils.js";
 
 describe("collectStateDirsForCleanup", () => {
   const prevState = process.env.PORTLESS_STATE_DIR;
@@ -34,6 +40,42 @@ describe("removePortlessStateFiles", () => {
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // The status file records the hostnames the user registered, so leaving it
+  // behind is clean failing to remove user data after saying it did. Nothing
+  // could have failed here before: the allowlist has no coupling to the code
+  // that writes these files, so the writer worked and the remover was unaware.
+  // Driven through the REAL writer, not a hand-planted file. The allowlist and
+  // the code that writes these names are joined by nothing but agreement, and
+  // agreement drifts in the one direction no test catches: the writer works and
+  // the remover is merely unaware. Calling the writer here means changing either
+  // side alone turns this red.
+  it("removes what the real status writer creates, including an interrupted write", () => {
+    writeHostsSyncStatus(tmpDir, {
+      protocol: HOSTS_SYNC_PROTOCOL,
+      ok: false,
+      message: "Could not write /etc/hosts; hostnames may not resolve.",
+      hostnames: ["app.localhost"],
+      at: Date.now(),
+      pid: process.pid,
+      autoSync: true,
+    });
+    // A crash between the temp write and the rename orphans a name carrying a
+    // PID. Built from the writer's own rule rather than a literal, so the rule
+    // cannot change on one side only.
+    const orphan = hostsSyncStatusTempPath(tmpDir, 4194303);
+    fs.writeFileSync(orphan, "{}");
+    // Near misses that share the prefix but are not the writer's temp shape.
+    fs.writeFileSync(path.join(tmpDir, "proxy.hosts-sync-status.notes"), "keep me");
+    fs.writeFileSync(path.join(tmpDir, "proxy.hosts-sync-status.backup.tmp"), "keep me");
+
+    removePortlessStateFiles(tmpDir);
+
+    expect(fs.existsSync(path.join(tmpDir, HOSTS_SYNC_STATUS_FILE))).toBe(false);
+    expect(fs.existsSync(orphan)).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, "proxy.hosts-sync-status.notes"))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, "proxy.hosts-sync-status.backup.tmp"))).toBe(true);
   });
 
   it("removes allowlisted files and host-certs directory", () => {

--- a/packages/portless/src/clean-utils.ts
+++ b/packages/portless/src/clean-utils.ts
@@ -1,6 +1,11 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { LEGACY_SYSTEM_STATE_DIR, USER_STATE_DIR } from "./cli-utils.js";
+import {
+  HOSTS_SYNC_STATUS_FILE,
+  isHostsSyncStatusTemp,
+  LEGACY_SYSTEM_STATE_DIR,
+  USER_STATE_DIR,
+} from "./cli-utils.js";
 
 /** Filenames portless creates under a state directory (allowlisted for clean). */
 const PORTLESS_STATE_FILES = [
@@ -14,6 +19,7 @@ const PORTLESS_STATE_FILES = [
   "proxy.tld",
   "proxy.tlds",
   "proxy.lan",
+  HOSTS_SYNC_STATUS_FILE,
   "ca.trusted",
   "ca.trust-refresh-pending",
   "ca-key.pem",
@@ -83,6 +89,23 @@ export function removePortlessStateFiles(
     } catch {
       // ENOENT or permission; non-fatal
     }
+  }
+  // The status file is written atomically as a temporary plus a rename, so a
+  // crash between the two orphans a file whose name carries a PID. No static
+  // allowlist can enumerate those. The match rule is not restated here: it is
+  // owned by the writer's module, so changing the naming on one side cannot
+  // silently leave the other side unable to find what it now creates.
+  try {
+    for (const entry of fs.readdirSync(dir)) {
+      if (!isHostsSyncStatusTemp(entry)) continue;
+      try {
+        fs.unlinkSync(path.join(dir, entry));
+      } catch {
+        // ENOENT or permission; non-fatal
+      }
+    }
+  } catch {
+    // Directory unreadable; the allowlist pass above already reported what it could.
   }
   try {
     fs.rmSync(path.join(dir, HOST_CERTS_DIR), { recursive: true, force: true });

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -23,6 +23,7 @@ import {
   getProxyBindTargets,
   isHttpsEnvDisabled,
   injectFrameworkFlags,
+  syncHostsWithWarning,
   isPortListening,
   isProxyRunning,
   listenOnProxyInterface,
@@ -464,6 +465,45 @@ describe("isHttpsEnvDisabled", () => {
   it("returns false when PORTLESS_HTTPS is unset", () => {
     delete process.env.PORTLESS_HTTPS;
     expect(isHttpsEnvDisabled()).toBe(false);
+  });
+});
+
+describe("syncHostsWithWarning", () => {
+  it("warns and latches when the sync fails and it has not warned yet", () => {
+    const onWarn = vi.fn();
+    const warned = syncHostsWithWarning(["a.localhost"], false, onWarn, () => false);
+    expect(warned).toBe(true);
+    expect(onWarn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not warn again while the sync keeps failing", () => {
+    const onWarn = vi.fn();
+    const warned = syncHostsWithWarning(["a.localhost"], true, onWarn, () => false);
+    expect(warned).toBe(true);
+    expect(onWarn).not.toHaveBeenCalled();
+  });
+
+  it("re-arms the warning after a successful sync", () => {
+    const onWarn = vi.fn();
+    const warned = syncHostsWithWarning(["a.localhost"], true, onWarn, () => true);
+    expect(warned).toBe(false);
+    expect(onWarn).not.toHaveBeenCalled();
+  });
+
+  it("warns again on failure after a success re-armed it", () => {
+    const onWarn = vi.fn();
+    let warned = syncHostsWithWarning(["a"], false, onWarn, () => false); // fail -> warn
+    warned = syncHostsWithWarning(["a"], warned, onWarn, () => false); // fail -> silent
+    warned = syncHostsWithWarning(["a"], warned, onWarn, () => true); // ok -> re-arm
+    warned = syncHostsWithWarning(["a"], warned, onWarn, () => false); // fail -> warn
+    expect(warned).toBe(true);
+    expect(onWarn).toHaveBeenCalledTimes(2);
+  });
+
+  it("passes the hostnames through to the sync function", () => {
+    const sync = vi.fn(() => true);
+    syncHostsWithWarning(["a.localhost", "b.localhost"], false, vi.fn(), sync);
+    expect(sync).toHaveBeenCalledWith(["a.localhost", "b.localhost"]);
   });
 });
 

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -39,6 +39,8 @@ import {
   writeTldFile,
   writeTldsFile,
   writeTlsMarker,
+  writeHostsSyncWarningMarker,
+  consumeHostsSyncWarningMarker,
 } from "./cli-utils.js";
 
 describe("proxy listener interface", () => {
@@ -504,6 +506,90 @@ describe("syncHostsWithWarning", () => {
     const sync = vi.fn(() => true);
     syncHostsWithWarning(["a.localhost", "b.localhost"], false, vi.fn(), sync);
     expect(sync).toHaveBeenCalledWith(["a.localhost", "b.localhost"]);
+  });
+
+  it("does not consume the warn-once latch when an empty-route sync fails", () => {
+    // Regression for issue #364 finding 2: the proxy's warm-up sync at
+    // startup runs with zero routes. If its failure latched `hostsSyncWarned`
+    // to true, the first REAL route registered afterward would fail its own
+    // sync silently, because the latch had already been spent on a sync that
+    // had nothing user-visible to write.
+    const onWarn = vi.fn();
+
+    // Empty-route warm-up sync fails.
+    let warned = syncHostsWithWarning([], false, onWarn, () => false);
+    expect(onWarn).not.toHaveBeenCalled();
+    expect(warned).toBe(false); // latch must still be unarmed
+
+    // A real route is registered; its sync also fails and must warn.
+    warned = syncHostsWithWarning(["a.localhost"], warned, onWarn, () => false);
+    expect(onWarn).toHaveBeenCalledTimes(1);
+    expect(warned).toBe(true);
+  });
+
+  it("does not re-arm or disarm the latch on a successful empty-route sync", () => {
+    const onWarn = vi.fn();
+
+    // A real route already failed and warned.
+    let warned = syncHostsWithWarning(["a.localhost"], false, onWarn, () => false);
+    expect(warned).toBe(true);
+    expect(onWarn).toHaveBeenCalledTimes(1);
+
+    // All routes removed; the resulting empty sync succeeds. This must not
+    // be treated as a meaningful state change for the latch either way, but
+    // it also must not crash or warn again.
+    warned = syncHostsWithWarning([], warned, onWarn, () => true);
+    expect(warned).toBe(false);
+    expect(onWarn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("hosts-sync-warning marker (daemon-to-CLI handoff)", () => {
+  // Regression for issue #364 finding 1: the hosts-sync warning is computed
+  // and would previously only be printed inside the detached proxy daemon,
+  // whose stdio is redirected to proxy.log (see the `spawn(...)` call in
+  // `doProxyStart`, cli.ts). A CLI process attached to the user's terminal
+  // never sees it. writeHostsSyncWarningMarker/consumeHostsSyncWarningMarker
+  // are the cross-process channel that lets a CLI-facing process (the one
+  // that spawned the daemon, or the one that just registered a route) pick
+  // up and print a failure that happened inside the daemon.
+  //
+  // This channel-crossing itself is exercised structurally, not by spawning
+  // a real daemon process in this unit test: `warnHostsSyncFailed` in
+  // `startProxyServer` (cli.ts) calls `writeHostsSyncWarningMarker`, and the
+  // CLI-facing checkpoints (`doProxyStart` after `waitForProxy`, and
+  // `reportHostsSyncWarningAfterRouteChange` after `addRoutes` in `runApp`)
+  // call `consumeHostsSyncWarningMarker` and print with `console.warn` on
+  // their own process's stdio. An end-to-end assertion that stdout literally
+  // differs between the daemon's fd and the parent's fd is not practical in
+  // this vitest harness (it would require spawning a real detached child and
+  // inspecting its inherited file descriptors); it is covered by the code
+  // structure above plus this in-process round-trip test.
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-hosts-sync-marker-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("round-trips a written warning message", () => {
+    writeHostsSyncWarningMarker(tmpDir, "Could not write /etc/hosts; hostnames may not resolve.");
+    expect(consumeHostsSyncWarningMarker(tmpDir)).toBe(
+      "Could not write /etc/hosts; hostnames may not resolve."
+    );
+  });
+
+  it("is one-shot: a second read returns null and does not resurface the warning", () => {
+    writeHostsSyncWarningMarker(tmpDir, "boom");
+    expect(consumeHostsSyncWarningMarker(tmpDir)).toBe("boom");
+    expect(consumeHostsSyncWarningMarker(tmpDir)).toBeNull();
+  });
+
+  it("returns null when no warning was ever written", () => {
+    expect(consumeHostsSyncWarningMarker(tmpDir)).toBeNull();
   });
 });
 

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -41,6 +41,7 @@ import {
   writeTlsMarker,
   writeHostsSyncWarningMarker,
   consumeHostsSyncWarningMarker,
+  pollForHostsSyncWarningMarker,
 } from "./cli-utils.js";
 
 describe("proxy listener interface", () => {
@@ -590,6 +591,56 @@ describe("hosts-sync-warning marker (daemon-to-CLI handoff)", () => {
 
   it("returns null when no warning was ever written", () => {
     expect(consumeHostsSyncWarningMarker(tmpDir)).toBeNull();
+  });
+});
+
+describe("pollForHostsSyncWarningMarker", () => {
+  // Regression for issue #364 finding 2: reportHostsSyncWarningAfterRouteChange
+  // used to check for the marker exactly once, after a single fixed delay
+  // (DEBOUNCE_MS + 100). If the daemon was slower than that window (a real
+  // possibility: it reloads routes.json on its own debounce, then runs the
+  // sync, then writes the marker), the single check ran too early, found
+  // nothing, and the warning was lost for good even though the daemon wrote
+  // it moments later. Polling must keep checking until the marker shows up
+  // or a bounded ceiling is hit, so a slow daemon does not cost the user a
+  // silently dropped warning.
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-hosts-sync-poll-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("picks up a marker written after the poll has already started", async () => {
+    // Simulate a daemon that is slower than a single fixed-delay check would
+    // tolerate: nothing exists yet when polling begins, and the marker only
+    // shows up after a short delay.
+    setTimeout(() => {
+      writeHostsSyncWarningMarker(tmpDir, "delayed warning");
+    }, 120);
+
+    const message = await pollForHostsSyncWarningMarker(tmpDir, 20, 1000);
+    expect(message).toBe("delayed warning");
+  });
+
+  it("returns the marker immediately if it is already present", async () => {
+    writeHostsSyncWarningMarker(tmpDir, "already here");
+    const start = Date.now();
+    const message = await pollForHostsSyncWarningMarker(tmpDir, 50, 1500);
+    expect(message).toBe("already here");
+    expect(Date.now() - start).toBeLessThan(100);
+  });
+
+  it("gives up at the ceiling and returns null when no marker ever appears", async () => {
+    const start = Date.now();
+    const message = await pollForHostsSyncWarningMarker(tmpDir, 20, 100);
+    expect(message).toBeNull();
+    expect(Date.now() - start).toBeGreaterThanOrEqual(100);
+    // Bounded: does not run away past the ceiling.
+    expect(Date.now() - start).toBeLessThan(400);
   });
 });
 

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -22,7 +22,8 @@ import {
   getProtocolPort,
   getProxyBindTargets,
   getRiskyTldReason,
-  hasLiveHostsSyncPublisher,
+  HOSTS_SYNC_PROTOCOL,
+  readHostsSyncPublisher,
   isHttpsEnvDisabled,
   injectFrameworkFlags,
   syncHostsWithWarning,
@@ -568,8 +569,11 @@ describe("hosts-sync status file (daemon-to-CLI handoff)", () => {
   const status = (over: Partial<Parameters<typeof writeHostsSyncStatus>[1]> = {}) => ({
     ok: false,
     message: "Could not write /etc/hosts; hostnames may not resolve.",
+    protocol: HOSTS_SYNC_PROTOCOL,
     hostnames: ["app1.localhost"],
     at: Date.now(),
+    pid: process.pid,
+    autoSync: true,
     ...over,
   });
 
@@ -597,6 +601,22 @@ describe("hosts-sync status file (daemon-to-CLI handoff)", () => {
     expect(readHostsSyncStatus(tmpDir)).toBeNull();
   });
 
+  // Absence of the file answers "the daemon predates publishing". It cannot
+  // answer "the daemon is NEWER and moved these fields", and interpreting a
+  // record whose shape this build does not know is how a reader turns a
+  // forward-compatibility problem into a wrong warning.
+  it("declines a record whose protocol this build does not support", () => {
+    writeHostsSyncStatus(tmpDir, { ...status(), protocol: HOSTS_SYNC_PROTOCOL + 1 });
+    expect(readHostsSyncStatus(tmpDir)).toBeNull();
+  });
+
+  it("declines a record written before the protocol field existed", () => {
+    const legacy = status() as Record<string, unknown>;
+    delete legacy.protocol;
+    fs.writeFileSync(path.join(tmpDir, "proxy.hosts-sync-status"), JSON.stringify(legacy));
+    expect(readHostsSyncStatus(tmpDir)).toBeNull();
+  });
+
   it("returns null on a corrupt or partially written file", () => {
     fs.writeFileSync(path.join(tmpDir, "proxy.hosts-sync-status"), "{not json");
     expect(readHostsSyncStatus(tmpDir)).toBeNull();
@@ -616,8 +636,11 @@ describe("waitForHostsSyncStatus", () => {
     writeHostsSyncStatus(tmpDir, {
       ok: false,
       message: "boom",
+      protocol: HOSTS_SYNC_PROTOCOL,
       hostnames: ["app1.localhost"],
       at: Date.now(),
+      pid: process.pid,
+      autoSync: true,
       ...over,
     });
 
@@ -676,7 +699,13 @@ describe("waitForHostsSyncStatus", () => {
     expect(Date.now() - start).toBeLessThan(100);
   });
 
-  it("gives up at the ceiling when the daemon never publishes", async () => {
+  // This covers the bound itself, at an injected ceiling. It deliberately does
+  // NOT bless reaching the bound in production: at the shipped
+  // HOSTS_SYNC_STATUS_WAIT_CEILING_MS that is a 4.1s hang on a routine command,
+  // and the publisher guard below is what keeps every mute-daemon case off this
+  // path. Asserting a timeout at 100ms reads as reasonable bounded behavior and
+  // is exactly how the shipped hang stayed green through two review rounds.
+  it("bounds the wait when an outcome never arrives", async () => {
     const start = Date.now();
     const result = await waitForHostsSyncStatus(tmpDir, {
       since: Date.now(),
@@ -690,9 +719,33 @@ describe("waitForHostsSyncStatus", () => {
   });
 });
 
-describe("hasLiveHostsSyncPublisher", () => {
+describe("readHostsSyncPublisher", () => {
+  // A wait for a published outcome is a wait on the daemon, so the guard in
+  // front of it must answer "will anyone publish, and does that daemon sync at
+  // all". Liveness cannot answer either: the round-5 guard proved a PID was
+  // alive, which every case below also satisfies, and each still hangs for the
+  // full ceiling on a routine command.
   let tmpDir: string;
   let pidPath: string;
+
+  // The shipped HOSTS_SYNC_STATUS_WAIT_CEILING_MS (cli.ts). Timing assertions
+  // here run against the real constant on purpose: a guard verified at an
+  // injected 100ms proves nothing about the command a user actually runs.
+  const PRODUCTION_CEILING_MS = 4100;
+
+  const handshake = (over: Record<string, unknown> = {}) => {
+    fs.writeFileSync(pidPath, `${process.pid}\n`);
+    writeHostsSyncStatus(tmpDir, {
+      protocol: HOSTS_SYNC_PROTOCOL,
+      ok: true,
+      message: null,
+      hostnames: [],
+      at: Date.now(),
+      pid: process.pid,
+      autoSync: true,
+      ...over,
+    } as Parameters<typeof writeHostsSyncStatus>[1]);
+  };
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-publisher-"));
@@ -703,48 +756,78 @@ describe("hasLiveHostsSyncPublisher", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("returns false when no PID file exists", () => {
-    expect(hasLiveHostsSyncPublisher(pidPath)).toBe(false);
+  it("returns null when no daemon is running", () => {
+    expect(readHostsSyncPublisher(tmpDir, pidPath)).toBeNull();
   });
 
-  it("returns false for a stale PID file", () => {
+  // The upgrade path, and the reason liveness is not enough. A daemon from a
+  // build older than the handshake is alive, correct, and serving traffic; it
+  // simply never writes the status file. It is also, by construction, the
+  // daemon every user is running the moment this ships.
+  it("returns null for a live daemon from a build that predates the handshake", () => {
+    fs.writeFileSync(pidPath, `${process.pid}\n`);
+    expect(readHostsSyncPublisher(tmpDir, pidPath)).toBeNull();
+  });
+
+  it("returns null for a record left by a previous daemon", () => {
+    handshake({ pid: 4194303 });
+    expect(readHostsSyncPublisher(tmpDir, pidPath)).toBeNull();
+  });
+
+  it("returns null when the PID it names is no longer alive", () => {
     // PID 1 is init and always alive, so pick one that cannot be running:
     // a freshly reaped child's PID is racy, and 2^22 is above every default
     // pid_max on the platforms portless supports.
+    handshake({ pid: 4194303 });
     fs.writeFileSync(pidPath, "4194303");
-    expect(hasLiveHostsSyncPublisher(pidPath)).toBe(false);
+    expect(readHostsSyncPublisher(tmpDir, pidPath)).toBeNull();
   });
 
-  it("returns false for an unparseable PID file", () => {
+  it("returns null for an unparseable PID file", () => {
+    handshake();
     fs.writeFileSync(pidPath, "not-a-pid");
-    expect(hasLiveHostsSyncPublisher(pidPath)).toBe(false);
+    expect(readHostsSyncPublisher(tmpDir, pidPath)).toBeNull();
   });
 
-  it("returns false for a non-positive PID", () => {
-    fs.writeFileSync(pidPath, "0");
-    expect(hasLiveHostsSyncPublisher(pidPath)).toBe(false);
+  // The forward half of the skew problem: a daemon from a build this CLI does
+  // not understand is as mute as one that predates publishing, and waiting on
+  // it costs the same full ceiling.
+  it("returns null for a live daemon speaking an unsupported protocol", () => {
+    handshake({ protocol: HOSTS_SYNC_PROTOCOL + 1 });
+    expect(readHostsSyncPublisher(tmpDir, pidPath)).toBeNull();
   });
 
-  it("returns true for a live PID", () => {
-    fs.writeFileSync(pidPath, `${process.pid}\n`);
-    expect(hasLiveHostsSyncPublisher(pidPath)).toBe(true);
+  it("reports a live publisher that syncs", () => {
+    handshake();
+    expect(readHostsSyncPublisher(tmpDir, pidPath)).toEqual({ autoSync: true });
   });
 
-  // Regression guard for the reason this check exists: without it, the
-  // no-daemon case waits out HOSTS_SYNC_STATUS_WAIT_CEILING_MS on a routine
-  // alias registration.
-  it("short-circuits the wait instead of burning the ceiling", async () => {
+  // The daemon's own answer, which is the only one that exists: a CLI reading
+  // its own PORTLESS_SYNC_HOSTS describes the shell the command was typed in,
+  // not the environment the daemon was spawned with.
+  it("reports a live publisher that was started with syncing disabled", () => {
+    handshake({ autoSync: false });
+    expect(readHostsSyncPublisher(tmpDir, pidPath)).toEqual({ autoSync: false });
+  });
+
+  // Every way a daemon can be alive and mute, timed against the real ceiling.
+  it.each([
+    ["a daemon predating the handshake", () => fs.writeFileSync(pidPath, `${process.pid}\n`)],
+    ["a daemon started with syncing disabled", () => handshake({ autoSync: false })],
+    ["a record left by a previous daemon", () => handshake({ pid: 4194303 })],
+  ])("does not spend the production ceiling on %s", async (_label, setup) => {
+    setup();
     const start = Date.now();
-    const skipped = !hasLiveHostsSyncPublisher(pidPath);
-    const result = skipped
-      ? null
-      : await waitForHostsSyncStatus(tmpDir, {
-          since: Date.now(),
-          hostnames: ["app1.localhost"],
-          intervalMs: 50,
-          ceilingMs: 4100,
-        });
-    expect(skipped).toBe(true);
+    const publisher = readHostsSyncPublisher(tmpDir, pidPath);
+    const result =
+      publisher && publisher.autoSync
+        ? await waitForHostsSyncStatus(tmpDir, {
+            since: Date.now(),
+            hostnames: ["app1.localhost"],
+            intervalMs: 50,
+            ceilingMs: PRODUCTION_CEILING_MS,
+          })
+        : null;
     expect(result).toBeNull();
     expect(Date.now() - start).toBeLessThan(100);
   });

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -21,6 +21,7 @@ import {
   getDefaultTlds,
   getProtocolPort,
   getProxyBindTargets,
+  hasLiveHostsSyncPublisher,
   isHttpsEnvDisabled,
   injectFrameworkFlags,
   syncHostsWithWarning,
@@ -685,6 +686,66 @@ describe("waitForHostsSyncStatus", () => {
     expect(result).toBeNull();
     expect(Date.now() - start).toBeGreaterThanOrEqual(100);
     expect(Date.now() - start).toBeLessThan(400);
+  });
+});
+
+describe("hasLiveHostsSyncPublisher", () => {
+  let tmpDir: string;
+  let pidPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-publisher-"));
+    pidPath = path.join(tmpDir, "proxy.pid");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns false when no PID file exists", () => {
+    expect(hasLiveHostsSyncPublisher(pidPath)).toBe(false);
+  });
+
+  it("returns false for a stale PID file", () => {
+    // PID 1 is init and always alive, so pick one that cannot be running:
+    // a freshly reaped child's PID is racy, and 2^22 is above every default
+    // pid_max on the platforms portless supports.
+    fs.writeFileSync(pidPath, "4194303");
+    expect(hasLiveHostsSyncPublisher(pidPath)).toBe(false);
+  });
+
+  it("returns false for an unparseable PID file", () => {
+    fs.writeFileSync(pidPath, "not-a-pid");
+    expect(hasLiveHostsSyncPublisher(pidPath)).toBe(false);
+  });
+
+  it("returns false for a non-positive PID", () => {
+    fs.writeFileSync(pidPath, "0");
+    expect(hasLiveHostsSyncPublisher(pidPath)).toBe(false);
+  });
+
+  it("returns true for a live PID", () => {
+    fs.writeFileSync(pidPath, `${process.pid}\n`);
+    expect(hasLiveHostsSyncPublisher(pidPath)).toBe(true);
+  });
+
+  // Regression guard for the reason this check exists: without it, the
+  // no-daemon case waits out HOSTS_SYNC_STATUS_WAIT_CEILING_MS on a routine
+  // alias registration.
+  it("short-circuits the wait instead of burning the ceiling", async () => {
+    const start = Date.now();
+    const skipped = !hasLiveHostsSyncPublisher(pidPath);
+    const result = skipped
+      ? null
+      : await waitForHostsSyncStatus(tmpDir, {
+          since: Date.now(),
+          hostnames: ["app1.localhost"],
+          intervalMs: 50,
+          ceilingMs: 4100,
+        });
+    expect(skipped).toBe(true);
+    expect(result).toBeNull();
+    expect(Date.now() - start).toBeLessThan(100);
   });
 });
 

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -39,9 +39,9 @@ import {
   writeTldFile,
   writeTldsFile,
   writeTlsMarker,
-  writeHostsSyncWarningMarker,
-  consumeHostsSyncWarningMarker,
-  pollForHostsSyncWarningMarker,
+  writeHostsSyncStatus,
+  readHostsSyncStatus,
+  waitForHostsSyncStatus,
 } from "./cli-utils.js";
 
 describe("proxy listener interface", () => {
@@ -545,101 +545,145 @@ describe("syncHostsWithWarning", () => {
   });
 });
 
-describe("hosts-sync-warning marker (daemon-to-CLI handoff)", () => {
+describe("hosts-sync status file (daemon-to-CLI handoff)", () => {
   // Regression for issue #364 finding 1: the hosts-sync warning is computed
-  // and would previously only be printed inside the detached proxy daemon,
-  // whose stdio is redirected to proxy.log (see the `spawn(...)` call in
-  // `doProxyStart`, cli.ts). A CLI process attached to the user's terminal
-  // never sees it. writeHostsSyncWarningMarker/consumeHostsSyncWarningMarker
-  // are the cross-process channel that lets a CLI-facing process (the one
-  // that spawned the daemon, or the one that just registered a route) pick
-  // up and print a failure that happened inside the daemon.
+  // inside the detached proxy daemon, whose stdio is redirected to proxy.log
+  // (see the `spawn(...)` call in `doProxyStart`, cli.ts), so a CLI process
+  // attached to the user's terminal never sees it. The status file is the
+  // cross-process channel: the daemon publishes the outcome of every sync,
+  // and each CLI-facing checkpoint (`doProxyStart` after `waitForProxy`, and
+  // `reportHostsSyncAfterRouteChange` after `addRoutes`) reads the outcome
+  // for its OWN route change and prints it on its own stdio.
   //
-  // This channel-crossing itself is exercised structurally, not by spawning
-  // a real daemon process in this unit test: `warnHostsSyncFailed` in
-  // `startProxyServer` (cli.ts) calls `writeHostsSyncWarningMarker`, and the
-  // CLI-facing checkpoints (`doProxyStart` after `waitForProxy`, and
-  // `reportHostsSyncWarningAfterRouteChange` after `addRoutes` in `runApp`)
-  // call `consumeHostsSyncWarningMarker` and print with `console.warn` on
-  // their own process's stdio. An end-to-end assertion that stdout literally
-  // differs between the daemon's fd and the parent's fd is not practical in
-  // this vitest harness (it would require spawning a real detached child and
-  // inspecting its inherited file descriptors); it is covered by the code
-  // structure above plus this in-process round-trip test.
+  // Reading is non-destructive by design. A one-shot marker made the first
+  // reader the only reader: a second app registering a route against the
+  // same failing daemon found the warning already consumed and stayed
+  // silent, two concurrent readers raced for one message, and a marker
+  // outlived the failure it described. The stamp and hostname coverage are
+  // what make an outcome attributable instead of first-come-first-served.
   let tmpDir: string;
 
+  const status = (over: Partial<Parameters<typeof writeHostsSyncStatus>[1]> = {}) => ({
+    ok: false,
+    message: "Could not write /etc/hosts; hostnames may not resolve.",
+    hostnames: ["app1.localhost"],
+    at: Date.now(),
+    ...over,
+  });
+
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-hosts-sync-marker-test-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-hosts-sync-status-test-"));
   });
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("round-trips a written warning message", () => {
-    writeHostsSyncWarningMarker(tmpDir, "Could not write /etc/hosts; hostnames may not resolve.");
-    expect(consumeHostsSyncWarningMarker(tmpDir)).toBe(
-      "Could not write /etc/hosts; hostnames may not resolve."
-    );
+  it("round-trips a published outcome", () => {
+    const published = status();
+    writeHostsSyncStatus(tmpDir, published);
+    expect(readHostsSyncStatus(tmpDir)).toEqual(published);
   });
 
-  it("is one-shot: a second read returns null and does not resurface the warning", () => {
-    writeHostsSyncWarningMarker(tmpDir, "boom");
-    expect(consumeHostsSyncWarningMarker(tmpDir)).toBe("boom");
-    expect(consumeHostsSyncWarningMarker(tmpDir)).toBeNull();
+  it("is not consumed by reading, so every attached CLI sees the same failure", () => {
+    writeHostsSyncStatus(tmpDir, status());
+    expect(readHostsSyncStatus(tmpDir)?.ok).toBe(false);
+    expect(readHostsSyncStatus(tmpDir)?.ok).toBe(false);
   });
 
-  it("returns null when no warning was ever written", () => {
-    expect(consumeHostsSyncWarningMarker(tmpDir)).toBeNull();
+  it("returns null when nothing was ever published", () => {
+    expect(readHostsSyncStatus(tmpDir)).toBeNull();
+  });
+
+  it("returns null on a corrupt or partially written file", () => {
+    fs.writeFileSync(path.join(tmpDir, "proxy.hosts-sync-status"), "{not json");
+    expect(readHostsSyncStatus(tmpDir)).toBeNull();
   });
 });
 
-describe("pollForHostsSyncWarningMarker", () => {
-  // Regression for issue #364 finding 2: reportHostsSyncWarningAfterRouteChange
-  // used to check for the marker exactly once, after a single fixed delay
-  // (DEBOUNCE_MS + 100). If the daemon was slower than that window (a real
-  // possibility: it reloads routes.json on its own debounce, then runs the
-  // sync, then writes the marker), the single check ran too early, found
-  // nothing, and the warning was lost for good even though the daemon wrote
-  // it moments later. Polling must keep checking until the marker shows up
-  // or a bounded ceiling is hit, so a slow daemon does not cost the user a
-  // silently dropped warning.
+describe("waitForHostsSyncStatus", () => {
+  // Regression for issue #364 finding 2 and the round-4 review: the wait must
+  // outlive the daemon's own worst-case cadence (fs.watch debounce, or the
+  // fallback poll interval where fs.watch is unavailable), and it must only
+  // accept an outcome that belongs to the caller's own route change. A wait
+  // that accepts any outcome reports a stale failure the user already fixed;
+  // a wait shorter than the producer's cadence reports nothing at all.
   let tmpDir: string;
 
+  const publish = (over: Record<string, unknown> = {}) =>
+    writeHostsSyncStatus(tmpDir, {
+      ok: false,
+      message: "boom",
+      hostnames: ["app1.localhost"],
+      at: Date.now(),
+      ...over,
+    });
+
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-hosts-sync-poll-test-"));
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-hosts-sync-wait-test-"));
   });
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("picks up a marker written after the poll has already started", async () => {
-    // Simulate a daemon that is slower than a single fixed-delay check would
-    // tolerate: nothing exists yet when polling begins, and the marker only
-    // shows up after a short delay.
-    setTimeout(() => {
-      writeHostsSyncWarningMarker(tmpDir, "delayed warning");
-    }, 120);
-
-    const message = await pollForHostsSyncWarningMarker(tmpDir, 20, 1000);
-    expect(message).toBe("delayed warning");
+  it("picks up an outcome published after the wait has already started", async () => {
+    const since = Date.now();
+    setTimeout(publish, 120);
+    const result = await waitForHostsSyncStatus(tmpDir, {
+      since,
+      hostnames: ["app1.localhost"],
+      intervalMs: 20,
+      ceilingMs: 1000,
+    });
+    expect(result?.message).toBe("boom");
   });
 
-  it("returns the marker immediately if it is already present", async () => {
-    writeHostsSyncWarningMarker(tmpDir, "already here");
+  it("ignores an outcome older than the caller's own route change", async () => {
+    publish({ at: Date.now() - 5_000 });
+    const result = await waitForHostsSyncStatus(tmpDir, {
+      since: Date.now(),
+      hostnames: ["app1.localhost"],
+      intervalMs: 20,
+      ceilingMs: 100,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("ignores an outcome that does not cover the caller's hostnames", async () => {
+    publish({ hostnames: ["other.localhost"] });
+    const result = await waitForHostsSyncStatus(tmpDir, {
+      since: Date.now() - 1_000,
+      hostnames: ["app1.localhost"],
+      intervalMs: 20,
+      ceilingMs: 100,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns a successful outcome so the caller can stop waiting early", async () => {
+    publish({ ok: true, message: null });
     const start = Date.now();
-    const message = await pollForHostsSyncWarningMarker(tmpDir, 50, 1500);
-    expect(message).toBe("already here");
+    const result = await waitForHostsSyncStatus(tmpDir, {
+      since: Date.now() - 1_000,
+      hostnames: ["app1.localhost"],
+      intervalMs: 50,
+      ceilingMs: 4100,
+    });
+    expect(result?.ok).toBe(true);
     expect(Date.now() - start).toBeLessThan(100);
   });
 
-  it("gives up at the ceiling and returns null when no marker ever appears", async () => {
+  it("gives up at the ceiling when the daemon never publishes", async () => {
     const start = Date.now();
-    const message = await pollForHostsSyncWarningMarker(tmpDir, 20, 100);
-    expect(message).toBeNull();
+    const result = await waitForHostsSyncStatus(tmpDir, {
+      since: Date.now(),
+      hostnames: ["app1.localhost"],
+      intervalMs: 20,
+      ceilingMs: 100,
+    });
+    expect(result).toBeNull();
     expect(Date.now() - start).toBeGreaterThanOrEqual(100);
-    // Bounded: does not run away past the ceiling.
     expect(Date.now() - start).toBeLessThan(400);
   });
 });

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -7,6 +7,7 @@ import * as path from "node:path";
 import * as readline from "node:readline";
 import { execSync, spawn } from "node:child_process";
 import { PORTLESS_HEADER } from "./proxy.js";
+import { syncHostsFile } from "./hosts.js";
 import { createLoopbackConnection, resolveUserHome } from "./utils.js";
 
 // ---------------------------------------------------------------------------
@@ -156,6 +157,27 @@ export function killTree(
   } catch {
     // Already dead
   }
+}
+
+/**
+ * Run a hosts-file sync and emit a one-time warning when it fails, so an
+ * unwritable hosts file (e.g. an unprivileged proxy on a high port) surfaces
+ * instead of failing silently and leaving hostnames unresolvable server-side.
+ *
+ * Returns the next "already warned" state, which the caller threads back in:
+ * a failed sync latches it to true so repeated auto-syncs (route reloads) do
+ * not spam the terminal, and a successful sync re-arms it to false so a later
+ * failure warns again. `sync` is injectable for testing.
+ */
+export function syncHostsWithWarning(
+  hostnames: string[],
+  alreadyWarned: boolean,
+  onWarn: () => void,
+  sync: (hostnames: string[]) => boolean = syncHostsFile
+): boolean {
+  if (sync(hostnames)) return false;
+  if (!alreadyWarned) onWarn();
+  return true;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -349,6 +349,30 @@ export function consumeHostsSyncWarningMarker(dir: string): string | null {
   }
 }
 
+/**
+ * Poll for a pending hosts-sync-warning marker instead of checking once
+ * after a fixed delay. The daemon writes the marker asynchronously (it
+ * reloads routes.json on a debounce, then syncs, then writes), so a single
+ * fixed-delay check either wastes time waiting when the marker is already
+ * there, or misses it entirely when the daemon is slower than expected
+ * (e.g. under load, or a slow hosts-file write). Polling returns as soon as
+ * the marker appears, and gives up after `ceilingMs` so callers on the
+ * happy path (no failure) never wait longer than that ceiling.
+ */
+export async function pollForHostsSyncWarningMarker(
+  dir: string,
+  intervalMs = 50,
+  ceilingMs = 1500
+): Promise<string | null> {
+  const deadline = Date.now() + ceilingMs;
+  while (true) {
+    const message = consumeHostsSyncWarningMarker(dir);
+    if (message) return message;
+    if (Date.now() >= deadline) return null;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}
+
 /** Default TLD when PORTLESS_TLD is not set. */
 export const DEFAULT_TLD = "localhost";
 

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -176,6 +176,11 @@ export function syncHostsWithWarning(
   sync: (hostnames: string[]) => boolean = syncHostsFile
 ): boolean {
   if (sync(hostnames)) return false;
+  // An empty-route sync (the warm-up sync at proxy startup, or all routes
+  // removed) has nothing user-visible to write. Its failure must not consume
+  // the warn-once latch, or the first REAL route's sync failure later on
+  // finds the latch already spent and never warns.
+  if (hostnames.length === 0) return alreadyWarned;
   if (!alreadyWarned) onWarn();
   return true;
 }
@@ -306,6 +311,41 @@ export function writeLanMarker(dir: string, ip: string | null): void {
     }
   } else {
     fs.writeFileSync(markerPath, ip, { mode: 0o644 });
+  }
+}
+
+/** Marker file recording an unreported hosts-sync failure, written by the daemon. */
+const HOSTS_SYNC_WARNING_MARKER_FILE = "proxy.hosts-sync-warning";
+
+/**
+ * Record a hosts-sync failure so a CLI process attached to the user's
+ * terminal can surface it later. The sync itself, and the warn-once latch
+ * that gates it, run inside the detached proxy daemon (its stdio is
+ * redirected to proxy.log, see the `spawn(...)` in `doProxyStart`), so the
+ * daemon writing a warning to its own log is invisible to the user. This
+ * marker is the only channel back to a process the user can actually see.
+ */
+export function writeHostsSyncWarningMarker(dir: string, message: string): void {
+  try {
+    fs.writeFileSync(path.join(dir, HOSTS_SYNC_WARNING_MARKER_FILE), message, { mode: 0o644 });
+  } catch {
+    // Best-effort; the daemon's own log still has the failure.
+  }
+}
+
+/**
+ * Read and clear a pending hosts-sync-warning marker, if any. Reading is
+ * destructive (one-shot) so the same failure is not reported to the user
+ * more than once across separate CLI invocations.
+ */
+export function consumeHostsSyncWarningMarker(dir: string): string | null {
+  const markerPath = path.join(dir, HOSTS_SYNC_WARNING_MARKER_FILE);
+  try {
+    const message = fs.readFileSync(markerPath, "utf-8");
+    fs.unlinkSync(markerPath);
+    return message || null;
+  } catch {
+    return null;
   }
 }
 

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -314,60 +314,101 @@ export function writeLanMarker(dir: string, ip: string | null): void {
   }
 }
 
-/** Marker file recording an unreported hosts-sync failure, written by the daemon. */
-const HOSTS_SYNC_WARNING_MARKER_FILE = "proxy.hosts-sync-warning";
+/** Status file recording the outcome of the daemon's last hosts sync. */
+const HOSTS_SYNC_STATUS_FILE = "proxy.hosts-sync-status";
 
-/**
- * Record a hosts-sync failure so a CLI process attached to the user's
- * terminal can surface it later. The sync itself, and the warn-once latch
- * that gates it, run inside the detached proxy daemon (its stdio is
- * redirected to proxy.log, see the `spawn(...)` in `doProxyStart`), so the
- * daemon writing a warning to its own log is invisible to the user. This
- * marker is the only channel back to a process the user can actually see.
- */
-export function writeHostsSyncWarningMarker(dir: string, message: string): void {
-  try {
-    fs.writeFileSync(path.join(dir, HOSTS_SYNC_WARNING_MARKER_FILE), message, { mode: 0o644 });
-  } catch {
-    // Best-effort; the daemon's own log still has the failure.
-  }
+/** Outcome of one hosts-file sync performed by the daemon. */
+export interface HostsSyncStatus {
+  /** Whether the sync wrote the hosts file. */
+  ok: boolean;
+  /** User-facing warning when `ok` is false. */
+  message: string | null;
+  /** Hostnames the sync tried to write, so a CLI can tell whether its own route was covered. */
+  hostnames: string[];
+  /** `Date.now()` when the sync finished, so a CLI can ignore outcomes older than its own route change. */
+  at: number;
 }
 
 /**
- * Read and clear a pending hosts-sync-warning marker, if any. Reading is
- * destructive (one-shot) so the same failure is not reported to the user
- * more than once across separate CLI invocations.
+ * Publish the outcome of a hosts sync so a CLI process attached to the
+ * user's terminal can report it. The sync runs inside the detached proxy
+ * daemon, whose stdio is redirected to proxy.log (see the `spawn(...)` in
+ * `doProxyStart`), so a warning printed there never reaches the user.
+ *
+ * Written on every sync, success included, and never consumed by the
+ * reader: the file is current state, not a one-shot message. A one-shot
+ * marker had three failure modes this avoids — a second attached app found
+ * the warning already consumed by the first, a marker outlived the failure
+ * it described and resurfaced on an unrelated command, and two concurrent
+ * readers raced for the same message. The stamp (`at`) and `hostnames` are
+ * what let a reader decide whether an outcome is its own.
+ *
+ * The write is atomic (temp file plus rename) so a reader never observes a
+ * half-written file.
  */
-export function consumeHostsSyncWarningMarker(dir: string): string | null {
-  const markerPath = path.join(dir, HOSTS_SYNC_WARNING_MARKER_FILE);
+export function writeHostsSyncStatus(dir: string, status: HostsSyncStatus): void {
+  const target = path.join(dir, HOSTS_SYNC_STATUS_FILE);
+  const tmp = `${target}.${process.pid}.tmp`;
   try {
-    const message = fs.readFileSync(markerPath, "utf-8");
-    fs.unlinkSync(markerPath);
-    return message || null;
+    fs.writeFileSync(tmp, JSON.stringify(status), { mode: 0o644 });
+    fs.renameSync(tmp, target);
+  } catch {
+    // Best-effort; the daemon's own log still has the failure.
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      // Nothing to clean up.
+    }
+  }
+}
+
+/** Read the last published hosts-sync outcome. Non-destructive. */
+export function readHostsSyncStatus(dir: string): HostsSyncStatus | null {
+  try {
+    const parsed: unknown = JSON.parse(
+      fs.readFileSync(path.join(dir, HOSTS_SYNC_STATUS_FILE), "utf-8")
+    );
+    if (!parsed || typeof parsed !== "object") return null;
+    const status = parsed as Partial<HostsSyncStatus>;
+    if (typeof status.ok !== "boolean" || typeof status.at !== "number") return null;
+    return {
+      ok: status.ok,
+      message: typeof status.message === "string" ? status.message : null,
+      hostnames: Array.isArray(status.hostnames) ? status.hostnames : [],
+      at: status.at,
+    };
   } catch {
     return null;
   }
 }
 
 /**
- * Poll for a pending hosts-sync-warning marker instead of checking once
- * after a fixed delay. The daemon writes the marker asynchronously (it
- * reloads routes.json on a debounce, then syncs, then writes), so a single
- * fixed-delay check either wastes time waiting when the marker is already
- * there, or misses it entirely when the daemon is slower than expected
- * (e.g. under load, or a slow hosts-file write). Polling returns as soon as
- * the marker appears, and gives up after `ceilingMs` so callers on the
- * happy path (no failure) never wait longer than that ceiling.
+ * Wait for the daemon to publish the outcome of a sync that covers this
+ * caller's own route change, and return it (or null at the ceiling).
+ *
+ * Two conditions make an outcome "mine": it is stamped no earlier than the
+ * moment the caller wrote its route (`since`), and it covers every hostname
+ * the caller registered. Without both, a CLI reports an outcome that belongs
+ * to a different route change, or to a failure that has since been fixed.
+ *
+ * `ceilingMs` is the caller's business, but it must be derived from the
+ * daemon's own worst-case cadence: routes.json changes reach the daemon
+ * through fs.watch plus a debounce, and where fs.watch is unavailable the
+ * daemon falls back to a periodic poll. A ceiling under that poll interval
+ * expires before the daemon has even looked at the file.
  */
-export async function pollForHostsSyncWarningMarker(
+export async function waitForHostsSyncStatus(
   dir: string,
-  intervalMs = 50,
-  ceilingMs = 1500
-): Promise<string | null> {
+  options: { since: number; hostnames?: string[]; intervalMs?: number; ceilingMs: number }
+): Promise<HostsSyncStatus | null> {
+  const { since, hostnames = [], intervalMs = 50, ceilingMs } = options;
   const deadline = Date.now() + ceilingMs;
   while (true) {
-    const message = consumeHostsSyncWarningMarker(dir);
-    if (message) return message;
+    const status = readHostsSyncStatus(dir);
+    if (status && status.at >= since) {
+      const covered = hostnames.every((hostname) => status.hostnames.includes(hostname));
+      if (covered) return status;
+    }
     if (Date.now() >= deadline) return null;
     await new Promise((resolve) => setTimeout(resolve, intervalMs));
   }

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -8,7 +8,7 @@ import * as readline from "node:readline";
 import { execSync, spawn } from "node:child_process";
 import { PORTLESS_HEADER } from "./proxy.js";
 import { syncHostsFile } from "./hosts.js";
-import { createLoopbackConnection, resolveUserHome } from "./utils.js";
+import { createLoopbackConnection, isProcessAlive, resolveUserHome } from "./utils.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -380,6 +380,30 @@ export function readHostsSyncStatus(dir: string): HostsSyncStatus | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Whether a daemon is alive to publish a hosts-sync outcome at all.
+ *
+ * Every wait for an outcome is a wait on the daemon: it is the only process
+ * that publishes one. When no daemon is running there is no producer, so the
+ * wait cannot end early and burns its full ceiling before returning null.
+ * Registering an alias before starting the proxy is an ordinary flow, so that
+ * ceiling would land on a routine command.
+ *
+ * A missing or unparseable PID file, or a PID no longer alive, all mean the
+ * same thing here: nobody will publish.
+ */
+export function hasLiveHostsSyncPublisher(pidPath: string): boolean {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(pidPath, "utf-8").trim();
+  } catch {
+    return false;
+  }
+  const pid = parseInt(raw, 10);
+  if (isNaN(pid) || pid <= 0) return false;
+  return isProcessAlive(pid);
 }
 
 /**

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -315,10 +315,43 @@ export function writeLanMarker(dir: string, ip: string | null): void {
 }
 
 /** Status file recording the outcome of the daemon's last hosts sync. */
-const HOSTS_SYNC_STATUS_FILE = "proxy.hosts-sync-status";
+export const HOSTS_SYNC_STATUS_FILE = "proxy.hosts-sync-status";
+
+/**
+ * Schema this build writes and understands.
+ *
+ * An absent file already answers "the daemon predates publishing". This answers
+ * the case absence cannot: a daemon from a *newer* build whose record this one
+ * would misread. Unsupported becomes a statement rather than an inference, and
+ * a reader that does not recognize the version declines instead of guessing.
+ */
+export const HOSTS_SYNC_PROTOCOL = 1;
+
+/**
+ * Path of the temporary file an atomic status write renames from.
+ *
+ * Exported because cleanup must match exactly what the writer creates. A PID in
+ * the name means no static allowlist can enumerate these, so the writer and the
+ * remover have to share one definition of the rule or they drift apart in the
+ * one direction nothing tests: the writer works and the remover is unaware.
+ */
+export function hostsSyncStatusTempPath(dir: string, pid: number): string {
+  return path.join(dir, `${HOSTS_SYNC_STATUS_FILE}.${pid}.tmp`);
+}
+
+/** Whether a directory entry is a temporary file left by an interrupted status write. */
+export function isHostsSyncStatusTemp(entry: string): boolean {
+  return (
+    entry.startsWith(`${HOSTS_SYNC_STATUS_FILE}.`) &&
+    entry.endsWith(".tmp") &&
+    /^\d+$/.test(entry.slice(HOSTS_SYNC_STATUS_FILE.length + 1, -".tmp".length))
+  );
+}
 
 /** Outcome of one hosts-file sync performed by the daemon. */
 export interface HostsSyncStatus {
+  /** Schema of this record; a reader that does not support it must decline the record. */
+  protocol: number;
   /** Whether the sync wrote the hosts file. */
   ok: boolean;
   /** User-facing warning when `ok` is false. */
@@ -327,6 +360,14 @@ export interface HostsSyncStatus {
   hostnames: string[];
   /** `Date.now()` when the sync finished, so a CLI can ignore outcomes older than its own route change. */
   at: number;
+  /** The publishing daemon's PID, so a reader can tell this record from one left by a previous daemon. */
+  pid: number;
+  /**
+   * Whether that daemon syncs the hosts file at all. It is the daemon's answer,
+   * not the reader's: a CLI's own PORTLESS_SYNC_HOSTS describes the environment
+   * the CLI was started in, which the daemon may never have seen.
+   */
+  autoSync: boolean;
 }
 
 /**
@@ -348,7 +389,7 @@ export interface HostsSyncStatus {
  */
 export function writeHostsSyncStatus(dir: string, status: HostsSyncStatus): void {
   const target = path.join(dir, HOSTS_SYNC_STATUS_FILE);
-  const tmp = `${target}.${process.pid}.tmp`;
+  const tmp = hostsSyncStatusTempPath(dir, process.pid);
   try {
     fs.writeFileSync(tmp, JSON.stringify(status), { mode: 0o644 });
     fs.renameSync(tmp, target);
@@ -371,11 +412,17 @@ export function readHostsSyncStatus(dir: string): HostsSyncStatus | null {
     if (!parsed || typeof parsed !== "object") return null;
     const status = parsed as Partial<HostsSyncStatus>;
     if (typeof status.ok !== "boolean" || typeof status.at !== "number") return null;
+    // A record this build cannot read is the same answer as no record: decline
+    // rather than interpret fields that may have moved.
+    if (status.protocol !== HOSTS_SYNC_PROTOCOL) return null;
     return {
+      protocol: HOSTS_SYNC_PROTOCOL,
       ok: status.ok,
       message: typeof status.message === "string" ? status.message : null,
       hostnames: Array.isArray(status.hostnames) ? status.hostnames : [],
       at: status.at,
+      pid: typeof status.pid === "number" ? status.pid : 0,
+      autoSync: status.autoSync !== false,
     };
   } catch {
     return null;
@@ -383,27 +430,45 @@ export function readHostsSyncStatus(dir: string): HostsSyncStatus | null {
 }
 
 /**
- * Whether a daemon is alive to publish a hosts-sync outcome at all.
+ * The running daemon's own declaration that it publishes hosts-sync outcomes,
+ * and whether it syncs at all. Null means nobody will publish, so a caller
+ * must not wait.
  *
  * Every wait for an outcome is a wait on the daemon: it is the only process
- * that publishes one. When no daemon is running there is no producer, so the
- * wait cannot end early and burns its full ceiling before returning null.
- * Registering an alias before starting the proxy is an ordinary flow, so that
- * ceiling would land on a routine command.
+ * that publishes one. When nobody will publish, the wait cannot end early and
+ * burns its full ceiling before returning the same empty answer it could have
+ * returned immediately.
  *
- * A missing or unparseable PID file, or a PID no longer alive, all mean the
- * same thing here: nobody will publish.
+ * A live PID is not enough to answer this. A daemon can be running, correct,
+ * and mute in two ordinary ways:
+ *
+ *   1. It predates the publishing side. The moment this feature ships, the
+ *      daemon already running is the older build by definition, so the upgrade
+ *      path is the first one users take and the only one the branch cannot
+ *      test against itself. Such a daemon never writes the status file, so its
+ *      absence is the answer.
+ *   2. It was started with syncing disabled. Only the daemon knows that: it
+ *      inherited its environment at spawn time, possibly hours earlier and
+ *      from another shell. A CLI reading its own PORTLESS_SYNC_HOSTS is
+ *      describing an environment the daemon never saw.
+ *
+ * The PID cross-check is what separates a live publisher from a record left by
+ * a previous daemon: the record must name the PID that `proxy.pid` currently
+ * names, and that process must still be alive.
  */
-export function hasLiveHostsSyncPublisher(pidPath: string): boolean {
+export function readHostsSyncPublisher(dir: string, pidPath: string): { autoSync: boolean } | null {
+  const status = readHostsSyncStatus(dir);
+  if (!status || status.pid <= 0) return null;
   let raw: string;
   try {
     raw = fs.readFileSync(pidPath, "utf-8").trim();
   } catch {
-    return false;
+    return null;
   }
   const pid = parseInt(raw, 10);
-  if (isNaN(pid) || pid <= 0) return false;
-  return isProcessAlive(pid);
+  if (isNaN(pid) || pid <= 0 || pid !== status.pid) return null;
+  if (!isProcessAlive(pid)) return null;
+  return { autoSync: status.autoSync };
 }
 
 /**

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -77,6 +77,7 @@ import {
   resolveStateDir,
   spawnCommand,
   augmentedPath,
+  syncHostsWithWarning,
   waitForProxy,
   writeCustomCertMarker,
   writeLanMarker,
@@ -577,6 +578,16 @@ function startProxyServer(
 
   const autoSyncHosts = shouldAutoSyncHosts(process.env.PORTLESS_SYNC_HOSTS);
 
+  // Warn once when an auto-sync cannot write the hosts file (e.g. an
+  // unprivileged proxy on a high port); a later successful sync re-arms it.
+  let hostsSyncWarned = false;
+  const warnHostsSyncFailed = () =>
+    console.warn(
+      colors.yellow(
+        `Could not write ${HOSTS_DISPLAY}; hostnames may not resolve. Run: portless hosts sync`
+      )
+    );
+
   const onMdnsError = (msg: string) => console.warn(chalk.yellow(msg));
 
   const publishCachedRoutes = () => {
@@ -612,7 +623,11 @@ function startProxyServer(
       const previousRoutes = new Map(cachedRoutes.map((r) => [r.hostname, r.port]));
       cachedRoutes = store.loadRoutes();
       if (autoSyncHosts) {
-        syncHostsFile(cachedRoutes.map((r) => r.hostname));
+        hostsSyncWarned = syncHostsWithWarning(
+          cachedRoutes.map((r) => r.hostname),
+          hostsSyncWarned,
+          warnHostsSyncFailed
+        );
       }
       // Sync mDNS records with current routes
       if (activeLanIp) {
@@ -649,7 +664,11 @@ function startProxyServer(
   }
 
   if (autoSyncHosts) {
-    syncHostsFile(cachedRoutes.map((r) => r.hostname));
+    hostsSyncWarned = syncHostsWithWarning(
+      cachedRoutes.map((r) => r.hostname),
+      hostsSyncWarned,
+      warnHostsSyncFailed
+    );
   }
 
   // Publish mDNS for routes that already exist at startup
@@ -1917,7 +1936,8 @@ ${colors.bold("Safari / DNS:")}
   .localhost subdomains auto-resolve in Chrome, Firefox, and Edge.
   Safari relies on the system DNS resolver, which may not handle them.
   Auto-syncs ${HOSTS_DISPLAY} for route hostnames by default (including .localhost,
-  custom TLDs, and LAN .local). Set PORTLESS_SYNC_HOSTS=0 to disable. To manually sync:
+  custom TLDs, and LAN .local). Set PORTLESS_SYNC_HOSTS=0 to disable. If the file
+  is not writable, it warns once instead of failing silently. To sync manually:
     ${colors.cyan("portless hosts sync")}
   Clean up later with:
     ${colors.cyan("portless hosts clean")}

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -80,6 +80,7 @@ import {
   syncHostsWithWarning,
   writeHostsSyncWarningMarker,
   consumeHostsSyncWarningMarker,
+  pollForHostsSyncWarningMarker,
   waitForProxy,
   writeCustomCertMarker,
   writeLanMarker,
@@ -531,19 +532,32 @@ function removeRoutes(store: RouteStore, hostnames: readonly string[], ownerPid?
   }
 }
 
-/** Debounce delay used by the daemon before it reloads routes.json on change. */
-const HOSTS_SYNC_MARKER_WAIT_MS = DEBOUNCE_MS + 100;
+/**
+ * Ceiling for how long a CLI-attached process waits for the daemon to write
+ * a hosts-sync-warning marker after a route change, before giving up.
+ * Generous relative to the daemon's own debounce (DEBOUNCE_MS) plus the
+ * sync itself, so a slow daemon still gets its warning surfaced instead of
+ * silently losing it to a single too-early check.
+ */
+const HOSTS_SYNC_MARKER_POLL_CEILING_MS = 1500;
 
 /**
  * Surface a pending hosts-sync-failure marker (written by the daemon) on
  * this process's own stdio. Adding a route writes to routes.json, which the
- * daemon picks up asynchronously via fs.watch; wait past its debounce so a
- * sync triggered by the route we just added has had a chance to run and
- * write the marker before we check for it.
+ * daemon picks up asynchronously via fs.watch, debounces, and then syncs;
+ * poll for the marker rather than checking once after a fixed delay, so a
+ * slower-than-usual daemon still gets its warning surfaced instead of the
+ * warning being silently lost. On the happy path (no failure) this costs at
+ * most the poll ceiling and never blocks the caller's own return to the
+ * caller — invoke it without awaiting (`void reportHostsSyncWarningAfterRouteChange(...)`)
+ * so it never delays the primary flow (e.g. dev server startup output).
  */
 async function reportHostsSyncWarningAfterRouteChange(store: RouteStore): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, HOSTS_SYNC_MARKER_WAIT_MS));
-  const message = consumeHostsSyncWarningMarker(store.dir);
+  const message = await pollForHostsSyncWarningMarker(
+    store.dir,
+    50,
+    HOSTS_SYNC_MARKER_POLL_CEILING_MS
+  );
   if (message) console.warn(colors.yellow(message));
 }
 
@@ -2365,6 +2379,11 @@ ${colors.bold("Examples:")}
   const force = args.includes("--force");
   addRoutes(store, hostnames, port, 0, force);
   console.log(colors.green(`Alias registered: ${hostnames.join(", ")} -> 127.0.0.1:${port}`));
+  // Runs in this CLI-attached process, not the daemon; surface a resulting
+  // hosts-sync failure here instead of leaving it in the daemon's proxy.log.
+  // Awaited (rather than void'd) because this is a one-shot command whose
+  // process would otherwise exit before a slower daemon writes the marker.
+  await reportHostsSyncWarningAfterRouteChange(store);
 }
 
 async function handleHosts(args: string[]): Promise<void> {
@@ -3627,6 +3646,9 @@ async function spawnProxiedApp(
     displayUrl = url;
 
     addRoutes(store, hostnames, appPort, process.pid);
+    // Runs in this CLI-attached process (the turbo/multi-app orchestrator),
+    // not the daemon; void so a slow poll never delays spawning the child.
+    void reportHostsSyncWarningAfterRouteChange(store);
 
     env = {
       ...pkgEnv,
@@ -3883,6 +3905,9 @@ async function runWithTurbo(
 
     addRoutes(store, hostnames, appPort, process.pid);
     routes.push({ hostnames });
+    // Runs in this CLI-attached process (the turbo orchestrator), not the
+    // daemon; void so a slow poll never delays spawning turbo.
+    void reportHostsSyncWarningAfterRouteChange(store);
 
     const entry: ManifestEntry = {
       PORT: String(appPort),

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -78,6 +78,8 @@ import {
   spawnCommand,
   augmentedPath,
   syncHostsWithWarning,
+  writeHostsSyncWarningMarker,
+  consumeHostsSyncWarningMarker,
   waitForProxy,
   writeCustomCertMarker,
   writeLanMarker,
@@ -529,6 +531,22 @@ function removeRoutes(store: RouteStore, hostnames: readonly string[], ownerPid?
   }
 }
 
+/** Debounce delay used by the daemon before it reloads routes.json on change. */
+const HOSTS_SYNC_MARKER_WAIT_MS = DEBOUNCE_MS + 100;
+
+/**
+ * Surface a pending hosts-sync-failure marker (written by the daemon) on
+ * this process's own stdio. Adding a route writes to routes.json, which the
+ * daemon picks up asynchronously via fs.watch; wait past its debounce so a
+ * sync triggered by the route we just added has had a chance to run and
+ * write the marker before we check for it.
+ */
+async function reportHostsSyncWarningAfterRouteChange(store: RouteStore): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, HOSTS_SYNC_MARKER_WAIT_MS));
+  const message = consumeHostsSyncWarningMarker(store.dir);
+  if (message) console.warn(colors.yellow(message));
+}
+
 // ---------------------------------------------------------------------------
 // Proxy server lifecycle
 // ---------------------------------------------------------------------------
@@ -581,12 +599,16 @@ function startProxyServer(
   // Warn once when an auto-sync cannot write the hosts file (e.g. an
   // unprivileged proxy on a high port); a later successful sync re-arms it.
   let hostsSyncWarned = false;
-  const warnHostsSyncFailed = () =>
-    console.warn(
-      colors.yellow(
-        `Could not write ${HOSTS_DISPLAY}; hostnames may not resolve. Run: portless hosts sync`
-      )
-    );
+  const hostsSyncWarningMessage = `Could not write ${HOSTS_DISPLAY}; hostnames may not resolve. Run: portless hosts sync`;
+  const warnHostsSyncFailed = () => {
+    // This runs inside the detached daemon; its stdio is redirected to
+    // proxy.log (see the `spawn(...)` call in doProxyStart), so console.warn
+    // here only reaches the log file, never the user's terminal. Write a
+    // marker so a CLI process the user is actually attached to can surface
+    // this on its own stdio (see consumeHostsSyncWarningMarker callers).
+    console.warn(colors.yellow(hostsSyncWarningMessage));
+    writeHostsSyncWarningMarker(store.dir, hostsSyncWarningMessage);
+  };
 
   const onMdnsError = (msg: string) => console.warn(chalk.yellow(msg));
 
@@ -1317,6 +1339,10 @@ async function runApp(
     }
     throw err;
   }
+  // The daemon syncs /etc/hosts asynchronously in reaction to the route we
+  // just registered; check for a resulting failure so it reaches this
+  // terminal instead of only the daemon's proxy.log.
+  void reportHostsSyncWarningAfterRouteChange(store);
   if (killedPids.length > 0) {
     console.log(colors.yellow(`Killed existing process(es): ${killedPids.join(", ")}`));
   }
@@ -3377,6 +3403,12 @@ ${colors.bold("LAN mode (--lan):")}
 
   const proto = useHttps ? "HTTPS/2" : "HTTP";
   console.log(chalk.green(`${proto} proxy started on port ${proxyPort}`));
+  // The daemon may have already hit a hosts-sync failure during its own
+  // startup (before it started listening); surface it here, on this
+  // process's stdio, since the daemon's own console.warn only reached
+  // proxy.log.
+  const startupHostsSyncWarning = consumeHostsSyncWarningMarker(store.dir);
+  if (startupHostsSyncWarning) console.warn(colors.yellow(startupHostsSyncWarning));
   if (lanMode && lanIp) {
     console.log(chalk.green(`LAN mode active. IP: ${lanIp}`));
     console.log(chalk.gray("Services will be discoverable as <name>.local on your network."));

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -78,9 +78,8 @@ import {
   spawnCommand,
   augmentedPath,
   syncHostsWithWarning,
-  writeHostsSyncWarningMarker,
-  consumeHostsSyncWarningMarker,
-  pollForHostsSyncWarningMarker,
+  writeHostsSyncStatus,
+  waitForHostsSyncStatus,
   waitForProxy,
   writeCustomCertMarker,
   writeLanMarker,
@@ -533,32 +532,40 @@ function removeRoutes(store: RouteStore, hostnames: readonly string[], ownerPid?
 }
 
 /**
- * Ceiling for how long a CLI-attached process waits for the daemon to write
- * a hosts-sync-warning marker after a route change, before giving up.
- * Generous relative to the daemon's own debounce (DEBOUNCE_MS) plus the
- * sync itself, so a slow daemon still gets its warning surfaced instead of
- * silently losing it to a single too-early check.
+ * Ceiling for how long a CLI-attached process waits for the daemon to
+ * publish the outcome of the sync triggered by its route change.
+ *
+ * Derived from the daemon's own worst-case cadence rather than picked: a
+ * route change reaches the daemon through fs.watch plus DEBOUNCE_MS, and
+ * where fs.watch is unavailable the daemon only notices on its next
+ * POLL_INTERVAL_MS tick. A ceiling below that interval expires before the
+ * daemon has looked at routes.json at all. The extra second covers the
+ * hosts-file write itself on a loaded machine.
  */
-const HOSTS_SYNC_MARKER_POLL_CEILING_MS = 1500;
+const HOSTS_SYNC_STATUS_WAIT_CEILING_MS = DEBOUNCE_MS + POLL_INTERVAL_MS + 1000;
 
 /**
- * Surface a pending hosts-sync-failure marker (written by the daemon) on
- * this process's own stdio. Adding a route writes to routes.json, which the
- * daemon picks up asynchronously via fs.watch, debounces, and then syncs;
- * poll for the marker rather than checking once after a fixed delay, so a
- * slower-than-usual daemon still gets its warning surfaced instead of the
- * warning being silently lost. On the happy path (no failure) this costs at
- * most the poll ceiling and never blocks the caller's own return to the
- * caller — invoke it without awaiting (`void reportHostsSyncWarningAfterRouteChange(...)`)
- * so it never delays the primary flow (e.g. dev server startup output).
+ * Report the outcome of the hosts sync triggered by a route this process
+ * just registered, on this process's own stdio. The sync runs in the
+ * detached daemon, whose warnings only reach proxy.log.
+ *
+ * Returns as soon as the daemon publishes an outcome covering these
+ * hostnames, so the happy path costs one debounce, not the full ceiling.
+ * When auto-sync is disabled there is no outcome to wait for and this
+ * returns immediately.
  */
-async function reportHostsSyncWarningAfterRouteChange(store: RouteStore): Promise<void> {
-  const message = await pollForHostsSyncWarningMarker(
-    store.dir,
-    50,
-    HOSTS_SYNC_MARKER_POLL_CEILING_MS
-  );
-  if (message) console.warn(colors.yellow(message));
+async function reportHostsSyncAfterRouteChange(
+  store: RouteStore,
+  hostnames: string[],
+  since: number
+): Promise<void> {
+  if (!shouldAutoSyncHosts(process.env.PORTLESS_SYNC_HOSTS)) return;
+  const status = await waitForHostsSyncStatus(store.dir, {
+    since,
+    hostnames,
+    ceilingMs: HOSTS_SYNC_STATUS_WAIT_CEILING_MS,
+  });
+  if (status && !status.ok && status.message) console.warn(colors.yellow(status.message));
 }
 
 // ---------------------------------------------------------------------------
@@ -617,11 +624,34 @@ function startProxyServer(
   const warnHostsSyncFailed = () => {
     // This runs inside the detached daemon; its stdio is redirected to
     // proxy.log (see the `spawn(...)` call in doProxyStart), so console.warn
-    // here only reaches the log file, never the user's terminal. Write a
-    // marker so a CLI process the user is actually attached to can surface
-    // this on its own stdio (see consumeHostsSyncWarningMarker callers).
+    // here only reaches the log file, never the user's terminal. The latch
+    // keeps that log from filling up on repeated reloads.
     console.warn(colors.yellow(hostsSyncWarningMessage));
-    writeHostsSyncWarningMarker(store.dir, hostsSyncWarningMessage);
+  };
+
+  /**
+   * Sync the hosts file and publish the outcome for CLI-attached processes.
+   *
+   * The publish is deliberately outside the warn-once latch: the latch is
+   * per-daemon and delivery is per-CLI-process, so latching the publish too
+   * would mean only the first attached app ever learns about a failure that
+   * affects every app registered afterwards. Each CLI reads the outcome for
+   * its own route change, so publishing every time cannot spam anyone.
+   */
+  const syncHostsAndPublish = (hostnames: string[]): boolean => {
+    const ok = syncHostsFile(hostnames);
+    // An empty sync (the warm-up at startup, or all routes removed) has no
+    // route for any CLI to be waiting on; publishing it would only let a
+    // reader mistake it for the outcome of its own change.
+    if (hostnames.length > 0) {
+      writeHostsSyncStatus(store.dir, {
+        ok,
+        message: ok ? null : hostsSyncWarningMessage,
+        hostnames,
+        at: Date.now(),
+      });
+    }
+    return ok;
   };
 
   const onMdnsError = (msg: string) => console.warn(chalk.yellow(msg));
@@ -662,7 +692,8 @@ function startProxyServer(
         hostsSyncWarned = syncHostsWithWarning(
           cachedRoutes.map((r) => r.hostname),
           hostsSyncWarned,
-          warnHostsSyncFailed
+          warnHostsSyncFailed,
+          syncHostsAndPublish
         );
       }
       // Sync mDNS records with current routes
@@ -703,7 +734,8 @@ function startProxyServer(
     hostsSyncWarned = syncHostsWithWarning(
       cachedRoutes.map((r) => r.hostname),
       hostsSyncWarned,
-      warnHostsSyncFailed
+      warnHostsSyncFailed,
+      syncHostsAndPublish
     );
   }
 
@@ -1344,6 +1376,7 @@ async function runApp(
 
   // Register route (--force kills the existing owner if any)
   let killedPids: number[] = [];
+  const routeChangeAt = Date.now();
   try {
     killedPids = addRoutes(store, hostnames, port, process.pid, force);
   } catch (err) {
@@ -1354,9 +1387,10 @@ async function runApp(
     throw err;
   }
   // The daemon syncs /etc/hosts asynchronously in reaction to the route we
-  // just registered; check for a resulting failure so it reaches this
-  // terminal instead of only the daemon's proxy.log.
-  void reportHostsSyncWarningAfterRouteChange(store);
+  // just registered; report the outcome here so it reaches this terminal
+  // instead of only the daemon's proxy.log. Not awaited: the dev server must
+  // not wait on it.
+  void reportHostsSyncAfterRouteChange(store, hostnames, routeChangeAt);
   if (killedPids.length > 0) {
     console.log(colors.yellow(`Killed existing process(es): ${killedPids.join(", ")}`));
   }
@@ -2377,13 +2411,15 @@ ${colors.bold("Examples:")}
   }
 
   const force = args.includes("--force");
+  const routeChangeAt = Date.now();
   addRoutes(store, hostnames, port, 0, force);
   console.log(colors.green(`Alias registered: ${hostnames.join(", ")} -> 127.0.0.1:${port}`));
   // Runs in this CLI-attached process, not the daemon; surface a resulting
   // hosts-sync failure here instead of leaving it in the daemon's proxy.log.
-  // Awaited (rather than void'd) because this is a one-shot command whose
-  // process would otherwise exit before a slower daemon writes the marker.
-  await reportHostsSyncWarningAfterRouteChange(store);
+  // Awaited (rather than void'd) because this one-shot command would
+  // otherwise exit before the daemon publishes the outcome. It returns as
+  // soon as that outcome lands, so a successful sync costs one debounce.
+  await reportHostsSyncAfterRouteChange(store, hostnames, routeChangeAt);
 }
 
 async function handleHosts(args: string[]): Promise<void> {
@@ -2400,7 +2436,8 @@ ${colors.bold("Usage:")}
 
 ${colors.bold("Auto-sync:")}
   The proxy updates ${HOSTS_DISPLAY} for route hostnames by default. Disable with
-  PORTLESS_SYNC_HOSTS=0.
+  PORTLESS_SYNC_HOSTS=0. If the file is not writable, the terminal that
+  registered the route warns instead of failing silently.
 `);
     process.exit(0);
   }
@@ -3367,6 +3404,10 @@ ${colors.bold("LAN mode (--lan):")}
 
   // Daemon mode (default): fork and detach, logging to file
   store.ensureDir();
+  // Stamped before the daemon exists so any hosts-sync outcome it publishes
+  // is newer than this moment, and an outcome left over from a previous
+  // daemon is ignored.
+  let daemonStartAt = Date.now();
   const logPath = path.join(stateDir, "proxy.log");
   const logFd = fs.openSync(logPath, "a");
   try {
@@ -3377,6 +3418,7 @@ ${colors.bold("LAN mode (--lan):")}
     }
     fixOwnership(logPath);
 
+    daemonStartAt = Date.now();
     const daemonArgs = [
       getEntryScript(),
       "proxy",
@@ -3422,12 +3464,14 @@ ${colors.bold("LAN mode (--lan):")}
 
   const proto = useHttps ? "HTTPS/2" : "HTTP";
   console.log(chalk.green(`${proto} proxy started on port ${proxyPort}`));
-  // The daemon may have already hit a hosts-sync failure during its own
-  // startup (before it started listening); surface it here, on this
-  // process's stdio, since the daemon's own console.warn only reached
-  // proxy.log.
-  const startupHostsSyncWarning = consumeHostsSyncWarningMarker(store.dir);
-  if (startupHostsSyncWarning) console.warn(colors.yellow(startupHostsSyncWarning));
+  // The daemon syncs the routes that were already persisted when it started;
+  // report the outcome here, on this process's stdio, since the daemon's own
+  // console.warn only reached proxy.log. With no persisted routes there is no
+  // sync to wait for.
+  const persistedHostnames = store.loadRoutes().map((route) => route.hostname);
+  if (persistedHostnames.length > 0) {
+    await reportHostsSyncAfterRouteChange(store, persistedHostnames, daemonStartAt);
+  }
   if (lanMode && lanIp) {
     console.log(chalk.green(`LAN mode active. IP: ${lanIp}`));
     console.log(chalk.gray("Services will be discoverable as <name>.local on your network."));
@@ -3645,10 +3689,11 @@ async function spawnProxiedApp(
     const url = urls[0]!;
     displayUrl = url;
 
+    const routeChangeAt = Date.now();
     addRoutes(store, hostnames, appPort, process.pid);
     // Runs in this CLI-attached process (the turbo/multi-app orchestrator),
-    // not the daemon; void so a slow poll never delays spawning the child.
-    void reportHostsSyncWarningAfterRouteChange(store);
+    // not the daemon; void so a slow wait never delays spawning the child.
+    void reportHostsSyncAfterRouteChange(store, hostnames, routeChangeAt);
 
     env = {
       ...pkgEnv,
@@ -3903,11 +3948,12 @@ async function runWithTurbo(
     const url = urls[0]!;
     appUrls.push({ label: app.label, url });
 
+    const routeChangeAt = Date.now();
     addRoutes(store, hostnames, appPort, process.pid);
     routes.push({ hostnames });
     // Runs in this CLI-attached process (the turbo orchestrator), not the
-    // daemon; void so a slow poll never delays spawning turbo.
-    void reportHostsSyncWarningAfterRouteChange(store);
+    // daemon; void so a slow wait never delays spawning turbo.
+    void reportHostsSyncAfterRouteChange(store, hostnames, routeChangeAt);
 
     const entry: ManifestEntry = {
       PORT: String(appPort),

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -77,6 +77,7 @@ import {
   resolveStateDir,
   spawnCommand,
   augmentedPath,
+  hasLiveHostsSyncPublisher,
   syncHostsWithWarning,
   writeHostsSyncStatus,
   waitForHostsSyncStatus,
@@ -551,8 +552,8 @@ const HOSTS_SYNC_STATUS_WAIT_CEILING_MS = DEBOUNCE_MS + POLL_INTERVAL_MS + 1000;
  *
  * Returns as soon as the daemon publishes an outcome covering these
  * hostnames, so the happy path costs one debounce, not the full ceiling.
- * When auto-sync is disabled there is no outcome to wait for and this
- * returns immediately.
+ * When auto-sync is disabled, or when no daemon is alive to publish an
+ * outcome, there is nothing to wait for and this returns immediately.
  */
 async function reportHostsSyncAfterRouteChange(
   store: RouteStore,
@@ -560,6 +561,7 @@ async function reportHostsSyncAfterRouteChange(
   since: number
 ): Promise<void> {
   if (!shouldAutoSyncHosts(process.env.PORTLESS_SYNC_HOSTS)) return;
+  if (!hasLiveHostsSyncPublisher(store.pidPath)) return;
   const status = await waitForHostsSyncStatus(store.dir, {
     since,
     hostnames,

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -77,7 +77,8 @@ import {
   resolveStateDir,
   spawnCommand,
   augmentedPath,
-  hasLiveHostsSyncPublisher,
+  HOSTS_SYNC_PROTOCOL,
+  readHostsSyncPublisher,
   syncHostsWithWarning,
   writeHostsSyncStatus,
   waitForHostsSyncStatus,
@@ -552,16 +553,21 @@ const HOSTS_SYNC_STATUS_WAIT_CEILING_MS = DEBOUNCE_MS + POLL_INTERVAL_MS + 1000;
  *
  * Returns as soon as the daemon publishes an outcome covering these
  * hostnames, so the happy path costs one debounce, not the full ceiling.
- * When auto-sync is disabled, or when no daemon is alive to publish an
- * outcome, there is nothing to wait for and this returns immediately.
+ *
+ * Whether there is anything to wait for is the daemon's answer, read from the
+ * handshake it publishes at startup, never inferred here. This process's own
+ * PORTLESS_SYNC_HOSTS describes the shell this command was typed in; the
+ * daemon may have been started hours ago from another one. Inferring from it
+ * costs the full ceiling against a daemon that will never publish, and — the
+ * worse direction — throws away a real failure the daemon did publish.
  */
 async function reportHostsSyncAfterRouteChange(
   store: RouteStore,
   hostnames: string[],
   since: number
 ): Promise<void> {
-  if (!shouldAutoSyncHosts(process.env.PORTLESS_SYNC_HOSTS)) return;
-  if (!hasLiveHostsSyncPublisher(store.pidPath)) return;
+  const publisher = readHostsSyncPublisher(store.dir, store.pidPath);
+  if (!publisher || !publisher.autoSync) return;
   const status = await waitForHostsSyncStatus(store.dir, {
     since,
     hostnames,
@@ -647,10 +653,13 @@ function startProxyServer(
     // reader mistake it for the outcome of its own change.
     if (hostnames.length > 0) {
       writeHostsSyncStatus(store.dir, {
+        protocol: HOSTS_SYNC_PROTOCOL,
         ok,
         message: ok ? null : hostsSyncWarningMessage,
         hostnames,
         at: Date.now(),
+        pid: process.pid,
+        autoSync: autoSyncHosts,
       });
     }
     return ok;
@@ -840,6 +849,24 @@ function startProxyServer(
     // Save PID and port once the server is actually listening
     fs.writeFileSync(store.pidPath, process.pid.toString(), { mode: FILE_MODE });
     fs.writeFileSync(store.portFilePath, proxyPort.toString(), { mode: FILE_MODE });
+    // Handshake, written beside the PID it names: this daemon publishes
+    // hosts-sync outcomes, and here is whether it syncs at all. A CLI can
+    // infer neither. A daemon from a build older than this feature never
+    // writes the file, which is how its absence answers "nobody will publish";
+    // and the daemon's PORTLESS_SYNC_HOSTS is the one it was spawned with, not
+    // the one in the shell a later command was typed in.
+    //
+    // The empty `hostnames` keeps the handshake from ever being read as a sync
+    // outcome: a waiter requires its own hostnames covered, and none are.
+    writeHostsSyncStatus(store.dir, {
+      protocol: HOSTS_SYNC_PROTOCOL,
+      ok: true,
+      message: null,
+      hostnames: [],
+      at: Date.now(),
+      pid: process.pid,
+      autoSync: autoSyncHosts,
+    });
     writeTlsMarker(store.dir, isTls);
     writeCustomCertMarker(store.dir, isTls && customCert);
     writeTldsFile(store.dir, tlds);
@@ -2013,7 +2040,8 @@ ${colors.bold("Safari / DNS:")}
   Safari relies on the system DNS resolver, which may not handle them.
   Auto-syncs ${HOSTS_DISPLAY} for route hostnames by default (including .localhost,
   custom TLDs, and LAN .local). Set PORTLESS_SYNC_HOSTS=0 to disable. If the file
-  is not writable, it warns once instead of failing silently. To sync manually:
+  is not writable, the command that registered the route warns instead of
+  failing silently. To sync manually:
     ${colors.cyan("portless hosts sync")}
   Clean up later with:
     ${colors.cyan("portless hosts clean")}

--- a/packages/portless/src/hosts-sync-docs.test.ts
+++ b/packages/portless/src/hosts-sync-docs.test.ts
@@ -1,0 +1,45 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+// The hosts-sync failure warning is delivered per registering process: the
+// daemon's warn-once latch bounds its own proxy.log, while every CLI that
+// registers a route reads the published outcome for that route and prints it.
+// Both halves are deliberate and both are pinned by unit tests elsewhere (the
+// latch in cli-utils.test.ts, the non-destructive read in the status-file
+// suite).
+//
+// What went unpinned was the sentence describing them. Five surfaces said the
+// failure "warns once", which is true of the daemon log and false of the thing
+// a user sees; two successive registrations against one failing daemon print
+// two warnings. The claim survived three rewrites of these same files across
+// three review rounds, because docs review checked that the new sentence was
+// present and that its exception list was complete, never that it was true.
+//
+// This is the missing half: the wording is now a test. A future edit that
+// reintroduces the unscoped claim fails here rather than shipping.
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+
+const SURFACES = [
+  "README.md",
+  "skills/portless/SKILL.md",
+  "apps/docs/src/app/page.mdx",
+  "apps/docs/src/app/commands/page.mdx",
+  "packages/portless/src/cli.ts",
+];
+
+describe("hosts-sync failure wording", () => {
+  it.each(SURFACES)("%s does not claim the failure warns once", (surface) => {
+    const full = path.join(REPO_ROOT, surface);
+    // A surface that moved is a finding, not a skip: silence here would be the
+    // same false pass the claim itself enjoyed.
+    expect(fs.existsSync(full), `${surface} not found; update SURFACES`).toBe(true);
+    expect(fs.readFileSync(full, "utf-8")).not.toMatch(/warns once/i);
+  });
+
+  it.each(SURFACES)("%s attributes the warning to the registering command", (surface) => {
+    const text = fs.readFileSync(path.join(REPO_ROOT, surface), "utf-8");
+    expect(text).toMatch(/(command|terminal) that registered the route warns/i);
+  });
+});

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -408,7 +408,7 @@ portless hosts sync    # Adds current routes to /etc/hosts
 portless hosts clean   # Remove entries later
 ```
 
-Auto-syncs `/etc/hosts` for route hostnames by default. Set `PORTLESS_SYNC_HOSTS=0` to disable.
+Auto-syncs `/etc/hosts` for route hostnames by default. Set `PORTLESS_SYNC_HOSTS=0` to disable. If it cannot write the file, it warns once and points you to `portless hosts sync`.
 
 ### Browser shows certificate warning with --https
 

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -411,7 +411,7 @@ portless hosts sync    # Adds current routes to /etc/hosts
 portless hosts clean   # Remove entries later
 ```
 
-Auto-syncs `/etc/hosts` for route hostnames by default. Set `PORTLESS_SYNC_HOSTS=0` to disable. If it cannot write the file, it warns once and points you to `portless hosts sync`.
+Auto-syncs `/etc/hosts` for route hostnames by default. Set `PORTLESS_SYNC_HOSTS=0` to disable. If it cannot write the file, the command that registered the route warns and points you to `portless hosts sync`.
 
 ### Browser shows certificate warning with --https
 


### PR DESCRIPTION
Automatic hosts sync ignored the result of `syncHostsFile`, so an unprivileged
run registered a route, skipped the hosts block and said nothing. On resolvers
that do not handle multi-label `.localhost` (macOS, see #23) the app then fails
with `ENOTFOUND` and nothing points at the skipped sync.

## Fix

The sync runs in the detached daemon, whose output only reaches `proxy.log`, so
the failure has to cross a process boundary to reach the terminal that caused it.

- the daemon publishes every non-empty sync outcome to `proxy.hosts-sync-status`,
  stamped and carrying its hostnames, so each CLI reads the outcome for its own
  route change
- the daemon declares itself in the same file at startup: protocol version, PID
  and whether it syncs at all. A CLI waits only when a live daemon says it will
  publish, so an older daemon or one started with `PORTLESS_SYNC_HOSTS=0` costs
  nothing instead of the full timeout
- a CLI never reads its own `PORTLESS_SYNC_HOSTS` to decide what the daemon does
- an empty warm-up sync neither publishes nor spends the daemon's warn-once latch
- `portless clean` removes the status file and any temporary left by an
  interrupted atomic write

## Behavior

The daemon logs the failure once per failure episode. Each command that registers
a route is warned for its own registration, so two apps against the same failing
daemon are both told.

## Verify

- unprivileged `portless proxy start --port 1355 --no-tls`, then `portless myapp <cmd>`:
  the route registers, the warning prints, `/etc/hosts` is unchanged
- run the proxy elevated or `portless hosts sync`: the sync succeeds and nothing prints
- against a daemon from an older build, or one with syncing disabled, `portless alias`
  returns in under 0.1s instead of 4.1s
- `portless clean` leaves no `proxy.hosts-sync-status` behind

Fixes #364
