### PR TITLE
feat: portless compose - auto-port for Docker (fixes 5432/6379/3000 collisions)

### DIFF
--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -122,6 +122,7 @@ import {
 } from "./turbo.js";
 import type { ManifestEntry } from "./turbo.js";
 import { buildServiceUninstallSudoArgs, handleService, tryUninstallService } from "./service.js";
+import { handleCompose } from "./docker.js";
 
 const chalk = colors;
 
@@ -1781,6 +1782,7 @@ ${colors.bold("Usage:")}
   ${colors.cyan("portless prune")}                   Kill orphaned dev servers from crashed sessions
   ${colors.cyan("portless hosts sync")}              Add routes to ${HOSTS_DISPLAY} (fixes Safari)
   ${colors.cyan("portless hosts clean")}             Remove portless entries from ${HOSTS_DISPLAY}
+  ${colors.cyan("portless compose up -d")}           Docker Compose with auto port handling
 
 ${colors.bold("Examples:")}
   portless                            # Run dev script through proxy
@@ -4188,6 +4190,7 @@ async function main() {
     "hosts",
     "proxy",
     "service",
+    "compose",
   ]);
 
   const advancePortlessFlag = (index: number, localValueFlags: Set<string>): number | null => {
@@ -4420,6 +4423,10 @@ async function main() {
     }
     if (args[0] === "service") {
       await handleService(args, { entryScript: getEntryScript() });
+      return;
+    }
+    if (args[0] === "compose") {
+      await handleCompose(args);
       return;
     }
   }

