### PR TITLE
Fix orphaned child processes after Ctrl+C

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ With a `portless.json`, you can simplify to:
 
 Then run `portless` or `portless run` to go through the proxy.
 
+When you press Ctrl+C, portless forwards the interrupt and waits for the command's process tree to
+exit. Press Ctrl+C again to forward another interrupt. Any remaining descendants are terminated
+after a short grace period.
+
 ## Subdomains
 
 Organize services with subdomains:

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -5,7 +5,7 @@ import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as readline from "node:readline";
-import { execSync, spawn } from "node:child_process";
+import { execFileSync, execSync, spawn } from "node:child_process";
 import { PORTLESS_HEADER } from "./proxy.js";
 import { resolveScript, resolveScriptRaw } from "./config.js";
 import { createLoopbackConnection, resolveUserHome } from "./utils.js";
@@ -109,6 +109,100 @@ export const SIGNAL_CODES: Record<string, number> = {
   SIGKILL: 9,
   SIGTERM: 15,
 };
+
+const COMMAND_SHUTDOWN_GRACE_MS = 5000;
+const COMMAND_SHUTDOWN_FORCE_MS = 10_000;
+const COMMAND_SHUTDOWN_POLL_MS = 50;
+
+type TrackedProcess = {
+  pid: number;
+  pgid: number;
+};
+
+function trackProcessTree(rootPid: number, tracked: Map<number, TrackedProcess>): void {
+  tracked.set(rootPid, { pid: rootPid, pgid: rootPid });
+  if (isWindows) {
+    return;
+  }
+
+  try {
+    const output = execFileSync("ps", ["-axo", "pid=,ppid=,pgid="], {
+      encoding: "utf-8",
+      timeout: PID_LOOKUP_TIMEOUT_MS,
+    });
+    const rows = output
+      .trim()
+      .split("\n")
+      .map((line) => {
+        const match = line.trim().match(/^(\d+)\s+(\d+)\s+(\d+)$/);
+        if (!match) return null;
+        return {
+          pid: parseInt(match[1], 10),
+          ppid: parseInt(match[2], 10),
+          pgid: parseInt(match[3], 10),
+        };
+      })
+      .filter((row): row is { pid: number; ppid: number; pgid: number } => row !== null);
+
+    const descendants = new Set([rootPid]);
+    let foundDescendant = true;
+    while (foundDescendant) {
+      foundDescendant = false;
+      for (const row of rows) {
+        if (descendants.has(row.ppid) && !descendants.has(row.pid)) {
+          descendants.add(row.pid);
+          foundDescendant = true;
+        }
+      }
+    }
+
+    for (const row of rows) {
+      if (descendants.has(row.pid)) {
+        tracked.set(row.pid, { pid: row.pid, pgid: row.pgid });
+      }
+    }
+  } catch {
+    // Fall back to the root process group that was already tracked.
+  }
+}
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasRunningProcesses(tracked: Map<number, TrackedProcess>): boolean {
+  return [...tracked.keys()].some(isProcessRunning);
+}
+
+function signalTrackedProcesses(
+  tracked: Map<number, TrackedProcess>,
+  signal: NodeJS.Signals
+): void {
+  if (isWindows) {
+    for (const { pid } of tracked.values()) {
+      try {
+        process.kill(pid, signal);
+      } catch {
+        // Already dead
+      }
+    }
+    return;
+  }
+
+  const groups = new Set([...tracked.values()].map(({ pgid }) => pgid));
+  for (const pgid of groups) {
+    try {
+      process.kill(-pgid, signal);
+    } catch {
+      // Already dead
+    }
+  }
+}
 
 /** Return explicit IPv4 and IPv6 listener targets for the effective proxy mode. */
 export function getProxyBindTargets(lanMode: boolean): ProxyBindTarget[] {
@@ -1019,19 +1113,55 @@ export function spawnCommand(
       });
 
   let exiting = false;
+  let shutdownSignal: NodeJS.Signals | undefined;
+  let childExited = false;
+  const trackedProcesses = new Map<number, TrackedProcess>();
+  let graceTimer: NodeJS.Timeout | undefined;
+  let forceTimer: NodeJS.Timeout | undefined;
+  let shutdownPoll: NodeJS.Timeout | undefined;
 
   const cleanup = () => {
+    if (graceTimer) clearTimeout(graceTimer);
+    if (forceTimer) clearTimeout(forceTimer);
+    if (shutdownPoll) clearInterval(shutdownPoll);
     process.removeListener("SIGINT", onSigInt);
     process.removeListener("SIGTERM", onSigTerm);
     options?.onCleanup?.();
   };
 
