### PR TITLE
fix(service): disable Windows task time limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
 
   ci-windows:
     runs-on: windows-latest
-    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v4
@@ -65,24 +64,6 @@ jobs:
       - run: pnpm build
 
       - run: pnpm test
-
-      - name: Download cuse
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          $PSNativeCommandUseErrorActionPreference = $true
-          Invoke-WebRequest `
-            -Uri "https://github.com/crafter-agents/cuse/releases/download/v0.1.0/cuse-windows-x64.exe" `
-            -OutFile "cuse.exe"
-          Invoke-WebRequest `
-            -Uri "https://github.com/crafter-agents/cuse/releases/download/v0.1.0/SHA256SUMS" `
-            -OutFile "SHA256SUMS"
-          $expected = (Select-String -Path SHA256SUMS -Pattern "cuse-windows-x64.exe").Line.Split()[0]
-          $actual = (Get-FileHash cuse.exe -Algorithm SHA256).Hash.ToLowerInvariant()
-          if ($actual -ne $expected) {
-            throw "cuse checksum mismatch: expected $expected, got $actual"
-          }
-          .\cuse.exe os --json
 
       - name: Install and verify the Windows service
         shell: pwsh
@@ -134,18 +115,6 @@ jobs:
 
           node packages/portless/dist/cli.js service status | Tee-Object service-status.txt
 
-      - name: Inspect Task Scheduler with cuse
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          $PSNativeCommandUseErrorActionPreference = $true
-          Start-Process mmc.exe -ArgumentList "$env:WINDIR\System32\taskschd.msc"
-          .\cuse.exe wait --window="Task Scheduler" --timeout=30000 --json
-          .\cuse.exe focus "Task Scheduler" --json
-          .\cuse.exe windows --json | Tee-Object cuse-windows.json
-          .\cuse.exe elements "Task Scheduler" --json | Tee-Object cuse-elements.json
-          .\cuse.exe capture task-scheduler.png --json
-
       - name: Upload Windows service evidence
         if: always()
         uses: actions/upload-artifact@v4
@@ -154,9 +123,6 @@ jobs:
           path: |
             portless-task.xml
             service-status.txt
-            cuse-windows.json
-            cuse-elements.json
-            task-scheduler.png
 
       - name: Uninstall Windows service
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
 
   ci-windows:
     runs-on: windows-latest
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v4
@@ -64,3 +65,95 @@ jobs:
       - run: pnpm build
 
       - run: pnpm test
