### PR TITLE
fix(certs): stop generating a CA with duplicate basicConstraints

### DIFF
--- a/packages/portless/src/certs.test.ts
+++ b/packages/portless/src/certs.test.ts
@@ -230,6 +230,68 @@ describe("ensureCerts", () => {
     expect(getCertSignatureAlgo(second.certPath)).toContain("sha256");
   });
 
+  it("generates a CA that carries basicConstraints exactly once", () => {
+    const result = ensureCerts(tmpDir);
+    const text = execFileSync("openssl", ["x509", "-in", result.caPath, "-noout", "-text"], {
+      encoding: "utf-8",
+    });
+
+    expect((text.match(/X509v3 Basic Constraints/g) ?? []).length).toBe(1);
+  });
+
+  it("generates a CA that OpenSSL accepts when verifying the server cert", () => {
+    const result = ensureCerts(tmpDir);
+
+    // A CA carrying duplicate extensions violates RFC 5280. OpenSSL 3 refuses
+    // to build a chain through it, which is what breaks curl and Node.js.
+    const output = execFileSync("openssl", ["verify", "-CAfile", result.caPath, result.certPath], {
+      encoding: "utf-8",
+    });
+
+    expect(output).toContain("OK");
+  });
+
+  it("regenerates a CA that carries basicConstraints twice", () => {
+    // Built by portless versions that used "req -x509 -addext" on OpenSSL
+    // 1.1.1. Embedded as a fixture because OpenSSL 3 collapses the duplicate
+    // and so cannot reproduce it at runtime. Expires in 2126, so only the
+    // duplicate extension triggers regeneration here.
+    const duplicateCA = [
+      "-----BEGIN CERTIFICATE-----",
+      "MIIBbzCCARagAwIBAgIUW1e9aQ1IazId4nZ2NFa3n9/x0tswCgYIKoZIzj0EAwIw",
+      "HDEaMBgGA1UEAwwRcG9ydGxlc3MgTG9jYWwgQ0EwIBcNMjYwODE4MjA1NDAzWhgP",
+      "MjEyNjA3MjUyMDU0MDNaMBwxGjAYBgNVBAMMEXBvcnRsZXNzIExvY2FsIENBMFkw",
+      "EwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEUyFvqnRhhAABzXTmWgpBHmiWn2jyPshG",
+      "gmA4dNP5kfINATS8K1JtWLxYf/saqHPFxOesHYjr9oD0cBp6V4qxv6M0MDIwDwYD",
+      "VR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUwAwEB/zAK",
+      "BggqhkjOPQQDAgNHADBEAiAwxhr+G5JDO7qNqiX3bm/nFE41AXnSB0y34puz5c4J",
+      "zQIgTl7ah1MEHSd3HXXKPqzzR7U/152NzDvplbDfXNfRDTc=",
+      "-----END CERTIFICATE-----",
+    ].join("\n");
+    const duplicateCAKey = [
+      "-----BEGIN EC PRIVATE KEY-----",
+      "MHcCAQEEICnG5CETQb8As6nwQZ+YfkpTGydFLIgr8nETZ5ZHr5bQoAoGCCqGSM49",
+      "AwEHoUQDQgAEUyFvqnRhhAABzXTmWgpBHmiWn2jyPshGgmA4dNP5kfINATS8K1Jt",
+      "WLxYf/saqHPFxOesHYjr9oD0cBp6V4qxvw==",
+      "-----END EC PRIVATE KEY-----",
+    ].join("\n");
+
+    const caCertPath = path.join(tmpDir, "ca.pem");
+    const caKeyPath = path.join(tmpDir, "ca-key.pem");
+    fs.writeFileSync(caCertPath, duplicateCA + "\n");
+    fs.writeFileSync(caKeyPath, duplicateCAKey + "\n");
+
+    const result = ensureCerts(tmpDir);
+
+    expect(result.caGenerated).toBe(true);
+    expect(fs.readFileSync(caCertPath, "utf-8")).not.toContain("MIIBbzCCARagAwIBAgIUW1e9aQ1Iaz");
+
+    const text = execFileSync("openssl", ["x509", "-in", caCertPath, "-noout", "-text"], {
+      encoding: "utf-8",
+    });
+    expect((text.match(/X509v3 Basic Constraints/g) ?? []).length).toBe(1);
+  });
+
   it.skipIf(process.platform === "win32")("sets restrictive permissions on key files", () => {
     const result = ensureCerts(tmpDir);
 

--- a/packages/portless/src/certs.ts
+++ b/packages/portless/src/certs.ts
@@ -226,6 +226,27 @@ function isCertSignatureStrong(certPath: string): boolean {
 }
 
 /**
+ * Check whether a certificate carries basicConstraints exactly once.
+ *
+ * RFC 5280 requires that an extension appear at most once. Earlier portless
+ * versions generated the CA with "req -x509 -addext basicConstraints=...",
+ * which on OpenSSL 1.1.1 appends to the x509_extensions section from
+ * openssl.cnf rather than replacing it. Debian and Ubuntu point that section
+ * at v3_ca, which already carries basicConstraints, so the CA ended up with
+ * two copies. OpenSSL 3 then rejects such a CA with "X509 V3
+ * routines::invalid certificate", which breaks curl and Node.js even though
+ * NSS and browsers accept it. Detect those CAs so they get regenerated.
+ */
+function hasUniqueBasicConstraints(certPath: string): boolean {
+  try {
+    const text = openssl(["x509", "-in", certPath, "-noout", "-text"]);
+    return (text.match(/X509v3 Basic Constraints/g) ?? []).length <= 1;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Run openssl and return stdout. Throws on non-zero exit.
  */
 function openssl(args: string[], options?: { input?: string }): string {
@@ -281,29 +302,58 @@ async function opensslAsync(args: string[]): Promise<string> {
 function generateCA(stateDir: string): { certPath: string; keyPath: string } {
   const keyPath = path.join(stateDir, CA_KEY_FILE);
   const certPath = path.join(stateDir, CA_CERT_FILE);
+  const csrPath = path.join(stateDir, "ca.csr");
+  const extPath = path.join(stateDir, "ca-ext.cnf");
 
   // Generate EC private key
   openssl(["ecparam", "-genkey", "-name", "prime256v1", "-noout", "-out", keyPath]);
 
-  // Generate self-signed CA certificate
+  // Write extension config for the CA.
+  //
+  // Do not use "req -x509 -addext" here. On OpenSSL 1.1.1, -addext appends to
+  // the x509_extensions section configured in openssl.cnf instead of replacing
+  // it. Debian and Ubuntu set that section to v3_ca, which already carries
+  // basicConstraints, so the CA came out with the extension twice. RFC 5280
+  // forbids duplicate extensions, and OpenSSL 3 rejects such a CA with
+  // "X509 V3 routines::invalid certificate", so curl and Node.js fail to
+  // verify the chain while NSS and browsers still accept it. Signing a CSR
+  // with an explicit -extfile produces exactly one copy of each extension on
+  // every OpenSSL and LibreSSL version.
+  fs.writeFileSync(
+    extPath,
+    [
+      "basicConstraints=critical,CA:TRUE",
+      "keyUsage=critical,keyCertSign,cRLSign",
+      "subjectKeyIdentifier=hash",
+    ].join("\n") + "\n"
+  );
+
+  // Generate CSR, then self-sign it into the CA certificate
+  openssl(["req", "-new", "-key", keyPath, "-out", csrPath, "-subj", `/CN=${CA_COMMON_NAME}`]);
   openssl([
-    "req",
-    "-new",
-    "-x509",
+    "x509",
+    "-req",
     "-sha256",
-    "-key",
+    "-in",
+    csrPath,
+    "-signkey",
     keyPath,
     "-out",
     certPath,
     "-days",
     CA_VALIDITY_DAYS.toString(),
-    "-subj",
-    `/CN=${CA_COMMON_NAME}`,
-    "-addext",
-    "basicConstraints=critical,CA:TRUE",
-    "-addext",
-    "keyUsage=critical,keyCertSign,cRLSign",
+    "-extfile",
+    extPath,
   ]);
+
+  // Clean up temporary files
+  for (const tmp of [csrPath, extPath]) {
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      // Non-fatal
+    }
+  }
 
   fs.chmodSync(keyPath, 0o600);
   fs.chmodSync(certPath, 0o644);
@@ -423,7 +473,8 @@ export function ensureCerts(stateDir: string): {
     !fileExists(caCertPath) ||
     !fileExists(caKeyPath) ||
     !isCertValid(caCertPath) ||
-    !isCertSignatureStrong(caCertPath);
+    !isCertSignatureStrong(caCertPath) ||
+    !hasUniqueBasicConstraints(caCertPath);
 
   if (caMissing) {
     generateCA(stateDir);


### PR DESCRIPTION
## Problem

On systems where `openssl` resolves to OpenSSL 1.1.1, portless generates a root CA that carries `basicConstraints` twice:

```
X509v3 Basic Constraints: critical
    CA:TRUE
X509v3 Basic Constraints: critical
    CA:TRUE
```

RFC 5280 requires an extension to appear at most once, so the resulting CA is malformed. NSS accepts it, which is why Chrome and Firefox work and the problem stays invisible, but OpenSSL 3 rejects it:

```
$ curl https://myapp.localhost
curl: (35) error:1100009E:X509 V3 routines::invalid certificate

$ NODE_EXTRA_CA_CERTS=~/.portless/ca.pem node -e "fetch('https://myapp.localhost')"
UNABLE_TO_VERIFY_LEAF_SIGNATURE
```

`openssl verify -CAfile ~/.portless/ca.pem ~/.portless/server.pem` fails the same way. This makes portless unusable for any server-side HTTPS call, so backend-to-backend requests and SSR fetches fail even though the browser is happy.

## Root cause

`generateCA` builds the root with:

```
openssl req -new -x509 ... -addext basicConstraints=critical,CA:TRUE
```

On OpenSSL 1.1.1, `-addext` **appends to** the `x509_extensions` section configured in `openssl.cnf` rather than replacing it. Debian and Ubuntu set that section to `v3_ca` (`/etc/ssl/openssl.cnf`), and `v3_ca` already contains `basicConstraints = critical,CA:true`. Both end up in the certificate.

OpenSSL 3 collapses the duplicate, which is why this only reproduces where an OpenSSL 1.1.1 binary comes first on `PATH`. That is common in practice: conda, pyenv, older distributions and several CI images all ship one.

Reproduced with the exact arguments from `generateCA`:

| openssl on PATH | `basicConstraints` count | `openssl verify` |
| --- | --- | --- |
| 1.1.1n | 2 | fails with `invalid certificate` |
| 3.0.13 | 1 | OK |

Worth noting: the existing test `CA cert has CA:TRUE basic constraint` already fails on OpenSSL 1.1.1 on `main`, because Node's `X509Certificate.ca` returns `false` for the malformed cert.

## Fix

Generate a CSR and self-sign it with an explicit `-extfile`, which is the pattern `generateServerCert` already uses. The extension set is then fully controlled by portless and never merged with `openssl.cnf` defaults, so it produces exactly one copy of each extension on every OpenSSL and LibreSSL version.

`subjectKeyIdentifier=hash` is kept so the chain still builds against the `authorityKeyIdentifier=keyid,issuer` that server certs carry.

Existing installs are already broken on disk, so `ensureCerts` now also treats a CA carrying `basicConstraints` twice as needing regeneration, alongside the existing expiry and SHA-1 checks. Affected users self-heal on the next run instead of having to `portless clean`.

## Tests

Three tests added:

- the generated CA carries `basicConstraints` exactly once
- `openssl verify -CAfile ca.pem server.pem` succeeds
- a CA carrying `basicConstraints` twice is regenerated

The third uses an embedded fixture because OpenSSL 3 collapses the duplicate and cannot construct one at runtime. It expires in 2126 so only the duplicate extension triggers regeneration.

Verified against both binaries:

- OpenSSL 3.0.13: 31 passed, 1 skipped
- OpenSSL 1.1.1n: 31 passed, 1 skipped

Against `main` on OpenSSL 1.1.1n the new tests fail, together with the pre-existing `CA cert has CA:TRUE basic constraint`.

`pnpm lint`, `pnpm type-check` and `pnpm format` are clean. No user-facing commands, flags or behavior change, so no README, SKILL.md or `--help` updates are needed.