-  const handleSignal = (signal: NodeJS.Signals) => {
+  const finish = (code: number) => {
     if (exiting) return;
     exiting = true;
-    killTree(child, signal);
     cleanup();
-    process.exit(128 + (SIGNAL_CODES[signal] || 15));
+    process.exit(code);
+  };
+
+  const finishShutdownIfComplete = () => {
+    if (!shutdownSignal || !childExited || hasRunningProcesses(trackedProcesses)) return;
+    finish(128 + (SIGNAL_CODES[shutdownSignal] || 15));
+  };
+
+  const handleSignal = (signal: NodeJS.Signals) => {
+    if (shutdownSignal) {
+      if (child.pid) trackProcessTree(child.pid, trackedProcesses);
+      signalTrackedProcesses(trackedProcesses, signal);
+      return;
+    }
+    shutdownSignal = signal;
+    if (child.pid) trackProcessTree(child.pid, trackedProcesses);
+    killTree(child, signal);
+
+    graceTimer = setTimeout(() => {
+      if (child.pid) trackProcessTree(child.pid, trackedProcesses);
+      signalTrackedProcesses(trackedProcesses, "SIGTERM");
+    }, COMMAND_SHUTDOWN_GRACE_MS);
+
+    forceTimer = setTimeout(() => {
+      if (child.pid) trackProcessTree(child.pid, trackedProcesses);
+      signalTrackedProcesses(trackedProcesses, "SIGKILL");
+    }, COMMAND_SHUTDOWN_FORCE_MS);
+
+    shutdownPoll = setInterval(finishShutdownIfComplete, COMMAND_SHUTDOWN_POLL_MS);
   };
 
   const onSigInt = () => handleSignal("SIGINT");
@@ -1041,24 +1171,26 @@ export function spawnCommand(
   process.on("SIGTERM", onSigTerm);
 
   child.on("error", (err) => {
-    if (exiting) return;
-    exiting = true;
+    if (exiting || shutdownSignal) return;
     console.error(`Failed to run command: ${err.message}`);
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       console.error(`Is "${commandArgs[0]}" installed and in your PATH?`);
     }
-    cleanup();
-    process.exit(1);
+    finish(1);
   });
 
   child.on("exit", (code, signal) => {
     if (exiting) return;
-    exiting = true;
-    cleanup();
-    if (signal) {
-      process.exit(128 + (SIGNAL_CODES[signal] || 15));
+    childExited = true;
+    if (shutdownSignal) {
+      finishShutdownIfComplete();
+      return;
     }
-    process.exit(code ?? 1);
+    if (signal) {
+      finish(128 + (SIGNAL_CODES[signal] || 15));
+      return;
+    }
+    finish(code ?? 1);
   });
 }
 

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1620,6 +1620,9 @@ ${colors.bold("Usage:")}
   When no command is given, runs the configured script (default: "dev")
   from package.json.
 
+  Ctrl+C is forwarded to the command. Portless waits for its process tree to
+  exit and terminates remaining descendants after a short grace period.
+
 ${colors.bold("Options:")}
   --name <name>          Override the inferred base name (worktree prefix still applies)
   --force                Kill the existing process and take over its route

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -155,6 +155,10 @@ Set `PORTLESS=0` to run the command directly without the proxy:
 PORTLESS=0 pnpm dev   # Bypasses proxy, uses default port
 ```
 
+When a proxied command is stopped with Ctrl+C, portless waits for its process tree to exit. A second
+Ctrl+C forwards another interrupt, and remaining descendants are terminated after a short grace
+period.
+
 ## How It Works
 
 1. `portless proxy start` starts an HTTPS reverse proxy on port 443 as a background daemon. Auto-elevates with sudo on macOS/Linux; falls back to port 1355 if sudo is unavailable. Use `--no-tls` for plain HTTP on port 80. Configurable with `-p` / `--port` or the `PORTLESS_PORT` env var. The proxy also auto-starts when you run an app.

--- a/tests/e2e/fixtures/minimal-server/stubborn-wrapper.js
+++ b/tests/e2e/fixtures/minimal-server/stubborn-wrapper.js
@@ -1,0 +1,18 @@
+/* global process */
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import * as path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const child = spawn(process.execPath, [path.join(__dirname, "server.js")], {
+  detached: true,
+  stdio: "inherit",
+  env: process.env,
+});
+
+process.on("SIGINT", () => {});
+process.on("SIGTERM", () => {});
+
+child.on("exit", (code) => {
+  process.exit(code ?? 0);
+});

--- a/tests/e2e/src/zombie.test.ts
+++ b/tests/e2e/src/zombie.test.ts
@@ -101,6 +101,26 @@ async function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
+async function waitForPortToClose(port: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (findPidsOnPort(port).length === 0) return true;
+    await sleep(50);
+  }
+  return findPidsOnPort(port).length === 0;
+}
+
+async function waitForChildToExit(child: ChildProcess, timeoutMs: number): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) return true;
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => resolve(false), timeoutMs);
+    child.once("exit", () => {
+      clearTimeout(timeout);
+      resolve(true);
+    });
+  });
+}
+
 interface TestState {
   stateDir?: string;
   cliChild?: ChildProcess;
@@ -108,10 +128,11 @@ interface TestState {
 }
 
 async function cleanupTestState(state: TestState): Promise<void> {
-  if (state.cliChild && !state.cliChild.killed) {
+  if (state.cliChild && state.cliChild.exitCode === null && state.cliChild.signalCode === null) {
     state.cliChild.kill("SIGTERM");
-    await sleep(1000);
-    if (!state.cliChild.killed) state.cliChild.kill("SIGKILL");
+    if (!(await waitForChildToExit(state.cliChild, 1000))) {
+      state.cliChild.kill("SIGKILL");
+    }
   }
   if (state.appPort) killPort(state.appPort);
 
@@ -165,8 +186,14 @@ async function startCliApp(
     stdio: ["ignore", "pipe", "pipe"],
   });
 
-  state.cliChild.stdout!.on("data", () => {});
-  state.cliChild.stderr!.on("data", () => {});
+  let stdout = "";
+  let stderr = "";
+  state.cliChild.stdout!.on("data", (chunk: Buffer) => {
+    stdout += chunk.toString();
+  });
+  state.cliChild.stderr!.on("data", (chunk: Buffer) => {
+    stderr += chunk.toString();
+  });
 
   const hostname = `${appName}.localhost`;
   const deadline = Date.now() + 30_000;
@@ -198,7 +225,7 @@ async function startCliApp(
     }
     await sleep(500);
   }
-  expect(ready).toBe(true);
+  expect(ready, `CLI did not become ready.\nstdout:\n${stdout}\nstderr:\n${stderr}`).toBe(true);
 
   const routesPath = path.join(state.stateDir, "routes.json");
   const routes: Array<{ hostname: string; port: number; pid: number }> = JSON.parse(
@@ -240,6 +267,33 @@ describe("zombie process prevention", () => {
     // grandchild survives because child.kill() only kills /bin/sh.
     const survivors = findPidsOnPort(appPort);
     expect(survivors).toEqual([]);
+  });
+
+  it("SIGINT stops the command's dev server before exiting", async () => {
+    if (isWindows) return;
+
+    const { appPort } = await startCliApp("zombie-sigint", state, "stubborn-wrapper.js");
+
+    state.cliChild!.kill("SIGINT");
+    const cliExited = await waitForChildToExit(state.cliChild!, 10_000);
+    const portClosed = await waitForPortToClose(appPort, 1000);
+
+    expect({ cliExited, portClosed }).toEqual({ cliExited: true, portClosed: true });
+  });
+
+  it("forwards a second SIGINT while the command is shutting down", async () => {
+    if (isWindows) return;
+
+    const { appPort } = await startCliApp("zombie-second-sigint", state, "stubborn-wrapper.js");
+
+    state.cliChild!.kill("SIGINT");
+    await sleep(100);
+    state.cliChild!.kill("SIGINT");
+
+    const cliExited = await waitForChildToExit(state.cliChild!, 2000);
+    const portClosed = await waitForPortToClose(appPort, 2000);
+
+    expect({ cliExited, portClosed }).toEqual({ cliExited: true, portClosed: true });
   });
 
   it("SIGKILL leaves orphan, portless prune cleans it up", async () => {


### PR DESCRIPTION
## Problem

`portless run` exits immediately after forwarding Ctrl+C. If the command starts descendants in separate process groups, those processes can survive after Portless exits.

## Reproduction

1. Run a command through `portless run` that starts a persistent descendant in a separate process group.
2. Press Ctrl+C.
3. Observe that Portless exits while the descendant keeps running.

## Fix

Portless now tracks the command process tree before forwarding interrupts and waits for it to exit. Repeated interrupts are forwarded during shutdown. Remaining descendants receive SIGTERM after a grace period and SIGKILL as a final fallback.

Behavioral end-to-end coverage verifies both a single interrupt with bounded cleanup and a repeated interrupt during shutdown.