+
+      - name: Download cuse
+        shell: pwsh
+        run: |
+          Invoke-WebRequest `
+            -Uri "https://github.com/crafter-agents/cuse/releases/download/v0.1.0/cuse-windows-x64.exe" `
+            -OutFile "cuse.exe"
+          Invoke-WebRequest `
+            -Uri "https://github.com/crafter-agents/cuse/releases/download/v0.1.0/SHA256SUMS" `
+            -OutFile "SHA256SUMS"
+          $expected = (Select-String -Path SHA256SUMS -Pattern "cuse-windows-x64.exe").Line.Split()[0]
+          $actual = (Get-FileHash cuse.exe -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actual -ne $expected) {
+            throw "cuse checksum mismatch: expected $expected, got $actual"
+          }
+          .\cuse.exe os --json
+
+      - name: Install and verify the Windows service
+        shell: pwsh
+        run: |
+          $stateDir = "C:\portless-ci-state"
+          node packages/portless/dist/cli.js service install `
+            --no-tls `
+            --port 18080 `
+            --state-dir $stateDir
+
+          $task = Get-ScheduledTask -TaskName "Portless Proxy"
+          if ($task.Settings.ExecutionTimeLimit -ne [TimeSpan]::Zero) {
+            throw "Expected zero execution time limit, got $($task.Settings.ExecutionTimeLimit)"
+          }
+          if ($task.Principal.UserId -notin @("SYSTEM", "S-1-5-18")) {
+            throw "Expected SYSTEM principal, got $($task.Principal.UserId)"
+          }
+          if ($task.Principal.RunLevel -ne "Highest") {
+            throw "Expected highest run level, got $($task.Principal.RunLevel)"
+          }
+          if (-not ($task.Triggers | Where-Object {
+            $_.CimClass.CimClassName -eq "MSFT_TaskBootTrigger"
+          })) {
+            throw "Expected a boot trigger"
+          }
+          if ($task.Actions.Execute -notmatch "(?i)cmd(\.exe)?$") {
+            throw "Expected cmd.exe action, got $($task.Actions.Execute)"
+          }
+
+          Export-ScheduledTask -TaskName "Portless Proxy" | Set-Content portless-task.xml
+          if ((Get-Content portless-task.xml -Raw) -notmatch "<ExecutionTimeLimit>PT0S</ExecutionTimeLimit>") {
+            throw "Exported task XML does not contain PT0S"
+          }
+
+          $listening = $false
+          for ($attempt = 0; $attempt -lt 20; $attempt++) {
+            if (Get-NetTCPConnection -LocalPort 18080 -State Listen -ErrorAction SilentlyContinue) {
+              $listening = $true
+              break
+            }
+            Start-Sleep -Milliseconds 500
+          }
+          if (-not $listening) {
+            schtasks /Query /TN "Portless Proxy" /FO LIST /V
+            throw "Portless service did not listen on port 18080"
+          }
+
+          node packages/portless/dist/cli.js service status | Tee-Object service-status.txt
+
+      - name: Inspect Task Scheduler with cuse
+        shell: pwsh
+        run: |
+          Start-Process mmc.exe -ArgumentList "$env:WINDIR\System32\taskschd.msc"
+          .\cuse.exe wait --window="Task Scheduler" --timeout=30000 --json
+          .\cuse.exe focus "Task Scheduler" --json
+          .\cuse.exe windows --json | Tee-Object cuse-windows.json
+          .\cuse.exe elements "Task Scheduler" --json | Tee-Object cuse-elements.json
+          .\cuse.exe capture task-scheduler.png --json
+
+      - name: Upload Windows service evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-service-evidence
+          path: |
+            portless-task.xml
+            service-status.txt
+            cuse-windows.json
+            cuse-elements.json
+            task-scheduler.png
+
+      - name: Uninstall Windows service
+        if: always()
+        shell: pwsh
+        run: |
+          node packages/portless/dist/cli.js service uninstall

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,8 @@ jobs:
       - name: Download cuse
         shell: pwsh
         run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
           Invoke-WebRequest `
             -Uri "https://github.com/crafter-agents/cuse/releases/download/v0.1.0/cuse-windows-x64.exe" `
             -OutFile "cuse.exe"
@@ -85,6 +87,8 @@ jobs:
       - name: Install and verify the Windows service
         shell: pwsh
         run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
           $stateDir = "C:\portless-ci-state"
           node packages/portless/dist/cli.js service install `
             --no-tls `
@@ -133,6 +137,8 @@ jobs:
       - name: Inspect Task Scheduler with cuse
         shell: pwsh
         run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
           Start-Process mmc.exe -ArgumentList "$env:WINDIR\System32\taskschd.msc"
           .\cuse.exe wait --window="Task Scheduler" --timeout=30000 --json
           .\cuse.exe focus "Task Scheduler" --json
@@ -156,4 +162,6 @@ jobs:
         if: always()
         shell: pwsh
         run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
           node packages/portless/dist/cli.js service uninstall

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
             --state-dir $stateDir
 
           $task = Get-ScheduledTask -TaskName "Portless Proxy"
-          if ($task.Settings.ExecutionTimeLimit -ne [TimeSpan]::Zero) {
+          if ([string]$task.Settings.ExecutionTimeLimit -ne "PT0S") {
             throw "Expected zero execution time limit, got $($task.Settings.ExecutionTimeLimit)"
           }
           if ($task.Principal.UserId -notin @("SYSTEM", "S-1-5-18")) {

--- a/packages/portless/src/service.test.ts
+++ b/packages/portless/src/service.test.ts
@@ -488,6 +488,7 @@ describe("handleService", () => {
     expect(runIndex).toBeGreaterThan(createIndex);
     expect(calls.some((call) => call.command === "powershell.exe")).toBe(false);
     expect(taskXmlWrite?.[1]).toContain("<ExecutionTimeLimit>PT0S</ExecutionTimeLimit>");
+    expect(taskXmlWrite?.[2]).toBe("utf16le");
   });
 
   it("does not start a Windows task when atomic registration fails", async () => {
@@ -699,6 +700,7 @@ describe("handleService", () => {
         String(content).includes("<ExecutionTimeLimit>PT0S</ExecutionTimeLimit>")
       )
     ).toBe(true);
+    expect(taskXmlWrites.every(([, , encoding]) => encoding === "utf16le")).toBe(true);
     expect(createCalls).toHaveLength(2);
     expect(createCalls.every(([, args]) => args.includes("/XML"))).toBe(true);
   });

--- a/packages/portless/src/service.test.ts
+++ b/packages/portless/src/service.test.ts
@@ -172,12 +172,24 @@ describe("buildServiceSpec", () => {
     expect(spec.platform).toBe("win32");
     if (spec.platform !== "win32") throw new Error("Expected Windows service spec");
     expect(spec.taskName).toBe("Portless Proxy");
-    expect(spec.createArgs).toContain("/SC");
-    expect(spec.createArgs).toContain("ONSTART");
-    expect(spec.createArgs).toContain("/RU");
-    expect(spec.createArgs).toContain("SYSTEM");
     expect(spec.scriptPath).toBe("C:\\ProgramData\\portless\\service\\portless-service.cmd");
-    expect(spec.taskRun).toBe('"C:\\ProgramData\\portless\\service\\portless-service.cmd"');
+    expect(spec.taskXmlPath).toBe("C:\\ProgramData\\portless\\service\\portless-task.xml");
+    expect(spec.createArgs).toEqual([
+      "/Create",
+      "/TN",
+      "Portless Proxy",
+      "/XML",
+      "C:\\ProgramData\\portless\\service\\portless-task.xml",
+      "/F",
+    ]);
+    expect(spec.taskXml).toContain("<BootTrigger>");
+    expect(spec.taskXml).toContain("<UserId>S-1-5-18</UserId>");
+    expect(spec.taskXml).toContain("<RunLevel>HighestAvailable</RunLevel>");
+    expect(spec.taskXml).toContain("<ExecutionTimeLimit>PT0S</ExecutionTimeLimit>");
+    expect(spec.taskXml).toContain("<Command>cmd.exe</Command>");
+    expect(spec.taskXml).toContain(
+      "<Arguments>/d /s /c &quot;&quot;C:\\ProgramData\\portless\\service\\portless-service.cmd&quot;&quot;</Arguments>"
+    );
     expect(spec.script).toContain("PORTLESS_STATE_DIR=C:\\Users\\Alice\\.portless");
     expect(spec.script).toContain('"C:\\Program Files\\nodejs\\node.exe"');
     expect(spec.script).toContain("proxy");
@@ -427,6 +439,268 @@ describe("handleService", () => {
     expect(writeFileSync).not.toHaveBeenCalled();
     const output = errorSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
     expect(output).toContain("LAN mode requires mDNS publishing");
+  });
+
+  it("registers the Windows task with no execution time limit before starting it", async () => {
+    setPlatform("win32");
+    const originalUserProfile = process.env.USERPROFILE;
+    const originalProgramData = process.env.ProgramData;
+    process.env.USERPROFILE = "C:\\Users\\Alice";
+    process.env.ProgramData = "C:\\ProgramData";
+    const runner = vi.fn((_: string, _args: string[]) => ({
+      status: 0,
+      stdout: "",
+      stderr: "",
+    }));
+
+    try {
+      await handleService(["service", "install"], {
+        entryScript: "C:\\cli.js",
+        runner,
+      });
+    } finally {
+      if (originalUserProfile === undefined) {
+        delete process.env.USERPROFILE;
+      } else {
+        process.env.USERPROFILE = originalUserProfile;
+      }
+      if (originalProgramData === undefined) {
+        delete process.env.ProgramData;
+      } else {
+        process.env.ProgramData = originalProgramData;
+      }
+    }
+
+    const calls = runner.mock.calls.map(([command, args]) => ({ command, args }));
+    const createIndex = calls.findIndex(
+      (call) => call.command === "schtasks" && call.args[0] === "/Create"
+    );
+    const runIndex = calls.findIndex(
+      (call) => call.command === "schtasks" && call.args[0] === "/Run"
+    );
+    const taskXmlWrite = vi
+      .mocked(writeFileSync)
+      .mock.calls.find(
+        ([file]) => file === "C:\\ProgramData\\portless\\service\\portless-task.xml"
+      );
+
+    expect(createIndex).toBeGreaterThanOrEqual(0);
+    expect(runIndex).toBeGreaterThan(createIndex);
+    expect(calls.some((call) => call.command === "powershell.exe")).toBe(false);
+    expect(taskXmlWrite?.[1]).toContain("<ExecutionTimeLimit>PT0S</ExecutionTimeLimit>");
+  });
+
+  it("does not start a Windows task when atomic registration fails", async () => {
+    setPlatform("win32");
+    const originalUserProfile = process.env.USERPROFILE;
+    const originalProgramData = process.env.ProgramData;
+    process.env.USERPROFILE = "C:\\Users\\Alice";
+    process.env.ProgramData = "C:\\ProgramData";
+    const runner = vi.fn((command: string, args: string[]) => ({
+      status: command === "schtasks" && args[0] === "/Create" ? 1 : 0,
+      stdout: "",
+      stderr: command === "schtasks" && args[0] === "/Create" ? "registration failed" : "",
+    }));
+
+    try {
+      await expect(
+        handleService(["service", "install"], {
+          entryScript: "C:\\cli.js",
+          runner,
+        })
+      ).rejects.toThrow("process.exit");
+    } finally {
+      if (originalUserProfile === undefined) {
+        delete process.env.USERPROFILE;
+      } else {
+        process.env.USERPROFILE = originalUserProfile;
+      }
+      if (originalProgramData === undefined) {
+        delete process.env.ProgramData;
+      } else {
+        process.env.ProgramData = originalProgramData;
+      }
+    }
+
+    const calls = runner.mock.calls.map(([command, args]) => ({ command, args }));
+    expect(calls.some((call) => call.command === "powershell.exe")).toBe(false);
+    expect(calls.some((call) => call.command === "schtasks" && call.args[0] === "/Run")).toBe(
+      false
+    );
+    expect(errorSpy.mock.calls.flat().join(" ")).toContain("registration failed");
+  });
+
+  it("does not stop the previous Windows task when replacement registration fails", async () => {
+    setPlatform("win32");
+    const originalUserProfile = process.env.USERPROFILE;
+    const originalProgramData = process.env.ProgramData;
+    process.env.USERPROFILE = "C:\\Users\\Alice";
+    process.env.ProgramData = "C:\\ProgramData";
+    const runner = vi.fn((command: string, args: string[]) => ({
+      status: command === "schtasks" && args[0] === "/Create" ? 1 : 0,
+      stdout: "",
+      stderr: command === "schtasks" && args[0] === "/Create" ? "registration failed" : "",
+    }));
+
+    try {
+      await expect(
+        handleService(["service", "install"], {
+          entryScript: "C:\\cli.js",
+          runner,
+        })
+      ).rejects.toThrow("process.exit");
+    } finally {
+      if (originalUserProfile === undefined) {
+        delete process.env.USERPROFILE;
+      } else {
+        process.env.USERPROFILE = originalUserProfile;
+      }
+      if (originalProgramData === undefined) {
+        delete process.env.ProgramData;
+      } else {
+        process.env.ProgramData = originalProgramData;
+      }
+    }
+
+    const taskCalls = runner.mock.calls
+      .filter(([command]) => command === "schtasks")
+      .map(([, args]) => args[0]);
+    expect(taskCalls).toEqual(["/Create"]);
+    expect(taskCalls).not.toContain("/Delete");
+    expect(
+      runner.mock.calls.some(
+        ([command, args]) =>
+          command === process.execPath && args.join(" ") === "C:\\cli.js proxy stop --port 443"
+      )
+    ).toBe(false);
+  });
+
+  it("keeps an atomically registered Windows task when immediate start fails", async () => {
+    setPlatform("win32");
+    const originalUserProfile = process.env.USERPROFILE;
+    const originalProgramData = process.env.ProgramData;
+    process.env.USERPROFILE = "C:\\Users\\Alice";
+    process.env.ProgramData = "C:\\ProgramData";
+    const runner = vi.fn((command: string, args: string[]) => ({
+      status: command === "schtasks" && args[0] === "/Run" ? 1 : 0,
+      stdout: "",
+      stderr: "",
+    }));
+
+    try {
+      await handleService(["service", "install"], {
+        entryScript: "C:\\cli.js",
+        runner,
+      });
+    } finally {
+      if (originalUserProfile === undefined) {
+        delete process.env.USERPROFILE;
+      } else {
+        process.env.USERPROFILE = originalUserProfile;
+      }
+      if (originalProgramData === undefined) {
+        delete process.env.ProgramData;
+      } else {
+        process.env.ProgramData = originalProgramData;
+      }
+    }
+
+    const calls = runner.mock.calls.map(([command, args]) => ({ command, args }));
+    expect(calls.some((call) => call.command === "schtasks" && call.args[0] === "/Create")).toBe(
+      true
+    );
+    expect(calls.some((call) => call.command === "schtasks" && call.args[0] === "/Delete")).toBe(
+      false
+    );
+    expect(logSpy.mock.calls.flat().join(" ")).toContain("Portless service installed.");
+  });
+
+  it("removes Windows service files even when no task was registered", async () => {
+    setPlatform("win32");
+    const originalUserProfile = process.env.USERPROFILE;
+    const originalProgramData = process.env.ProgramData;
+    process.env.USERPROFILE = "C:\\Users\\Alice";
+    process.env.ProgramData = "C:\\ProgramData";
+    const runner = vi.fn((_: string, _args: string[]) => ({
+      status: 1,
+      stdout: "",
+      stderr: "",
+    }));
+
+    try {
+      await handleService(["service", "uninstall"], {
+        entryScript: "C:\\cli.js",
+        runner,
+      });
+    } finally {
+      if (originalUserProfile === undefined) {
+        delete process.env.USERPROFILE;
+      } else {
+        process.env.USERPROFILE = originalUserProfile;
+      }
+      if (originalProgramData === undefined) {
+        delete process.env.ProgramData;
+      } else {
+        process.env.ProgramData = originalProgramData;
+      }
+    }
+
+    expect(rmSync).toHaveBeenCalledWith("C:\\ProgramData\\portless\\service", {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  it("repeated Windows installs always register the PT0S task definition", async () => {
+    setPlatform("win32");
+    const originalUserProfile = process.env.USERPROFILE;
+    const originalProgramData = process.env.ProgramData;
+    process.env.USERPROFILE = "C:\\Users\\Alice";
+    process.env.ProgramData = "C:\\ProgramData";
+    const runner = vi.fn((_: string, _args: string[]) => ({
+      status: 0,
+      stdout: "",
+      stderr: "",
+    }));
+
+    try {
+      await handleService(["service", "install"], {
+        entryScript: "C:\\cli.js",
+        runner,
+      });
+      await handleService(["service", "install"], {
+        entryScript: "C:\\cli.js",
+        runner,
+      });
+    } finally {
+      if (originalUserProfile === undefined) {
+        delete process.env.USERPROFILE;
+      } else {
+        process.env.USERPROFILE = originalUserProfile;
+      }
+      if (originalProgramData === undefined) {
+        delete process.env.ProgramData;
+      } else {
+        process.env.ProgramData = originalProgramData;
+      }
+    }
+
+    const taskXmlWrites = vi
+      .mocked(writeFileSync)
+      .mock.calls.filter(
+        ([file]) => file === "C:\\ProgramData\\portless\\service\\portless-task.xml"
+      );
+    const createCalls = runner.mock.calls.filter(
+      ([command, args]) => command === "schtasks" && args[0] === "/Create"
+    );
+    expect(taskXmlWrites).toHaveLength(2);
+    expect(
+      taskXmlWrites.every(([, content]) =>
+        String(content).includes("<ExecutionTimeLimit>PT0S</ExecutionTimeLimit>")
+      )
+    ).toBe(true);
+    expect(createCalls).toHaveLength(2);
+    expect(createCalls.every(([, args]) => args.includes("/XML"))).toBe(true);
   });
 
   it("stops an existing proxy before restarting the Linux service", async () => {

--- a/packages/portless/src/service.ts
+++ b/packages/portless/src/service.ts
@@ -521,7 +521,7 @@ function buildWindowsScript(ctx: ServiceContext, command: string[]): string {
 
 function buildWindowsTaskXml(scriptPath: string): string {
   const taskArguments = `/d /s /c "${windowsQuote(scriptPath)}"`;
-  return `<?xml version="1.0" encoding="UTF-8"?>
+  return `\uFEFF<?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.3" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
   <RegistrationInfo>
     <Description>Portless HTTPS proxy</Description>
@@ -1044,7 +1044,7 @@ async function installService(
   } else {
     fs.mkdirSync(spec.scriptDir, { recursive: true });
     fs.writeFileSync(spec.scriptPath, spec.script);
-    fs.writeFileSync(spec.taskXmlPath, spec.taskXml);
+    fs.writeFileSync(spec.taskXmlPath, spec.taskXml, "utf16le");
     runRequired(runner, "schtasks", spec.createArgs);
     runOptional(runner, "schtasks", ["/End", "/TN", spec.taskName]);
     await stopExistingProxy(entryScript, runner, spec.config.proxyPort);

--- a/packages/portless/src/service.ts
+++ b/packages/portless/src/service.ts
@@ -125,7 +125,8 @@ export type ServiceSpec =
       scriptDir: string;
       scriptPath: string;
       script: string;
-      taskRun: string;
+      taskXmlPath: string;
+      taskXml: string;
       createArgs: string[];
       runArgs: string[];
       deleteArgs: string[];
@@ -518,6 +519,49 @@ function buildWindowsScript(ctx: ServiceContext, command: string[]): string {
   return `@echo off\r\n${setEnv}\r\n${proxyCommand}\r\n`;
 }
 
+function buildWindowsTaskXml(scriptPath: string): string {
+  const taskArguments = `/d /s /c "${windowsQuote(scriptPath)}"`;
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<Task version="1.3" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Description>Portless HTTPS proxy</Description>
+  </RegistrationInfo>
+  <Triggers>
+    <BootTrigger>
+      <Enabled>true</Enabled>
+    </BootTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id="System">
+      <UserId>S-1-5-18</UserId>
+      <RunLevel>HighestAvailable</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <AllowStartOnDemand>true</AllowStartOnDemand>
+    <Enabled>true</Enabled>
+    <Hidden>false</Hidden>
+    <RunOnlyIfIdle>false</RunOnlyIfIdle>
+    <WakeToRun>false</WakeToRun>
+    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
+    <Priority>7</Priority>
+  </Settings>
+  <Actions Context="System">
+    <Exec>
+      <Command>cmd.exe</Command>
+      <Arguments>${xmlEscape(taskArguments)}</Arguments>
+    </Exec>
+  </Actions>
+</Task>
+`;
+}
+
 export function buildServiceSpec(options: {
   platform: SupportedPlatform;
   nodePath: string;
@@ -596,8 +640,9 @@ export function buildServiceSpec(options: {
 
   const scriptDir = path.win32.join(ctx.programData, "portless", "service");
   const scriptPath = path.win32.join(scriptDir, "portless-service.cmd");
+  const taskXmlPath = path.win32.join(scriptDir, "portless-task.xml");
   const script = buildWindowsScript(ctx, proxyCommand);
-  const taskRun = windowsQuote(scriptPath);
+  const taskXml = buildWindowsTaskXml(scriptPath);
   return {
     platform: "win32",
     taskName: WINDOWS_TASK_NAME,
@@ -606,21 +651,9 @@ export function buildServiceSpec(options: {
     scriptDir,
     scriptPath,
     script,
-    taskRun,
-    createArgs: [
-      "/Create",
-      "/TN",
-      WINDOWS_TASK_NAME,
-      "/SC",
-      "ONSTART",
-      "/RU",
-      "SYSTEM",
-      "/RL",
-      "HIGHEST",
-      "/TR",
-      taskRun,
-      "/F",
-    ],
+    taskXmlPath,
+    taskXml,
+    createArgs: ["/Create", "/TN", WINDOWS_TASK_NAME, "/XML", taskXmlPath, "/F"],
     runArgs: ["/Run", "/TN", WINDOWS_TASK_NAME],
     deleteArgs: ["/Delete", "/TN", WINDOWS_TASK_NAME, "/F"],
     queryArgs: ["/Query", "/TN", WINDOWS_TASK_NAME, "/FO", "LIST", "/V"],
@@ -1009,11 +1042,12 @@ async function installService(
     runRequired(runner, "systemctl", ["enable", spec.serviceName]);
     runRequired(runner, "systemctl", ["restart", spec.serviceName]);
   } else {
-    runOptional(runner, "schtasks", ["/End", "/TN", spec.taskName]);
-    await stopExistingProxy(entryScript, runner, spec.config.proxyPort);
     fs.mkdirSync(spec.scriptDir, { recursive: true });
     fs.writeFileSync(spec.scriptPath, spec.script);
+    fs.writeFileSync(spec.taskXmlPath, spec.taskXml);
     runRequired(runner, "schtasks", spec.createArgs);
+    runOptional(runner, "schtasks", ["/End", "/TN", spec.taskName]);
+    await stopExistingProxy(entryScript, runner, spec.config.proxyPort);
     runOptional(runner, "schtasks", spec.runArgs);
   }
 


### PR DESCRIPTION
## Summary

- register the Windows service from Task Scheduler XML with `ExecutionTimeLimit` set to `PT0S`
- write the task definition as UTF-16 so Task Scheduler can import it
- preserve the existing SYSTEM principal, boot trigger, highest run level, and immediate start behavior
- add Windows CI validation that installs the built service, verifies the registered task and listening proxy, and captures Task Scheduler evidence with cuse

## Validation

- 28 focused service tests pass
- full isolated suite: 754/754
- build, type-check, lint, formatting, and `git diff --check` pass
- mutation from `PT0S` back to `PT72H` breaks the intended regression tests
- Windows CI run `31641000991` passes on `windows-latest`
- exported task contains `PT0S`, SYSTEM, highest privileges, a boot trigger, and `cmd.exe`
- built service reports running and responding on port 18080
- cuse found and focused Task Scheduler, extracted its accessibility tree, and captured a screenshot artifact
- cleanup uninstalled the service successfully

Closes #378