### PR TITLE
fix(proxy): prevent cold dev server loads from hanging

### DIFF
--- a/packages/portless/src/proxy.test.ts
+++ b/packages/portless/src/proxy.test.ts
@@ -634,6 +634,66 @@ describe("createProxyServer", () => {
     });
   });
 
+  describe("upstream connections", () => {
+    it("reuses one upstream connection across requests (issue #370)", async () => {
+      const connections = new Set<net.Socket>();
+      const backend = trackServer(http.createServer((_req, res) => res.end("ok")));
+      backend.on("connection", (socket) => connections.add(socket));
+      await listen(backend);
+      const backendAddr = backend.address();
+      if (!backendAddr || typeof backendAddr === "string") throw new Error("no addr");
+
+      const routes: RouteInfo[] = [{ hostname: "myapp.localhost", port: backendAddr.port }];
+      const server = trackServer(
+        createProxyServer({ getRoutes: () => routes, proxyPort: TEST_PROXY_PORT })
+      );
+      await listen(server);
+
+      for (let i = 0; i < 5; i++) {
+        expect((await request(server, { host: "myapp.localhost" })).status).toBe(200);
+      }
+      expect(connections.size).toBe(1);
+    });
+
+    it("replays a request when the backend resets a pooled connection", async () => {
+      // answer the first request on a connection then reset the next one, which
+      // is what an idle close looks like when it crosses our write
+      const handled = new WeakMap<net.Socket, number>();
+      let resets = 0;
+      const backend = trackServer(
+        http.createServer((req, res) => {
+          const count = (handled.get(req.socket) ?? 0) + 1;
+          handled.set(req.socket, count);
+          if (count === 1) return res.end("ok");
+          resets++;
+          req.socket.resetAndDestroy();
+        })
+      );
+      await listen(backend);
+      const backendAddr = backend.address();
+      if (!backendAddr || typeof backendAddr === "string") throw new Error("no addr");
+
+      const errors: string[] = [];
+      const routes: RouteInfo[] = [{ hostname: "myapp.localhost", port: backendAddr.port }];
+      const server = trackServer(
+        createProxyServer({
+          getRoutes: () => routes,
+          proxyPort: TEST_PROXY_PORT,
+          onError: (msg) => errors.push(msg),
+        })
+      );
+      await listen(server);
+
+      for (let i = 0; i < 4; i++) {
+        const res = await request(server, { host: "myapp.localhost" });
+        expect(res.status).toBe(200);
+        expect(res.body).toBe("ok");
+      }
+      expect(resets).toBeGreaterThan(0);
+      expect(errors).toEqual([]);
+    });
+  });
+
   describe("X-Portless header", () => {
     it("includes X-Portless header on 404 responses", async () => {
       const routes: RouteInfo[] = [];

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -28,6 +28,12 @@ const HOP_BY_HOP_HEADERS = new Set([
   "upgrade",
 ]);
 
+// http/2 doesn't limit connections per origin so without a cap a cold page
+// load overflows the backend accept backlog with simultaneous connects
+const MAX_UPSTREAM_SOCKETS = 64;
+
+const REPLAYABLE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
 /**
  * Get the effective host value from a request.
  * HTTP/2 uses the :authority pseudo-header; HTTP/1.1 uses Host.
@@ -162,7 +168,11 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
   const tldSuffixes = [...new Set(tlds.length > 0 ? tlds : [tld])].map((value) => `.${value}`);
   const primaryTldSuffix = tldSuffixes[0] ?? ".localhost";
 
-  const handleRequest = (req: http.IncomingMessage, res: http.ServerResponse) => {
+  const upstreamAgent = new http.Agent({ keepAlive: true, maxSockets: MAX_UPSTREAM_SOCKETS });
+  // Dial via createLoopbackConnection so ::1-only backends work too.
+  upstreamAgent.createConnection = (options) => createLoopbackConnection(options.port as number);
+
+  const handleRequest = (req: http.IncomingMessage, res: http.ServerResponse, isReplay = false) => {
     const reqTls = isEncrypted(req);
     res.setHeader(PORTLESS_HEADER, "1");
 
@@ -233,8 +243,9 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
     }
     proxyReqHeaders[PORTLESS_HOPS_HEADER] = String(hops + 1);
     // Remove HTTP/2 pseudo-headers before forwarding to HTTP/1.1 backend
+    // connection should go too, forwarding it would close the pooled socket
     for (const key of Object.keys(proxyReqHeaders)) {
-      if (key.startsWith(":")) {
+      if (key.startsWith(":") || key === "connection") {
         delete proxyReqHeaders[key];
       }
     }
@@ -247,8 +258,8 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
 
     const proxyReq = http.request(
       {
-        // Dial via createLoopbackConnection so ::1-only backends work too.
-        createConnection: () => createLoopbackConnection(route.port),
+        agent: upstreamAgent,
+        port: route.port,
         path: req.url,
         method: req.method,
         headers: proxyReqHeaders,
@@ -277,9 +288,22 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
     );
 
     proxyReq.on("error", (err) => {
+      const errWithCode = err as NodeJS.ErrnoException;
+      // backend closed the pooled socket as we yoinked it.
+      // replay once instead of a 502
+      if (
+        !isReplay &&
+        proxyReq.reusedSocket &&
+        errWithCode.code === "ECONNRESET" &&
+        !res.headersSent &&
+        REPLAYABLE_METHODS.has(req.method || "")
+      ) {
+        req.unpipe(proxyReq);
+        handleRequest(req, res, true);
+        return;
+      }
       onError(`Proxy error for ${getRequestHost(req)}: ${err.message}`);
       if (!res.headersSent) {
-        const errWithCode = err as NodeJS.ErrnoException;
         const detail =
           errWithCode.code === "ECONNREFUSED"
             ? "The target app is not responding. It may have crashed."
@@ -308,7 +332,11 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
       }
     });
 
-    req.pipe(proxyReq);
+    if (isReplay) {
+      proxyReq.end();
+    } else {
+      req.pipe(proxyReq);
+    }
   };
 
   const handleUpgrade = (req: http.IncomingMessage, socket: net.Socket, head: Buffer) => {
@@ -701,6 +729,7 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
     wrapper.close = function (cb?: (err?: Error) => void) {
       h2Server.close();
       plainServer.close();
+      upstreamAgent.destroy();
       return origClose(cb);
     } as typeof wrapper.close;
 
@@ -709,6 +738,7 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
 
   const httpServer = http.createServer(handleRequest);
   httpServer.on("upgrade", handleUpgrade);
+  httpServer.on("close", () => upstreamAgent.destroy());
 
   return httpServer;
 }

--- a/packages/portless/src/proxy.ts
+++ b/packages/portless/src/proxy.ts
@@ -296,7 +296,10 @@ export function createProxyServer(options: ProxyServerOptions): ProxyServer {
         proxyReq.reusedSocket &&
         errWithCode.code === "ECONNRESET" &&
         !res.headersSent &&
-        REPLAYABLE_METHODS.has(req.method || "")
+        REPLAYABLE_METHODS.has(req.method || "") &&
+        // the first pipe already ate the body so only replay when there wasn't one
+        !req.headers["transfer-encoding"] &&
+        !Number(req.headers["content-length"])
       ) {
         req.unpipe(proxyReq);
         handleRequest(req, res, true);


### PR DESCRIPTION
Cold loading a Vite app through Portless could stall or time out because every module request opened a fresh connection to the dev server.

This reuses and caps connections with a one time retry if a reused socket is reset.

Fixes #370