### PR TITLE
Prepare v0.15.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,23 @@
 # Changelog
 
-## 0.15.4
+## 0.15.5
 
 <!-- release:start -->
+
+### Bug Fixes
+
+- **Multi-segment custom TLDs**: `--tld` and `PORTLESS_TLD` now accept dotted DNS names such as `dev.example.com`, so local URLs can mirror production structure. `validateTld` checks per-label DNS rules and the 253-character total limit, overlapping TLDs resolve by longest match, and cert cache filenames stay under the filesystem name limit for long hostnames. (#365)
+- **WebSocket over HTTP/2**: Proxy now advertises RFC 8441 extended CONNECT and bridges `:protocol websocket` streams to an HTTP/1.1 upgrade against the backend, fixing dev server HMR for browsers that negotiate h2 over ALPN. Plain-HTTP upgrades on the TLS port are proxied instead of dropped, and a backend that rejects the handshake or answers with a bad `Sec-WebSocket-Accept` now gets a 502 instead of a silently destroyed socket. (#363)
+
+### Contributors
+
+- @Railly
+- @KingPsychopath
+- @erichurkman
+- @sanjevirau
+<!-- release:end -->
+
+## 0.15.4
 
 ### Bug Fixes
 
@@ -11,7 +26,6 @@
 ### Contributors
 
 - @ctate
-<!-- release:end -->
 
 ## 0.15.3
 

--- a/apps/docs/src/app/changelog/page.mdx
+++ b/apps/docs/src/app/changelog/page.mdx
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.15.5
+
+### Bug Fixes
+
+- **Multi-segment custom TLDs**: `--tld` and `PORTLESS_TLD` now accept dotted DNS names such as `dev.example.com`, so local URLs can mirror production structure. Validation checks per-label DNS rules and the 253-character total limit, and overlapping TLDs resolve by longest match
+- **WebSocket over HTTP/2**: Proxy now advertises RFC 8441 extended CONNECT and bridges WebSocket streams to an HTTP/1.1 upgrade against the backend, fixing dev server HMR for browsers that negotiate h2 over ALPN. Plain-HTTP upgrades on the TLS port are proxied instead of dropped
+
 ## 0.15.4
 
 ### Bug Fixes

--- a/packages/portless/package.json
+++ b/packages/portless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portless",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "description": "Replace port numbers with stable, named .localhost URLs. For humans and agents.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Patch release bundling the two fixes merged since v0.15.4.

### Included
- **Multi-segment custom TLDs** (#365) — `--tld dev.example.com` now validates and routes, so local URLs can mirror production structure (fixes #260)
- **WebSocket over HTTP/2** (#363) — RFC 8441 extended CONNECT bridged to an HTTP/1.1 upgrade, restoring dev server HMR for browsers that negotiate h2 over ALPN (fixes #281)

### Changes
- Bump `packages/portless/package.json` to `0.15.5`
- Add the `0.15.5` entry to `CHANGELOG.md` (wrapped in the release markers) and `apps/docs/src/app/changelog/page.mdx`

Contributors listed for this release are the PR authors plus the co-authors credited in the merged commits: @Railly, @KingPsychopath (#277 approach in #365), @erichurkman (#360 base for #363), @sanjevirau (#278 accept check in #363).

On merge, the release workflow detects the version change, publishes to npm with provenance, and creates the `v0.15.5` GitHub release from the changelog markers.