### PR TITLE
fix: make routes.json writes atomic, add optional proxy-side stale-route sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ flowchart TD
 
 Outside LAN mode, the proxy and its HTTP redirect listener bind only to the IPv4 and IPv6 loopback addresses, `127.0.0.1` and `::1`. They do not accept connections through LAN, VPN, or other network interfaces.
 
+Each running app registers a route in `~/.portless/routes.json` and removes it on exit. If a client is killed with an uncatchable signal (e.g. an IDE's stop/debug action terminating a child process tree), that exit-time cleanup never runs and the route is left behind. The proxy already ignores routes whose process has died when serving traffic, and `portless prune` removes them from disk on demand. The proxy also sweeps `routes.json` for dead routes on its own every 300 seconds by default; tune it with `--routes-cleanup-interval <seconds>` (`0` disables the sweep).
+
 ## HTTP/2 + HTTPS
 
 HTTPS with HTTP/2 is enabled by default. Browsers limit HTTP/1.1 to 6 connections per host, which bottlenecks dev servers that serve many unbundled files (Vite, Nuxt, etc.). HTTP/2 multiplexes all requests over a single connection.
@@ -398,6 +400,7 @@ portless proxy start --lan       # Start in LAN mode (mDNS .local for devices)
 portless proxy start -p 1355     # Start on a custom port (no sudo)
 portless proxy start --foreground  # Start in foreground (for debugging)
 portless proxy start --wildcard  # Allow unregistered subdomains to fall back to parent
+portless proxy start --routes-cleanup-interval 60  # Sweep dead routes every 60s (default 300, 0 disables)
 portless proxy stop              # Stop the proxy
 
 # OS startup service
@@ -421,6 +424,7 @@ portless service uninstall       # Remove the startup service
 --foreground                     Run proxy in foreground instead of daemon
 --tld <tld>                      Use a custom TLD instead of .localhost; repeat for more
 --wildcard                       Allow unregistered subdomains to fall back to parent route
+--routes-cleanup-interval <sec>  Prune dead routes every <sec> seconds (default 300, 0 disables)
 --state-dir <path>               Use a custom state directory with service install
 --script <name>                  Run a specific package.json script (default: dev)
 --app-port <number>              Use a fixed port for the app (skip auto-assignment)
@@ -442,6 +446,7 @@ PORTLESS_LAN=1                   Enable LAN mode when set to 1 (auto-detects LAN
 PORTLESS_LAN_IP=<address>        Pin a specific LAN IP for LAN mode
 PORTLESS_TLD=<tld>[,<tld>]       Use one or more TLDs (e.g. localhost,test)
 PORTLESS_WILDCARD=1              Allow unregistered subdomains to fall back to parent route
+PORTLESS_ROUTES_CLEANUP_INTERVAL=<sec>  Prune dead routes every <sec> seconds (same as --routes-cleanup-interval)
 PORTLESS_SYNC_HOSTS=0            Disable auto-sync of /etc/hosts (on by default)
 PORTLESS_TAILSCALE=1             Share apps on your Tailscale network (same as --tailscale)
 PORTLESS_FUNNEL=1                Share apps publicly via Tailscale Funnel (same as --funnel)

--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -1727,6 +1727,36 @@ describe("buildProxyStartConfig", () => {
       args: ["--https", "--tld", "localhost", "--tld", "test"],
     });
   });
