### PR TITLE
feat: Add flat worktree hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,14 @@ Use `--name` to override the inferred base name while keeping the worktree prefi
 portless run --name myapp next dev   # -> https://fix-ui.myapp.localhost
 ```
 
+Set `PORTLESS_WORKTREE_FLAT=1` when the hostname must fit a single-level wildcard
+certificate. It joins the worktree and app labels with hyphens:
+
+```bash
+PORTLESS_WORKTREE_FLAT=1 portless run next dev
+# -> https://fix-ui-myapp.localhost
+```
+
 Put `portless run` in your `package.json` once and it works everywhere. The main checkout uses the plain name, each worktree gets a unique subdomain. No collisions, no `--force`.
 
 ## Custom TLD
@@ -443,6 +451,7 @@ PORTLESS_LAN_IP=<address>        Pin a specific LAN IP for LAN mode
 PORTLESS_TLD=<tld>[,<tld>]       Use one or more TLDs (e.g. localhost,test)
 PORTLESS_WILDCARD=1              Allow unregistered subdomains to fall back to parent route
 PORTLESS_SYNC_HOSTS=0            Disable auto-sync of /etc/hosts (on by default)
+PORTLESS_WORKTREE_FLAT=1         Join worktree and app names into one DNS label
 PORTLESS_TAILSCALE=1             Share apps on your Tailscale network (same as --tailscale)
 PORTLESS_FUNNEL=1                Share apps publicly via Tailscale Funnel (same as --funnel)
 PORTLESS_NGROK=1                 Share apps publicly via ngrok (same as --ngrok)

--- a/packages/portless/src/auto.test.ts
+++ b/packages/portless/src/auto.test.ts
@@ -480,4 +480,20 @@ describe("applyWorktreePrefix", () => {
       "feature-x.api"
     );
   });
+
+  it("flattens every label for a single-level wildcard certificate", () => {
+    expect(
+      applyWorktreePrefix("web.json-render", { prefix: "feature-x", source: "git branch" }, true)
+    ).toBe("feature-x-web-json-render");
+  });
+
+  it("keeps a flat worktree name within one DNS label", () => {
+    const result = applyWorktreePrefix(
+      "very-long-application-name-that-would-overflow-a-dns-label",
+      { prefix: "very-long-feature-branch-name", source: "git branch" },
+      true
+    );
+    expect(result.length).toBeLessThanOrEqual(63);
+    expect(result).not.toContain(".");
+  });
 });

--- a/packages/portless/src/auto.ts
+++ b/packages/portless/src/auto.ts
@@ -160,13 +160,18 @@ export interface WorktreePrefix {
 }
 
 /**
- * Prepend a worktree prefix to a base hostname, or return the base name
- * unchanged when not in a worktree. Both single-app and multi-app modes
- * use this so a bare `portless` in a git worktree produces the same
- * `<prefix>.<name>` hostnames in either layout.
+ * Apply a worktree prefix to a base hostname, or return the base name
+ * unchanged when not in a worktree. With PORTLESS_WORKTREE_FLAT=1, all
+ * labels are joined into one DNS label for single-level wildcard certificates.
  */
-export function applyWorktreePrefix(baseName: string, worktree: WorktreePrefix | null): string {
-  return worktree ? `${worktree.prefix}.${baseName}` : baseName;
+export function applyWorktreePrefix(
+  baseName: string,
+  worktree: WorktreePrefix | null,
+  flat: boolean = process.env.PORTLESS_WORKTREE_FLAT === "1"
+): string {
+  if (!worktree) return baseName;
+  if (!flat) return `${worktree.prefix}.${baseName}`;
+  return truncateLabel(`${worktree.prefix}-${baseName.replace(/\./g, "-")}`);
 }
 
 /** Branch names that represent the default/primary checkout — no prefix needed. */

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1633,6 +1633,8 @@ ${colors.bold("Name inference (in order):")}
   Use --name to override the inferred name while keeping worktree prefixes.
   In git worktrees, the branch name is prepended as a subdomain prefix
   (e.g. feature-auth.myapp.localhost).
+  Set PORTLESS_WORKTREE_FLAT=1 to use one label instead
+  (e.g. feature-auth-myapp.localhost).
 
 ${colors.bold("Examples:")}
   portless run                        # Run dev script through proxy
@@ -1898,6 +1900,7 @@ ${colors.bold("Environment variables:")}
   PORTLESS_TLD=<tld>[,<tld>]    Use one or more TLDs (e.g. localhost,test,dev.example.com)
   PORTLESS_WILDCARD=1           Allow unregistered subdomains to fall back to parent route
   PORTLESS_SYNC_HOSTS=0         Disable auto-sync of ${HOSTS_DISPLAY} (on by default)
+  PORTLESS_WORKTREE_FLAT=1      Join worktree and app names into one DNS label
   PORTLESS_TAILSCALE=1          Share apps on your Tailscale network (same as --tailscale)
   PORTLESS_FUNNEL=1             Share apps publicly via Tailscale Funnel (same as --funnel)
   PORTLESS_NGROK=1              Share apps publicly via ngrok (same as --ngrok)
@@ -2246,7 +2249,7 @@ ${colors.bold("Examples:")}
 
   const name = positional[0];
   const worktree = skipWorktree ? null : detectWorktreePrefix();
-  const effectiveName = worktree ? `${worktree.prefix}.${name}` : name;
+  const effectiveName = applyWorktreePrefix(name, worktree);
 
   const { port, tls, tlds } = await discoverState();
   const hostname = buildHostnames(effectiveName, tlds)[0]!;
@@ -4057,7 +4060,7 @@ async function handleRunMode(args: string[], globalScript?: string): Promise<voi
   }
 
   const worktree = detectWorktreePrefix();
-  const effectiveName = worktree ? `${worktree.prefix}.${baseName}` : baseName;
+  const effectiveName = applyWorktreePrefix(baseName, worktree);
 
   const { dir, port, tls, tlds, lanMode, lanIp } = await discoverState();
   const store = new RouteStore(dir, {

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -147,6 +147,14 @@ portless run next dev   # -> https://fix-ui.myapp.localhost
 
 No config changes needed. Put `portless run` in `package.json` once and it works in all worktrees.
 
+Set `PORTLESS_WORKTREE_FLAT=1` to join the worktree and app labels with hyphens.
+This keeps the hostname inside one label for a single-level wildcard certificate:
+
+```bash
+PORTLESS_WORKTREE_FLAT=1 portless run next dev
+# -> https://fix-ui-myapp.localhost
+```
+
 ### Bypassing portless
 
 Set `PORTLESS=0` to run the command directly without the proxy:
@@ -177,21 +185,22 @@ Portless stores its state (routes, PID file, port file) in `~/.portless`. When t
 
 ### Environment variables
 
-| Variable              | Description                                                                    |
-| --------------------- | ------------------------------------------------------------------------------ |
-| `PORTLESS_PORT`       | Override the default proxy port (default: 443 with HTTPS, 80 without)          |
-| `PORTLESS_APP_PORT`   | Use a fixed port for the app (skip auto-assignment)                            |
-| `PORTLESS_HTTPS`      | HTTPS on by default; set to `0` to disable (same as `--no-tls`)                |
-| `PORTLESS_LAN`        | Set to `1` to always enable LAN mode (auto-detects LAN IP)                     |
-| `PORTLESS_LAN_IP`     | Pin a specific LAN IP for LAN mode                                             |
-| `PORTLESS_TLD`        | Use one or more TLDs, single or multi-segment (e.g. localhost,dev.example.com) |
-| `PORTLESS_WILDCARD`   | Set to `1` to allow unregistered subdomains to fall back to parent             |
-| `PORTLESS_SYNC_HOSTS` | Set to `0` to disable auto-sync of /etc/hosts (on by default)                  |
-| `PORTLESS_TAILSCALE`  | Set to `1` to share apps on your Tailscale network (same as `--tailscale`)     |
-| `PORTLESS_FUNNEL`     | Set to `1` to share apps publicly via Tailscale Funnel (same as `--funnel`)    |
-| `PORTLESS_NGROK`      | Set to `1` to share apps publicly via ngrok (same as `--ngrok`)                |
-| `PORTLESS_STATE_DIR`  | Override the state directory                                                   |
-| `PORTLESS=0`          | Bypass the proxy, run the command directly                                     |
+| Variable                 | Description                                                                    |
+| ------------------------ | ------------------------------------------------------------------------------ |
+| `PORTLESS_PORT`          | Override the default proxy port (default: 443 with HTTPS, 80 without)          |
+| `PORTLESS_APP_PORT`      | Use a fixed port for the app (skip auto-assignment)                            |
+| `PORTLESS_HTTPS`         | HTTPS on by default; set to `0` to disable (same as `--no-tls`)                |
+| `PORTLESS_LAN`           | Set to `1` to always enable LAN mode (auto-detects LAN IP)                     |
+| `PORTLESS_LAN_IP`        | Pin a specific LAN IP for LAN mode                                             |
+| `PORTLESS_TLD`           | Use one or more TLDs, single or multi-segment (e.g. localhost,dev.example.com) |
+| `PORTLESS_WILDCARD`      | Set to `1` to allow unregistered subdomains to fall back to parent             |
+| `PORTLESS_SYNC_HOSTS`    | Set to `0` to disable auto-sync of /etc/hosts (on by default)                  |
+| `PORTLESS_WORKTREE_FLAT` | Set to `1` to join worktree and app names into one DNS label                   |
+| `PORTLESS_TAILSCALE`     | Set to `1` to share apps on your Tailscale network (same as `--tailscale`)     |
+| `PORTLESS_FUNNEL`        | Set to `1` to share apps publicly via Tailscale Funnel (same as `--funnel`)    |
+| `PORTLESS_NGROK`         | Set to `1` to share apps publicly via ngrok (same as `--ngrok`)                |
+| `PORTLESS_STATE_DIR`     | Override the state directory                                                   |
+| `PORTLESS=0`             | Bypass the proxy, run the command directly                                     |
 
 ### HTTP/2 + HTTPS
 


### PR DESCRIPTION
A linked worktree currently adds another DNS label, so names such as `feature.myapp.dev.example.com` cannot use a single `*.dev.example.com` wildcard certificate.

This adds the opt-in `PORTLESS_WORKTREE_FLAT=1` mode. It joins the worktree prefix and all app-name labels with hyphens, then applies the existing collision-resistant 63-character truncation. The default subdomain behavior stays unchanged.

The same naming helper now covers `run`, default single/multi-app mode, and `get`. Tests cover multi-label flattening and DNS-label limits; README, CLI help, and the agent skill document the environment variable.

Verified with:
- `pnpm --filter portless exec vitest run src/auto.test.ts` (51 passing)
- `pnpm --filter portless type-check`
- `pnpm --filter portless build`
- targeted CLI help tests (2 passing)