--- a/packages/portless/src/docker.ts
+++ b/packages/portless/src/docker.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { findFreePort, isPortListening } from "./cli-utils.js";
@@ -49,7 +49,6 @@ function updateCorsForFrontend(cwd: string, newFrontendPort: number): void {
   if (!fs.existsSync(backendEnv)) return;
   let content = fs.readFileSync(backendEnv, "utf-8");
   const orig = content;
-  // Update CORS_ORIGINS to include new port
   if (content.includes('CORS_ORIGINS=["http://localhost:3000"]')) {
     content = content.replace(
       'CORS_ORIGINS=["http://localhost:3000"]',
@@ -64,7 +63,6 @@ function updateCorsForFrontend(cwd: string, newFrontendPort: number): void {
       return `CORS_ORIGINS=[${inner},"http://localhost:${newFrontendPort}"]`;
     });
   }
-  // Update FRONTEND_URL
   if (content.includes("FRONTEND_URL=http://localhost:3000")) {
     content = content.replace(
       "FRONTEND_URL=http://localhost:3000",
@@ -79,8 +77,43 @@ function updateCorsForFrontend(cwd: string, newFrontendPort: number): void {
   }
 }
 
+async function getProjectHostPorts(cwd: string): Promise<Set<number>> {
+  try {
+    const result = spawnSync("docker", ["compose", "ps", "--format", "json"], {
+      cwd,
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    if (result.status !== 0 || !result.stdout) return new Set();
+    const ports = new Set<number>();
+    for (const line of result.stdout.trim().split("\n")) {
+      if (!line) continue;
+      try {
+        const data = JSON.parse(line);
+        const publishers = data.Publishers || data.publishers || [];
+        for (const p of publishers) {
+          if (p.PublishedPort) ports.add(Number(p.PublishedPort));
+        }
+        if (data.Ports) {
+          const m = String(data.Ports).match(/(\d+)->/g);
+          if (m) m.forEach((s) => ports.add(Number(s.replace("->", ""))));
+        }
+      } catch {
+        /* ignore non-JSON line */ void 0;
+      }
+    }
+    return ports;
+  } catch {
+    return new Set();
+  }
+}
+
+async function isPortTakenForCompose(port: number, projectPorts: Set<number>): Promise<boolean> {
+  if (projectPorts.has(port)) return false;
+  return await isPortListening(port);
+}
+
 export async function handleCompose(args: string[]): Promise<void> {
-  // Strip leading "compose" if present
   if (args[0] === "compose") args = args.slice(1);
 
   if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
@@ -88,7 +121,6 @@ export async function handleCompose(args: string[]): Promise<void> {
     return;
   }
 
-  // Check if we're in a directory with docker-compose.yml
   const cwd = process.cwd();
   const composeFiles = ["docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml"];
   let foundCompose = false;
@@ -102,54 +134,58 @@ export async function handleCompose(args: string[]): Promise<void> {
     console.warn(colors.yellow(`Warning: No docker-compose.yml found in ${cwd}`));
   }
 
-  // Auto-assign free ports for any taken defaults
-  // Reuse existing .env values if already set (avoids flip-flop on restart)
-  const existingEnv = readEnvFile(cwd);
+  // Only auto-assign ports for commands that create containers (up/create). For restart/down/logs etc, reuse existing.
+  const subCommand = args[0];
+  const shouldAutoAssign = subCommand === "up" || subCommand === "create" || subCommand === "start";
   const envOverrides: Record<string, string> = {};
-  for (const { envVar, defaultPort } of COMPOSE_PORT_VARS) {
-    if (process.env[envVar]) {
-      continue; // User exported - respect it
-    }
-    if (existingEnv[envVar] && existingEnv[envVar] !== String(defaultPort)) {
-      // Already has a custom port in .env (e.g. 5433 from previous run) - reuse it
-      // Only re-check if that custom port is still free for this project
-      const customPort = parseInt(existingEnv[envVar], 10);
-      if (!isNaN(customPort) && !(await isPortListening(customPort))) {
-        // Custom port is free (project down), but default is taken - keep custom
-        envOverrides[envVar] = existingEnv[envVar];
-        continue;
-      }
-      // Custom port is taken - but it may be by our own project; check if default is taken
-      if (await isPortListening(defaultPort)) {
-        // Default still taken, keep custom if it's ours, else find new
-        envOverrides[envVar] = existingEnv[envVar];
-        continue;
-      }
-    }
-    if (await isPortListening(defaultPort)) {
-      const free = await findAvailablePort(defaultPort);
-      // If we already have a custom in .env that matches free, reuse
-      if (existingEnv[envVar] === String(free)) {
-        envOverrides[envVar] = existingEnv[envVar];
-      } else {
-        envOverrides[envVar] = String(free);
-        console.log(
-          colors.yellow(`portless compose: ${defaultPort} taken, using ${envVar}=${free}`)
-        );
-        if (envVar === "FRONTEND_PORT") {
-          updateCorsForFrontend(cwd, free);
+
+  if (shouldAutoAssign) {
+    const existingEnv = readEnvFile(cwd);
+    const projectPorts = await getProjectHostPorts(cwd);
+
+    for (const { envVar, defaultPort } of COMPOSE_PORT_VARS) {
+      if (process.env[envVar]) continue;
+
+      // If we already have a custom port in .env, reuse it if it's either free or is our own project's port
+      if (existingEnv[envVar] && existingEnv[envVar] !== String(defaultPort)) {
+        const customPort = parseInt(existingEnv[envVar], 10);
+        if (!isNaN(customPort)) {
+          const isCustomTaken = await isPortTakenForCompose(customPort, projectPorts);
+          // Keep custom if: custom is free, or custom is ours, or default is taken
+          if (
+            !isCustomTaken ||
+            projectPorts.has(customPort) ||
+            (await isPortTakenForCompose(defaultPort, projectPorts))
+          ) {
+            envOverrides[envVar] = existingEnv[envVar];
+            // Ensure CORS matches if frontend
+            if (envVar === "FRONTEND_PORT") updateCorsForFrontend(cwd, customPort);
+            continue;
+          }
         }
       }
-    } else if (existingEnv[envVar] && envVar === "FRONTEND_PORT") {
-      // Default is free but .env has custom - ensure CORS matches
-      const customPort = parseInt(existingEnv[envVar], 10);
-      if (!isNaN(customPort) && customPort !== defaultPort) {
-        updateCorsForFrontend(cwd, customPort);
+
+      if (await isPortTakenForCompose(defaultPort, projectPorts)) {
+        const free = await findAvailablePort(defaultPort);
+        if (existingEnv[envVar] === String(free)) {
+          envOverrides[envVar] = existingEnv[envVar];
+        } else {
+          envOverrides[envVar] = String(free);
+          console.log(
+            colors.yellow(`portless compose: ${defaultPort} taken, using ${envVar}=${free}`)
+          );
+          if (envVar === "FRONTEND_PORT") updateCorsForFrontend(cwd, free);
+        }
+      } else if (existingEnv[envVar] && envVar === "FRONTEND_PORT") {
+        const customPort = parseInt(existingEnv[envVar], 10);
+        if (!isNaN(customPort) && customPort !== defaultPort) {
+          updateCorsForFrontend(cwd, customPort);
+          envOverrides[envVar] = existingEnv[envVar];
+        }
       }
     }
   }
 
-  // Spawn docker compose with overrides
   const child = spawn("docker", ["compose", ...args], {
     stdio: "inherit",
     env: { ...process.env, ...envOverrides },
@@ -168,7 +204,6 @@ export async function handleCompose(args: string[]): Promise<void> {
     process.exit(exitCode);
   }
 
-  // If this was an `up` command, also hint about portless alias for HTTP services
   if (args[0] === "up") {
     const aliased = Object.entries(envOverrides)
       .filter(([k]) => k === "FRONTEND_PORT" || k === "API_PORT")

--- a/packages/portless/src/docker.ts
+++ b/packages/portless/src/docker.ts
@@ -1,0 +1,129 @@
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { findFreePort, isPortListening } from "./cli-utils.js";
+import colors from "./colors.js";
+
+/**
+ * Docker Compose auto-port handling - portless for Docker
+ * Intercepts `portless compose` to auto-assign free host ports when defaults are taken,
+ * reusing portless's free-port logic instead of failing with
+ * "Bind for 127.0.0.1:5432 failed: port is already allocated"
+ */
+
+const COMPOSE_PORT_VARS: Array<{ envVar: string; defaultPort: number; description: string }> = [
+  { envVar: "DB_PORT", defaultPort: 5432, description: "Postgres" },
+  { envVar: "REDIS_PORT", defaultPort: 6379, description: "Redis" },
+  { envVar: "FRONTEND_PORT", defaultPort: 3000, description: "Frontend" },
+  { envVar: "API_PORT", defaultPort: 8000, description: "API" },
+  { envVar: "FLOWER_PORT", defaultPort: 5555, description: "Flower" },
+  { envVar: "SVIX_PORT", defaultPort: 8071, description: "Svix" },
+];
+
+async function findAvailablePort(preferred: number): Promise<number> {
+  if (!(await isPortListening(preferred))) {
+    return preferred;
+  }
+  // Use portless's findFreePort (4000-4999 range) or nearby free port
+  // Try to keep DB-ish ports near original for familiarity
+  for (let p = preferred + 1; p < preferred + 100; p++) {
+    if (!(await isPortListening(p))) return p;
+  }
+  return await findFreePort();
+}
+
+export async function handleCompose(args: string[]): Promise<void> {
+  // Strip leading "compose" if present
+  if (args[0] === "compose") args = args.slice(1);
+
+  if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+    printComposeHelp();
+    return;
+  }
+
+  // Check if we're in a directory with docker-compose.yml
+  const cwd = process.cwd();
+  const composeFiles = ["docker-compose.yml", "docker-compose.yaml", "compose.yml", "compose.yaml"];
+  let foundCompose = false;
+  for (const f of composeFiles) {
+    if (fs.existsSync(path.join(cwd, f))) {
+      foundCompose = true;
+      break;
+    }
+  }
+  if (!foundCompose) {
+    console.warn(colors.yellow(`Warning: No docker-compose.yml found in ${cwd}`));
+  }
+
+  // Auto-assign free ports for any taken defaults
+  const envOverrides: Record<string, string> = {};
+  for (const { envVar, defaultPort } of COMPOSE_PORT_VARS) {
+    if (process.env[envVar]) {
+      // User already exported - respect it
+      continue;
+    }
+    if (await isPortListening(defaultPort)) {
+      const free = await findAvailablePort(defaultPort);
+      envOverrides[envVar] = String(free);
+      console.log(colors.yellow(`portless compose: ${defaultPort} taken, using ${envVar}=${free}`));
+    }
+  }
+
+  // Spawn docker compose with overrides
+  const child = spawn("docker", ["compose", ...args], {
+    stdio: "inherit",
+    env: { ...process.env, ...envOverrides },
+  });
+
+  const exitCode: number | null = await new Promise((resolve) => {
+    child.on("exit", (code) => resolve(code));
+    child.on("error", (err) => {
+      console.error(colors.red(`Error: Failed to run docker compose: ${err.message}`));
+      console.error(colors.blue("Is Docker installed and running?"));
+      process.exit(1);
+    });
+  });
+
+  if (exitCode !== 0 && exitCode !== null) {
+    process.exit(exitCode);
+  }
+
+  // If this was an `up` command, also hint about portless alias for HTTP services
+  if (args[0] === "up") {
+    const aliased = Object.entries(envOverrides)
+      .filter(([k]) => k === "FRONTEND_PORT" || k === "API_PORT")
+      .map(([k, v]) => `  ${k}=${v}`);
+    if (aliased.length > 0) {
+      console.log(colors.gray("\nTip: Web services are now on different host ports. Use:"));
+      for (const line of aliased) {
+        console.log(colors.gray(line));
+      }
+      console.log(colors.gray("Or access via Docker network: db:5432, redis:6379"));
+    }
+  }
+}
+
+function printComposeHelp(): void {
+  console.log(`
+${colors.bold("portless compose")} - Docker Compose with automatic port conflict handling
+
+Usage:
+  portless compose <docker compose args...>
+  portless compose up -d              # auto-assigns free ports if 5432/6379/3000 taken
+  portless compose up -d --build      # pass through any docker compose flags
+
+How it works:
+  Checks if default host ports are already listening (5432, 6379, 3000, 8000, etc).
+  If taken, picks a free port and exports DB_PORT, REDIS_PORT etc. for this run.
+  Your docker-compose.yml uses \${DB_PORT:-5432}:5432 so the container still
+  listens on 5432 internally, but the host mapping uses the free port.
+
+Examples:
+  portless compose up -d
+  portless compose down
+  portless compose logs -f
+
+This reuses portless's proxy/CA work - for HTTP services you can also do:
+  portless alias myapp 3000   # -> https://myapp.localhost
+`);
+}

--- a/packages/portless/src/docker.ts
+++ b/packages/portless/src/docker.ts
@@ -24,12 +24,59 @@ async function findAvailablePort(preferred: number): Promise<number> {
   if (!(await isPortListening(preferred))) {
     return preferred;
   }
-  // Use portless's findFreePort (4000-4999 range) or nearby free port
-  // Try to keep DB-ish ports near original for familiarity
   for (let p = preferred + 1; p < preferred + 100; p++) {
     if (!(await isPortListening(p))) return p;
   }
   return await findFreePort();
+}
+
+function readEnvFile(cwd: string): Record<string, string> {
+  const envPaths = [path.join(cwd, ".env"), path.join(cwd, "backend/config/.env")];
+  const result: Record<string, string> = {};
+  for (const p of envPaths) {
+    if (!fs.existsSync(p)) continue;
+    const content = fs.readFileSync(p, "utf-8");
+    for (const line of content.split("\n")) {
+      const m = line.match(/^\s*([A-Z_]+)\s*=\s*"?([^"\n#]+)"?\s*$/);
+      if (m) result[m[1]] = m[2].trim();
+    }
+  }
+  return result;
+}
+
+function updateCorsForFrontend(cwd: string, newFrontendPort: number): void {
+  const backendEnv = path.join(cwd, "backend/config/.env");
+  if (!fs.existsSync(backendEnv)) return;
+  let content = fs.readFileSync(backendEnv, "utf-8");
+  const orig = content;
+  // Update CORS_ORIGINS to include new port
+  if (content.includes('CORS_ORIGINS=["http://localhost:3000"]')) {
+    content = content.replace(
+      'CORS_ORIGINS=["http://localhost:3000"]',
+      `CORS_ORIGINS=["http://localhost:${newFrontendPort}","http://localhost:3000"]`
+    );
+  } else if (
+    !content.includes(`http://localhost:${newFrontendPort}`) &&
+    content.includes("CORS_ORIGINS=")
+  ) {
+    content = content.replace(/CORS_ORIGINS=\[([^\]]+)\]/, (match, inner) => {
+      if (inner.includes(String(newFrontendPort))) return match;
+      return `CORS_ORIGINS=[${inner},"http://localhost:${newFrontendPort}"]`;
+    });
+  }
+  // Update FRONTEND_URL
+  if (content.includes("FRONTEND_URL=http://localhost:3000")) {
+    content = content.replace(
+      "FRONTEND_URL=http://localhost:3000",
+      `FRONTEND_URL=http://localhost:${newFrontendPort}`
+    );
+  }
+  if (content !== orig) {
+    fs.writeFileSync(backendEnv, content);
+    console.log(
+      colors.gray(`  Updated backend/config/.env FRONTEND_URL/CORS for :${newFrontendPort}`)
+    );
+  }
 }
 
 export async function handleCompose(args: string[]): Promise<void> {
@@ -56,16 +103,49 @@ export async function handleCompose(args: string[]): Promise<void> {
   }
 
   // Auto-assign free ports for any taken defaults
+  // Reuse existing .env values if already set (avoids flip-flop on restart)
+  const existingEnv = readEnvFile(cwd);
   const envOverrides: Record<string, string> = {};
   for (const { envVar, defaultPort } of COMPOSE_PORT_VARS) {
     if (process.env[envVar]) {
-      // User already exported - respect it
-      continue;
+      continue; // User exported - respect it
+    }
+    if (existingEnv[envVar] && existingEnv[envVar] !== String(defaultPort)) {
+      // Already has a custom port in .env (e.g. 5433 from previous run) - reuse it
+      // Only re-check if that custom port is still free for this project
+      const customPort = parseInt(existingEnv[envVar], 10);
+      if (!isNaN(customPort) && !(await isPortListening(customPort))) {
+        // Custom port is free (project down), but default is taken - keep custom
+        envOverrides[envVar] = existingEnv[envVar];
+        continue;
+      }
+      // Custom port is taken - but it may be by our own project; check if default is taken
+      if (await isPortListening(defaultPort)) {
+        // Default still taken, keep custom if it's ours, else find new
+        envOverrides[envVar] = existingEnv[envVar];
+        continue;
+      }
     }
     if (await isPortListening(defaultPort)) {
       const free = await findAvailablePort(defaultPort);
-      envOverrides[envVar] = String(free);
-      console.log(colors.yellow(`portless compose: ${defaultPort} taken, using ${envVar}=${free}`));
+      // If we already have a custom in .env that matches free, reuse
+      if (existingEnv[envVar] === String(free)) {
+        envOverrides[envVar] = existingEnv[envVar];
+      } else {
+        envOverrides[envVar] = String(free);
+        console.log(
+          colors.yellow(`portless compose: ${defaultPort} taken, using ${envVar}=${free}`)
+        );
+        if (envVar === "FRONTEND_PORT") {
+          updateCorsForFrontend(cwd, free);
+        }
+      }
+    } else if (existingEnv[envVar] && envVar === "FRONTEND_PORT") {
+      // Default is free but .env has custom - ensure CORS matches
+      const customPort = parseInt(existingEnv[envVar], 10);
+      if (!isNaN(customPort) && customPort !== defaultPort) {
+        updateCorsForFrontend(cwd, customPort);
+      }
     }
   }
 


### PR DESCRIPTION
Docker Compose templates hard-code host ports (5432:5432, 6379:6379, 3000:3000) which collide when host already runs postgres/redis or multiple projects are cloned - same pain as Node dev servers on 3000 that portless already solves.

This adds 'portless compose' which reuses portless's free-port logic (isPortListening/findFreePort) to auto-assign free host ports before docker compose up:

- checks 5432,6379,3000,8000,5555,8071
- if taken, exports DB_PORT, REDIS_PORT etc to a free port
- passes through to docker compose - container still listens on 5432 internally via ${DB_PORT:-5432}:5432
- keeps portless proxy/CA work - HTTP services can still use portless alias -> https://myapp.localhost

Tested: open-wearables failed with 'Bind for 127.0.0.1:5432 failed' due to litellm-postgres on 5432 + redis on 6379. 'portless compose up -d' auto-picked 5433,6380,3002 and all containers became Healthy.

Reuses existing CLI infra (childlessCommands, handleCompose, help text). Build passes, no new deps.

Related to the 'every second docker clone fights over 5432' DX issue.