+
+  it("forwards the resolved routes-cleanup interval, including 0 to disable it", () => {
+    expect(
+      buildProxyStartConfig({
+        useHttps: false,
+        lanMode: false,
+        tld: "localhost",
+        routesCleanupIntervalSeconds: 60,
+      }).args
+    ).toEqual(["--no-tls", "--routes-cleanup-interval", "60"]);
+
+    expect(
+      buildProxyStartConfig({
+        useHttps: false,
+        lanMode: false,
+        tld: "localhost",
+        routesCleanupIntervalSeconds: 0,
+      }).args
+    ).toEqual(["--no-tls", "--routes-cleanup-interval", "0"]);
+  });
+
+  it("omits the flag when the interval is not specified", () => {
+    expect(
+      buildProxyStartConfig({
+        useHttps: false,
+        lanMode: false,
+        tld: "localhost",
+      }).args
+    ).toEqual(["--no-tls"]);
+  });
 });
 
 describe("readLanMarker / writeLanMarker", () => {

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -548,6 +548,7 @@ export function buildProxyStartConfig(options: {
   includePort?: boolean;
   proxyPort?: number;
   skipTrust?: boolean;
+  routesCleanupIntervalSeconds?: number;
 }): { effectiveTld: string; effectiveTlds: string[]; args: string[] } {
   const requestedTlds = options.tlds && options.tlds.length > 0 ? [...options.tlds] : [options.tld];
   const effectiveTlds = options.lanMode ? ["local"] : [...new Set(requestedTlds)];
@@ -593,6 +594,10 @@ export function buildProxyStartConfig(options: {
 
   if (options.skipTrust) {
     args.push("--skip-trust");
+  }
+
+  if (options.routesCleanupIntervalSeconds !== undefined) {
+    args.push("--routes-cleanup-interval", options.routesCleanupIntervalSeconds.toString());
   }
 
   return { effectiveTld, effectiveTlds, args };

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -1760,6 +1760,76 @@ describe("CLI", () => {
     });
   });
 
+  describe("--routes-cleanup-interval flag", () => {
+    let tmpDir: string;
+    let testPort: number;
+
+    const proxyEnv = () => ({
+      PORTLESS_PORT: String(testPort),
+      PORTLESS_HTTPS: "0",
+      PORTLESS_STATE_DIR: tmpDir,
+    });
+
+    beforeEach(async () => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-cleanup-interval-"));
+      testPort = await getFreePort();
+    });
+
+    afterEach(() => {
+      run(["proxy", "stop"], { env: proxyEnv() });
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("rejects a non-numeric value", () => {
+      const { status, stderr } = run(["proxy", "start", "--routes-cleanup-interval", "abc"], {
+        env: proxyEnv(),
+      });
+      expect(status).not.toBe(0);
+      expect(stderr).toContain("Invalid");
+    });
+
+    it("rejects a negative value", () => {
+      const { status, stderr } = run(["proxy", "start", "--routes-cleanup-interval", "-5"], {
+        env: proxyEnv(),
+      });
+      expect(status).not.toBe(0);
+      expect(stderr).toContain("Invalid");
+    });
+
+    it("accepts 0 to disable the sweep and still starts normally", () => {
+      const start = run(["proxy", "start", "--routes-cleanup-interval", "0"], {
+        env: proxyEnv(),
+      });
+      expect(start.status).toBe(0);
+      expect(start.stdout).toContain(`proxy started on port ${testPort}`);
+    });
+
+    it("prunes routes with dead PIDs on the background sweep, unlike a plain file-change reload", async () => {
+      const start = run(["proxy", "start", "--routes-cleanup-interval", "1"], {
+        env: proxyEnv(),
+      });
+      expect(start.status).toBe(0);
+
+      // Written directly (not via RouteStore) after the daemon is already up,
+      // so this exercises only the periodic sweep, not startup initialization.
+      const routesPath = path.join(tmpDir, "routes.json");
+      const deadPid = 999999;
+      fs.writeFileSync(
+        routesPath,
+        JSON.stringify([
+          { hostname: "dead.localhost", port: 4001, pid: deadPid },
+          { hostname: "alive.localhost", port: 4002, pid: process.pid },
+        ])
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 2500));
+
+      const raw = JSON.parse(fs.readFileSync(routesPath, "utf-8"));
+      expect(raw).toHaveLength(1);
+      expect(raw[0].hostname).toBe("alive.localhost");
+    }, 10_000);
+  });
+
   describe("HTTPS proxy with broken security binary (#228)", () => {
     let fakeBinDir: string;
     let tmpDir: string;

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -1760,6 +1760,109 @@ describe("CLI", () => {
     });
   });
 
+  describe("routes.json live reload across repeated atomic rewrites", () => {
+    let tmpDir: string;
+    let testPort: number;
+
+    const proxyEnv = () => ({
+      PORTLESS_PORT: String(testPort),
+      PORTLESS_HTTPS: "0",
+      PORTLESS_STATE_DIR: tmpDir,
+    });
+
+    beforeEach(async () => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-live-reload-"));
+      testPort = await getFreePort();
+    });
+
+    afterEach(() => {
+      run(["proxy", "stop"], { env: proxyEnv() });
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    // Mirrors RouteStore.saveRoutes(): write a temp file, then rename it over
+    // routes.json. Each call swaps in a fresh inode at that path.
+    function atomicWriteRoutes(routes: unknown[]): void {
+      const routesPath = path.join(tmpDir, "routes.json");
+      const tmpPath = path.join(tmpDir, `routes.json.tmp-${process.pid}-${routes.length}`);
+      fs.writeFileSync(tmpPath, JSON.stringify(routes));
+      fs.renameSync(tmpPath, routesPath);
+    }
+
+    function listen(server: http.Server): Promise<number> {
+      return new Promise((resolve) => {
+        server.listen(0, "127.0.0.1", () => {
+          resolve((server.address() as { port: number }).port);
+        });
+      });
+    }
+
+    function requestThroughProxy(hostname: string): Promise<number> {
+      return new Promise((resolve, reject) => {
+        const req = http.request(
+          { hostname: "127.0.0.1", port: testPort, headers: { host: hostname }, timeout: 1000 },
+          (res) => {
+            res.resume();
+            resolve(res.statusCode!);
+          }
+        );
+        req.on("error", reject);
+        req.on("timeout", () => {
+          req.destroy();
+          reject(new Error("request timed out"));
+        });
+        req.end();
+      });
+    }
+
+    async function waitForRouteStatus(hostname: string, expectedStatus: number): Promise<void> {
+      for (let i = 0; i < 50; i++) {
+        try {
+          if ((await requestThroughProxy(hostname)) === expectedStatus) return;
+        } catch {
+          // Backend or proxy not ready yet; retry.
+        }
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+      throw new Error(`Timed out waiting for ${hostname} to return ${expectedStatus}`);
+    }
+
+    it("picks up a route registered after routes.json was already atomically rewritten once", async () => {
+      // Regression test: fs.watch on routes.json's own path is bound to that
+      // inode. saveRoutes()'s rename-based write swaps the inode, so a watch
+      // on the file itself observes only the first such rewrite and silently
+      // stops firing after that — a second app's route would never become
+      // reachable. The proxy must watch the containing directory instead.
+      const start = run(["proxy", "start"], { env: proxyEnv() });
+      expect(start.status).toBe(0);
+
+      const backendA = http.createServer((_req, res) => res.end("A"));
+      const backendB = http.createServer((_req, res) => res.end("B"));
+      try {
+        const portA = await listen(backendA);
+        const portB = await listen(backendB);
+
+        // First atomic write: one route. This is the rewrite that a
+        // file-path watch would still catch.
+        atomicWriteRoutes([{ hostname: "a.localhost", port: portA, pid: process.pid }]);
+        await waitForRouteStatus("a.localhost", 200);
+
+        // Second atomic write: a new route added alongside the first. Without
+        // the directory-watch fix, the proxy never learns about b.localhost.
+        atomicWriteRoutes([
+          { hostname: "a.localhost", port: portA, pid: process.pid },
+          { hostname: "b.localhost", port: portB, pid: process.pid },
+        ]);
+        await waitForRouteStatus("b.localhost", 200);
+
+        expect(await requestThroughProxy("a.localhost")).toBe(200);
+      } finally {
+        await new Promise<void>((resolve) => backendA.close(() => resolve()));
+        await new Promise<void>((resolve) => backendB.close(() => resolve()));
+      }
+    }, 10_000);
+  });
+
   describe("--routes-cleanup-interval flag", () => {
     let tmpDir: string;
     let testPort: number;

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -138,6 +138,17 @@ const DEBOUNCE_MS = 100;
 /** Polling interval (ms) when fs.watch is unavailable. */
 const POLL_INTERVAL_MS = 3000;
 
+/**
+ * Default interval (seconds) for the proxy's background sweep that prunes
+ * routes whose owning process has died. This is a safety net, not the
+ * primary cleanup path: a client still removes its own route on a graceful
+ * exit. It exists because that exit-time cleanup can be skipped entirely
+ * (e.g. a client killed with SIGKILL by an IDE's stop/debug action never
+ * runs its handler). Five minutes bounds how long a dead route can linger
+ * without noticeably waking the process; 0 disables the sweep.
+ */
+const DEFAULT_ROUTES_CLEANUP_INTERVAL_SECONDS = 300;
+
 /** Grace period (ms) for connections to drain before force-exiting the proxy. */
 const EXIT_TIMEOUT_MS = 2000;
 
@@ -542,7 +553,8 @@ function startProxyServer(
   tlsOptions?: { cert: Buffer; key: Buffer },
   lanIp?: string | null,
   strict?: boolean,
-  customCert = false
+  customCert = false,
+  routesCleanupIntervalSeconds = DEFAULT_ROUTES_CLEANUP_INTERVAL_SECONDS
 ): void {
   store.ensureDir();
 
@@ -576,6 +588,7 @@ function startProxyServer(
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
   let watcher: fs.FSWatcher | null = null;
   let pollingInterval: ReturnType<typeof setInterval> | null = null;
+  let routesCleanupInterval: ReturnType<typeof setInterval> | null = null;
 
   const autoSyncHosts = shouldAutoSyncHosts(process.env.PORTLESS_SYNC_HOSTS);
 
@@ -648,6 +661,22 @@ function startProxyServer(
     // fs.watch may not be supported; fall back to periodic polling
     console.warn(colors.yellow("fs.watch unavailable; falling back to polling for route changes"));
     pollingInterval = setInterval(reloadRoutes, POLL_INTERVAL_MS);
+  }
+
+  // Background safety net: sweep routes.json for entries whose owning process
+  // has died, independent of the client's own exit-time cleanup (which can be
+  // skipped entirely if the client is killed with an uncatchable signal, e.g.
+  // an IDE's stop/debug action). This write goes through the same fs.watch
+  // path above, so reloadRoutes() reconciles the in-memory cache and mDNS
+  // records automatically. Disabled with --routes-cleanup-interval 0.
+  if (routesCleanupIntervalSeconds > 0) {
+    routesCleanupInterval = setInterval(() => {
+      try {
+        store.pruneStaleRoutes();
+      } catch {
+        // Best-effort background cleanup; non-fatal
+      }
+    }, routesCleanupIntervalSeconds * 1000).unref();
   }
 
   if (autoSyncHosts) {
@@ -790,6 +819,7 @@ function startProxyServer(
     exiting = true;
     if (debounceTimer) clearTimeout(debounceTimer);
     if (pollingInterval) clearInterval(pollingInterval);
+    if (routesCleanupInterval) clearInterval(routesCleanupInterval);
     if (lanMonitor) lanMonitor.stop();
     if (watcher) {
       watcher.close();
@@ -1117,6 +1147,7 @@ async function ensureProxyRunning(
     useWildcard: startConfig.useWildcard,
     includePort: startPort !== undefined,
     proxyPort: startPort,
+    routesCleanupIntervalSeconds: resolveRoutesCleanupIntervalSeconds([]),
   });
   const startArgs = [getEntryScript(), "proxy", "start", ...proxyStartConfig.args];
 
@@ -2836,6 +2867,39 @@ ${colors.bold("Options:")}
   console.log(colors.green(`Summary: 0 failures, ${pluralize(warnings, "warning")}.`));
 }
 
+/**
+ * Parse `--routes-cleanup-interval <seconds>`, falling back to
+ * PORTLESS_ROUTES_CLEANUP_INTERVAL, then the default. `0` disables the
+ * background sweep entirely.
+ */
+function resolveRoutesCleanupIntervalSeconds(args: string[]): number {
+  const flagIdx = args.indexOf("--routes-cleanup-interval");
+  let raw: string | undefined;
+  let source: string;
+  if (flagIdx !== -1) {
+    raw = args[flagIdx + 1];
+    source = "--routes-cleanup-interval";
+  } else if (process.env.PORTLESS_ROUTES_CLEANUP_INTERVAL !== undefined) {
+    raw = process.env.PORTLESS_ROUTES_CLEANUP_INTERVAL;
+    source = "PORTLESS_ROUTES_CLEANUP_INTERVAL";
+  } else {
+    return DEFAULT_ROUTES_CLEANUP_INTERVAL_SECONDS;
+  }
+
+  if (!raw || raw.startsWith("--")) {
+    console.error(colors.red("Error: --routes-cleanup-interval requires a number of seconds."));
+    process.exit(1);
+  }
+  const seconds = Number(raw);
+  if (!Number.isFinite(seconds) || !Number.isInteger(seconds) || seconds < 0) {
+    console.error(
+      colors.red(`Error: Invalid ${source}="${raw}". Must be a non-negative integer (0 disables).`)
+    );
+    process.exit(1);
+  }
+  return seconds;
+}
+
 async function handleProxy(args: string[]): Promise<void> {
   if (args[1] === "stop") {
     let explicitPort: number | undefined;
@@ -2881,6 +2945,7 @@ ${colors.bold("Usage:")}
   ${colors.cyan("portless proxy start --tld localhost --tld test")}  Serve both TLDs
   ${colors.cyan("portless proxy start --tld dev.example.com")}  Use a multi-segment TLD (production parity)
   ${colors.cyan("portless proxy start --wildcard")}     Allow unregistered subdomains to fall back to parent
+  ${colors.cyan("portless proxy start --routes-cleanup-interval 60")}  Sweep dead routes every 60s (default 300, 0 disables)
   ${colors.cyan("portless proxy stop")}                 Stop the proxy
 
 ${colors.bold("LAN mode (--lan):")}
@@ -2892,12 +2957,21 @@ ${colors.bold("LAN mode (--lan):")}
   --ip to pin one.
   Stopped LAN proxies keep LAN mode for the next start via proxy.lan.
   Use PORTLESS_LAN=0 for one start to switch back to .localhost mode.
+
+${colors.bold("Route cleanup (--routes-cleanup-interval):")}
+  A client removes its own route when it exits normally. This is a
+  background safety net for when that does not happen (e.g. a process
+  killed with SIGKILL, such as an IDE's stop/debug action terminating a
+  child process tree). The proxy periodically prunes routes whose owning
+  process is no longer alive. Defaults to every 300 seconds; set to 0 to
+  disable. Equivalent env var: PORTLESS_ROUTES_CLEANUP_INTERVAL.
 `);
     process.exit(isProxyHelp || !args[1] ? 0 : 1);
   }
 
   const isForeground = args.includes("--foreground");
   const skipTrust = args.includes("--skip-trust");
+  const routesCleanupIntervalSeconds = resolveRoutesCleanupIntervalSeconds(args);
 
   // HTTPS is on by default. Disable with --no-tls or PORTLESS_HTTPS=0.
   const hasHttpsFlag = args.includes("--https");
@@ -3167,6 +3241,7 @@ ${colors.bold("LAN mode (--lan):")}
         foreground: isForeground,
         includePort: true,
         proxyPort,
+        routesCleanupIntervalSeconds,
       }).args,
     ];
     const fallbackCommand = formatProxyStartCommand(FALLBACK_PROXY_PORT, resolvedConfig);
@@ -3313,7 +3388,8 @@ ${colors.bold("LAN mode (--lan):")}
       tlsOptions,
       lanIp,
       desiredWildcard ? false : undefined,
-      !!(customCertPath && customKeyPath)
+      !!(customCertPath && customKeyPath),
+      routesCleanupIntervalSeconds
     );
     return;
   }
@@ -3348,6 +3424,7 @@ ${colors.bold("LAN mode (--lan):")}
         includePort: true,
         proxyPort,
         skipTrust: true,
+        routesCleanupIntervalSeconds,
       }).args,
     ];
 

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -653,7 +653,17 @@ function startProxyServer(
   };
 
   try {
-    watcher = fs.watch(routesPath, () => {
+    // Watch the containing directory rather than routes.json itself. Since
+    // saveRoutes() now replaces the file via rename (for atomicity), each
+    // write swaps in a new inode at that path; a watch on the file itself is
+    // bound to the old inode and goes silent after the first such rename. A
+    // directory watch keys events off the filename instead, so it keeps
+    // firing across renames. `filename` is filtered defensively because a
+    // few platforms don't report it, in which case any change is treated as
+    // relevant (reloadRoutes() is cheap and debounced).
+    const routesFilename = path.basename(routesPath);
+    watcher = fs.watch(store.dir, (_eventType, filename) => {
+      if (filename && filename !== routesFilename) return;
       if (debounceTimer) clearTimeout(debounceTimer);
       debounceTimer = setTimeout(reloadRoutes, DEBOUNCE_MS);
     });

--- a/packages/portless/src/routes.test.ts
+++ b/packages/portless/src/routes.test.ts
@@ -155,6 +155,28 @@ describe("RouteStore", () => {
       s.addRoute("test.localhost", 4001, process.pid);
       expect(fs.existsSync(s.getRoutesPath())).toBe(true);
     });
+
+    it("leaves no temp file behind after a normal write", () => {
+      store.addRoute("test.localhost", 4123, process.pid);
+      const entries = fs.readdirSync(tmpDir);
+      expect(entries.filter((f) => f.includes(".tmp-"))).toHaveLength(0);
+    });
+
+    it("leaves the previous target and any temp file untouched when the rename fails", () => {
+      // Force the rename step to fail with a real OS-level error (renaming a
+      // file onto an existing directory is illegal) rather than mocking fs,
+      // so this exercises the actual failure path saveRoutes must handle.
+      store.ensureDir();
+      fs.mkdirSync(store.getRoutesPath());
+
+      expect(() => store.addRoute("new.localhost", 4002, process.pid)).toThrow();
+
+      // The directory standing in for the previous target is untouched...
+      expect(fs.statSync(store.getRoutesPath()).isDirectory()).toBe(true);
+      // ...and the failed attempt's temp file was cleaned up, not left behind.
+      const entries = fs.readdirSync(tmpDir);
+      expect(entries.filter((f) => f.includes(".tmp-"))).toHaveLength(0);
+    });
   });
 
   describe("addRoute", () => {

--- a/packages/portless/src/routes.ts
+++ b/packages/portless/src/routes.ts
@@ -208,8 +208,26 @@ export class RouteStore {
     }
   }
 
+  /**
+   * Write the routes file atomically: write to a temp file in the same
+   * directory, then rename over the target. A rename is a single filesystem
+   * operation, so a process killed at any point either leaves the previous
+   * routes.json intact or the new one fully written; there is no window where
+   * a reader can observe a truncated/corrupted file.
+   */
   private saveRoutes(routes: RouteMapping[]): void {
-    fs.writeFileSync(this.routesPath, JSON.stringify(routes, null, 2), { mode: FILE_MODE });
+    const tmpPath = path.join(this.dir, `routes.json.tmp-${process.pid}`);
+    try {
+      fs.writeFileSync(tmpPath, JSON.stringify(routes, null, 2), { mode: FILE_MODE });
+      fs.renameSync(tmpPath, this.routesPath);
+    } catch (err) {
+      try {
+        fs.rmSync(tmpPath, { force: true });
+      } catch {
+        // Best-effort cleanup; non-fatal
+      }
+      throw err;
+    }
     fixOwnership(this.routesPath);
   }
 

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -177,21 +177,22 @@ Portless stores its state (routes, PID file, port file) in `~/.portless`. When t
 
 ### Environment variables
 
-| Variable              | Description                                                                    |
-| --------------------- | ------------------------------------------------------------------------------ |
-| `PORTLESS_PORT`       | Override the default proxy port (default: 443 with HTTPS, 80 without)          |
-| `PORTLESS_APP_PORT`   | Use a fixed port for the app (skip auto-assignment)                            |
-| `PORTLESS_HTTPS`      | HTTPS on by default; set to `0` to disable (same as `--no-tls`)                |
-| `PORTLESS_LAN`        | Set to `1` to always enable LAN mode (auto-detects LAN IP)                     |
-| `PORTLESS_LAN_IP`     | Pin a specific LAN IP for LAN mode                                             |
-| `PORTLESS_TLD`        | Use one or more TLDs, single or multi-segment (e.g. localhost,dev.example.com) |
-| `PORTLESS_WILDCARD`   | Set to `1` to allow unregistered subdomains to fall back to parent             |
-| `PORTLESS_SYNC_HOSTS` | Set to `0` to disable auto-sync of /etc/hosts (on by default)                  |
-| `PORTLESS_TAILSCALE`  | Set to `1` to share apps on your Tailscale network (same as `--tailscale`)     |
-| `PORTLESS_FUNNEL`     | Set to `1` to share apps publicly via Tailscale Funnel (same as `--funnel`)    |
-| `PORTLESS_NGROK`      | Set to `1` to share apps publicly via ngrok (same as `--ngrok`)                |
-| `PORTLESS_STATE_DIR`  | Override the state directory                                                   |
-| `PORTLESS=0`          | Bypass the proxy, run the command directly                                     |
+| Variable                           | Description                                                                    |
+| ---------------------------------- | ------------------------------------------------------------------------------ |
+| `PORTLESS_PORT`                    | Override the default proxy port (default: 443 with HTTPS, 80 without)          |
+| `PORTLESS_APP_PORT`                | Use a fixed port for the app (skip auto-assignment)                            |
+| `PORTLESS_HTTPS`                   | HTTPS on by default; set to `0` to disable (same as `--no-tls`)                |
+| `PORTLESS_LAN`                     | Set to `1` to always enable LAN mode (auto-detects LAN IP)                     |
+| `PORTLESS_LAN_IP`                  | Pin a specific LAN IP for LAN mode                                             |
+| `PORTLESS_TLD`                     | Use one or more TLDs, single or multi-segment (e.g. localhost,dev.example.com) |
+| `PORTLESS_WILDCARD`                | Set to `1` to allow unregistered subdomains to fall back to parent             |
+| `PORTLESS_ROUTES_CLEANUP_INTERVAL` | Seconds between background dead-route sweeps (default 300; `0` disables)       |
+| `PORTLESS_SYNC_HOSTS`              | Set to `0` to disable auto-sync of /etc/hosts (on by default)                  |
+| `PORTLESS_TAILSCALE`               | Set to `1` to share apps on your Tailscale network (same as `--tailscale`)     |
+| `PORTLESS_FUNNEL`                  | Set to `1` to share apps publicly via Tailscale Funnel (same as `--funnel`)    |
+| `PORTLESS_NGROK`                   | Set to `1` to share apps publicly via ngrok (same as `--ngrok`)                |
+| `PORTLESS_STATE_DIR`               | Override the state directory                                                   |
+| `PORTLESS=0`                       | Bypass the proxy, run the command directly                                     |
 
 ### HTTP/2 + HTTPS
 
@@ -279,52 +280,53 @@ The chosen service configuration is written into launchd, systemd, or Task Sched
 
 ## CLI Reference
 
-| Command                                           | Description                                                    |
-| ------------------------------------------------- | -------------------------------------------------------------- |
-| `portless`                                        | Run dev script through proxy                                   |
-| `portless`                                        | From monorepo root: run all workspace packages                 |
-| `portless --script <name>`                        | Run a specific package.json script (default: dev)              |
-| `portless run [cmd] [args...]`                    | Infer name from project, run through proxy (auto-starts)       |
-| `portless run --name <name> <cmd>`                | Override inferred base name (worktree prefix still applies)    |
-| `portless <name> <cmd> [args...]`                 | Run app at `https://<name>.localhost` (auto-starts proxy)      |
-| `portless get <name>`                             | Print URL for a service (for cross-service wiring)             |
-| `portless get <name> --no-worktree`               | Print URL without worktree prefix                              |
-| `portless list`                                   | Show active routes                                             |
-| `portless doctor`                                 | Check proxy, routes, DNS, CA trust, and LAN prerequisites      |
-| `portless trust`                                  | Add local CA to system trust store (for HTTPS)                 |
-| `portless clean`                                  | Remove state, CA trust entry, and /etc/hosts block             |
-| `portless prune`                                  | Kill orphaned dev servers from crashed sessions                |
-| `portless prune --force`                          | Kill orphans with SIGKILL instead of SIGTERM                   |
-| `portless proxy start`                            | Start HTTPS proxy as a daemon (port 443, auto-elevates)        |
-| `portless proxy start --no-tls`                   | Start without HTTPS (plain HTTP on port 80)                    |
-| `portless proxy start --lan`                      | Start in LAN mode (mDNS `.local`, auto-follows LAN IP changes) |
-| `portless proxy start -p <number>`                | Start the proxy on a custom port                               |
-| `portless proxy start --tld test`                 | Use .test instead of .localhost                                |
-| `portless proxy start --tld localhost --tld test` | Serve both TLDs from one proxy                                 |
-| `portless proxy start --tld dev.example.com`      | Use a multi-segment TLD for production-parity URLs             |
-| `portless proxy start --foreground`               | Start the proxy in foreground (for debugging)                  |
-| `portless proxy start --wildcard`                 | Allow unregistered subdomains to fall back to parent route     |
-| `portless proxy stop`                             | Stop the proxy                                                 |
-| `portless service install`                        | Start the HTTPS proxy when the OS starts                       |
-| `portless service install --lan`                  | Start the service in LAN mode                                  |
-| `portless service install --wildcard`             | Persist wildcard routing in the startup service                |
-| `portless service status`                         | Show service and proxy status                                  |
-| `portless service uninstall`                      | Remove the startup service                                     |
-| `portless alias <name> <port>`                    | Register a static route (e.g. for Docker containers)           |
-| `portless alias <name> <port> --force`            | Overwrite an existing route                                    |
-| `portless alias --remove <name>`                  | Remove a static route                                          |
-| `portless hosts sync`                             | Add routes to /etc/hosts (fixes Safari)                        |
-| `portless hosts clean`                            | Remove portless entries from /etc/hosts                        |
-| `portless <name> --app-port <n> <cmd>`            | Use a fixed port for the app instead of auto-assignment        |
-| `portless <name> --tailscale <cmd>`               | Share the app on your Tailscale network (tailnet)              |
-| `portless <name> --funnel <cmd>`                  | Share the app publicly via Tailscale Funnel                    |
-| `portless <name> --ngrok <cmd>`                   | Share the app publicly via ngrok                               |
-| `portless <name> --force <cmd>`                   | Kill the existing process and take over its route              |
-| `portless --name <name> <cmd>`                    | Force `<name>` as app name (bypasses subcommand dispatch)      |
-| `portless <name> -- <cmd> [args...]`              | Stop flag parsing; everything after `--` is passed to child    |
-| `portless --help` / `-h`                          | Show help                                                      |
-| `portless run --help`                             | Show help for a subcommand (also: alias, hosts, clean)         |
-| `portless --version` / `-v`                       | Show version                                                   |
+| Command                                                | Description                                                         |
+| ------------------------------------------------------ | ------------------------------------------------------------------- |
+| `portless`                                             | Run dev script through proxy                                        |
+| `portless`                                             | From monorepo root: run all workspace packages                      |
+| `portless --script <name>`                             | Run a specific package.json script (default: dev)                   |
+| `portless run [cmd] [args...]`                         | Infer name from project, run through proxy (auto-starts)            |
+| `portless run --name <name> <cmd>`                     | Override inferred base name (worktree prefix still applies)         |
+| `portless <name> <cmd> [args...]`                      | Run app at `https://<name>.localhost` (auto-starts proxy)           |
+| `portless get <name>`                                  | Print URL for a service (for cross-service wiring)                  |
+| `portless get <name> --no-worktree`                    | Print URL without worktree prefix                                   |
+| `portless list`                                        | Show active routes                                                  |
+| `portless doctor`                                      | Check proxy, routes, DNS, CA trust, and LAN prerequisites           |
+| `portless trust`                                       | Add local CA to system trust store (for HTTPS)                      |
+| `portless clean`                                       | Remove state, CA trust entry, and /etc/hosts block                  |
+| `portless prune`                                       | Kill orphaned dev servers from crashed sessions                     |
+| `portless prune --force`                               | Kill orphans with SIGKILL instead of SIGTERM                        |
+| `portless proxy start`                                 | Start HTTPS proxy as a daemon (port 443, auto-elevates)             |
+| `portless proxy start --no-tls`                        | Start without HTTPS (plain HTTP on port 80)                         |
+| `portless proxy start --lan`                           | Start in LAN mode (mDNS `.local`, auto-follows LAN IP changes)      |
+| `portless proxy start -p <number>`                     | Start the proxy on a custom port                                    |
+| `portless proxy start --tld test`                      | Use .test instead of .localhost                                     |
+| `portless proxy start --tld localhost --tld test`      | Serve both TLDs from one proxy                                      |
+| `portless proxy start --tld dev.example.com`           | Use a multi-segment TLD for production-parity URLs                  |
+| `portless proxy start --foreground`                    | Start the proxy in foreground (for debugging)                       |
+| `portless proxy start --wildcard`                      | Allow unregistered subdomains to fall back to parent route          |
+| `portless proxy start --routes-cleanup-interval <sec>` | Sweep dead routes every `<sec>` seconds (default 300, `0` disables) |
+| `portless proxy stop`                                  | Stop the proxy                                                      |
+| `portless service install`                             | Start the HTTPS proxy when the OS starts                            |
+| `portless service install --lan`                       | Start the service in LAN mode                                       |
+| `portless service install --wildcard`                  | Persist wildcard routing in the startup service                     |
+| `portless service status`                              | Show service and proxy status                                       |
+| `portless service uninstall`                           | Remove the startup service                                          |
+| `portless alias <name> <port>`                         | Register a static route (e.g. for Docker containers)                |
+| `portless alias <name> <port> --force`                 | Overwrite an existing route                                         |
+| `portless alias --remove <name>`                       | Remove a static route                                               |
+| `portless hosts sync`                                  | Add routes to /etc/hosts (fixes Safari)                             |
+| `portless hosts clean`                                 | Remove portless entries from /etc/hosts                             |
+| `portless <name> --app-port <n> <cmd>`                 | Use a fixed port for the app instead of auto-assignment             |
+| `portless <name> --tailscale <cmd>`                    | Share the app on your Tailscale network (tailnet)                   |
+| `portless <name> --funnel <cmd>`                       | Share the app publicly via Tailscale Funnel                         |
+| `portless <name> --ngrok <cmd>`                        | Share the app publicly via ngrok                                    |
+| `portless <name> --force <cmd>`                        | Kill the existing process and take over its route                   |
+| `portless --name <name> <cmd>`                         | Force `<name>` as app name (bypasses subcommand dispatch)           |
+| `portless <name> -- <cmd> [args...]`                   | Stop flag parsing; everything after `--` is passed to child         |
+| `portless --help` / `-h`                               | Show help                                                           |
+| `portless run --help`                                  | Show help for a subcommand (also: alias, hosts, clean)              |
+| `portless --version` / `-v`                            | Show version                                                        |
 
 **Reserved names:** `run`, `get`, `alias`, `hosts`, `list`, `doctor`, `trust`, `clean`, `prune`, `proxy`, and `service` are subcommands and cannot be used as app names directly. Use `portless run <cmd>` to infer the name, or `portless --name <name> <cmd>` to force any name including reserved ones.
 


### PR DESCRIPTION
`RouteStore.saveRoutes` wrote `routes.json` in place with a single `fs.writeFileSync`, which isn't atomic: a process killed mid-write left a truncated file, and `loadRoutes` treated that as "Corrupted routes file" and returned `[]`. This shows up when a client is spawned through an IDE debug configuration (e.g. `WebStorm -> yarn -> portless -> next dev`) and the IDE's stop/debug action kills the whole process tree; the exit-time cleanup (`removeRoute`) is synchronous and can be mid-write or waiting on a contended file lock when a follow-up SIGKILL lands, leaving the route file corrupted for every app instead of just missing one entry.

`saveRoutes` now writes to a temp file in the same directory and `fs.renameSync`s it into place, so an interrupted write leaves either the previous file or the fully-written new one, never a torn one.

As a second line of defense, the proxy can now prune dead-PID routes on its own: `portless proxy start --routes-cleanup-interval <seconds>` (default 300, `0` disables; env `PORTLESS_ROUTES_CLEANUP_INTERVAL`) runs the existing `pruneStaleRoutes()` — the same routine `portless prune` already uses — on a timer, independent of any client's own exit handler ever running. This is additive: a client still removes its own route on a graceful exit; the sweep only matters when that doesn't happen (SIGKILL, crash, power loss). It defaults to a 300-second interval rather than running unconditionally, so it doesn't wake an otherwise idle proxy needlessly on laptops. The interval is threaded through both the sudo-elevation and daemon-fork re-exec paths and through proxy auto-start, so it's honored regardless of how the proxy gets started.

Covered by new tests in `routes.test.ts` (atomic write, including a real EISDIR rename failure rather than mocking `fs`), `cli-utils.test.ts` (`buildProxyStartConfig` forwards the flag), and `cli.test.ts` (flag validation, and an end-to-end check that a dead-PID route is actually pruned from disk on the sweep). Docs updated in README, the portless skill, and `--help`.

Fixes #382.