### PR TITLE
feat(docs): add agent-readable documentation

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -6,6 +6,17 @@ const withMDX = createMDX();
 const nextConfig = {
   pageExtensions: ["ts", "tsx", "md", "mdx"],
   serverExternalPackages: ["just-bash", "bash-tool"],
+  outputFileTracingIncludes: {
+    "/*": ["./src/app/**/*.mdx"],
+  },
+  async rewrites() {
+    return {
+      beforeFiles: [
+        { source: "/index.md", destination: "/api/docs-md" },
+        { source: "/:path*.md", destination: "/api/docs-md/:path*" },
+      ],
+    };
+  },
 };
 
 export default withMDX(nextConfig);

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "vitest run"
   },
   "dependencies": {
     "@ai-sdk/react": "^3.0.96",
@@ -16,6 +17,7 @@
     "@next/mdx": "^16.1.6",
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.36.2",
+    "@vercel/agent-readability": "0.5.0",
     "ai": "^6.0.94",
     "bash-tool": "^1.3.15",
     "clsx": "^2.1.1",
@@ -38,6 +40,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.0.18"
   }
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -17,7 +17,7 @@
     "@next/mdx": "^16.1.6",
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.36.2",
-    "@vercel/agent-readability": "0.5.0",
+    "@vercel/agent-readability": "0.5.1",
     "ai": "^6.0.94",
     "bash-tool": "^1.3.15",
     "clsx": "^2.1.1",

--- a/apps/docs/src/app/api/docs-chat/route.ts
+++ b/apps/docs/src/app/api/docs-chat/route.ts
@@ -1,11 +1,8 @@
-import { readFile } from "fs/promises";
-import { join } from "path";
 import { convertToModelMessages, stepCountIs, streamText } from "ai";
 import type { ModelMessage, UIMessage } from "ai";
 import { createBashTool } from "bash-tool";
 import { headers } from "next/headers";
-import { allDocsPages } from "@/lib/docs-navigation";
-import { mdxToCleanMarkdown } from "@/lib/mdx-to-markdown";
+import { loadAllDocsSources } from "@/lib/docs-source";
 import { minuteRateLimit, dailyRateLimit } from "@/lib/rate-limit";
 
 export const maxDuration = 60;
@@ -32,27 +29,10 @@ When answering questions:
 
 async function loadDocsFiles(): Promise<Record<string, string>> {
   const files: Record<string, string> = {};
-
-  const results = await Promise.allSettled(
-    allDocsPages.map(async (page) => {
-      const slug = page.href.replace(/^\//, "");
-      const filePath = slug
-        ? join(process.cwd(), "src", "app", slug, "page.mdx")
-        : join(process.cwd(), "src", "app", "page.mdx");
-
-      const raw = await readFile(filePath, "utf-8");
-      const md = mdxToCleanMarkdown(raw);
-      const fileName = slug ? `/${slug}.md` : "/index.md";
-      return { fileName, md };
-    })
-  );
-
-  for (const result of results) {
-    if (result.status === "fulfilled") {
-      files[result.value.fileName] = result.value.md;
-    }
+  const sources = await loadAllDocsSources();
+  for (const source of sources) {
+    files[source.markdownHref] = source.markdown;
   }
-
   return files;
 }
 

--- a/apps/docs/src/app/api/docs-md/[[...slug]]/route.ts
+++ b/apps/docs/src/app/api/docs-md/[[...slug]]/route.ts
@@ -1,0 +1,29 @@
+import { applyMarkdownHeaders, generateNotFoundMarkdown } from "@vercel/agent-readability";
+import { isSafePathSegments } from "@/lib/docs-source";
+import { markdownForPathname } from "@/lib/page-markdown";
+import { canonicalUrlFor, siteUrl } from "@/lib/site";
+
+type RouteContext = {
+  params: Promise<{ slug?: string[] }>;
+};
+
+export async function GET(_request: Request, { params }: RouteContext) {
+  const { slug = [] } = await params;
+  const safe = isSafePathSegments(slug);
+  const pathname = slug.length > 0 ? `/${slug.join("/")}` : "/";
+  const page = safe
+    ? await markdownForPathname(pathname)
+    : {
+        body: generateNotFoundMarkdown(pathname, {
+          sitemapUrl: "/sitemap.md",
+          indexUrl: "/llms.txt",
+          exampleUrl: "/commands",
+          baseUrl: siteUrl,
+        }),
+        canonicalUrl: canonicalUrlFor(pathname),
+      };
+  const headers = new Headers({ "Content-Type": "text/markdown; charset=utf-8" });
+  applyMarkdownHeaders(headers, { canonicalUrl: page.canonicalUrl });
+
+  return new Response(page.body, { status: 200, headers });
+}

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -18,6 +18,10 @@ export const metadata: Metadata = {
     template: "%s | portless",
   },
   description: "Replace port numbers with stable, named .localhost URLs. For humans and agents.",
+  alternates: {
+    canonical: "/",
+    types: { "text/markdown": "/index.md" },
+  },
   openGraph: {
     type: "website",
     locale: "en_US",
@@ -110,10 +114,21 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   const [cookieStore, stars] = await Promise.all([cookies(), getStarCount()]);
   const chatOpen = cookieStore.get("docs-chat-open")?.value === "true";
   const chatWidth = Number(cookieStore.get("docs-chat-width")?.value) || 400;
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: "portless",
+    url: "https://portless.sh",
+    description: "Replace port numbers with stable, named .localhost URLs. For humans and agents.",
+  };
 
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+        />
         {chatOpen && (
           <style
             dangerouslySetInnerHTML={{

--- a/apps/docs/src/app/llms.txt/route.ts
+++ b/apps/docs/src/app/llms.txt/route.ts
@@ -1,0 +1,24 @@
+import { loadAllDocsSources } from "@/lib/docs-source";
+import { siteDescription, siteName, siteUrl } from "@/lib/site";
+
+export const dynamic = "force-static";
+
+export async function GET() {
+  const sources = await loadAllDocsSources();
+  const body = [
+    `# ${siteName}`,
+    "",
+    `> ${siteDescription}`,
+    "",
+    `Documentation: [${siteUrl}](${siteUrl})`,
+    "",
+    "## Pages",
+    "",
+    ...sources.map((source) => `- [${source.title}](${source.canonicalUrl})`),
+    "",
+  ].join("\n");
+
+  return new Response(body, {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+}

--- a/apps/docs/src/app/sitemap.ts
+++ b/apps/docs/src/app/sitemap.ts
@@ -6,6 +6,5 @@ const baseUrl = "https://portless.sh";
 export default function sitemap(): MetadataRoute.Sitemap {
   return allDocsPages.map((page) => ({
     url: `${baseUrl}${page.href}`,
-    lastModified: new Date(),
   }));
 }

--- a/apps/docs/src/lib/agent-readability.test.ts
+++ b/apps/docs/src/lib/agent-readability.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "vitest";
+import { shouldServeMarkdown } from "@vercel/agent-readability";
 import { GET as getMarkdown } from "../app/api/docs-md/[[...slug]]/route";
 import { allDocsPages } from "./docs-navigation";
 import { isSafePathSegments, loadAllDocsSources } from "./docs-source";
-import { isPreviewBot } from "./agent-routing";
 import { markdownForPathname } from "./page-markdown";
 
 describe("docs source", () => {
@@ -56,11 +56,25 @@ describe("public Markdown", () => {
 });
 
 describe("social previews", () => {
-  test.each(["Slackbot-LinkExpanding 1.0", "Discordbot/2.0"])("bypasses %s", (ua) => {
-    expect(isPreviewBot(ua)).toBe(true);
+  test.each([
+    "Slackbot-LinkExpanding 1.0",
+    "Discordbot/2.0",
+    "redditbot/1.0",
+    "bitlybot/3.0",
+    "Pinterestbot/1.0",
+  ])("keeps %s on HTML", (userAgent) => {
+    const result = shouldServeMarkdown({
+      headers: new Headers({ "user-agent": userAgent }),
+    });
+
+    expect(result.serve).toBe(false);
   });
 
-  test("does not bypass agents", () => {
-    expect(isPreviewBot("ClaudeBot/1.0")).toBe(false);
+  test("still detects agents", () => {
+    const result = shouldServeMarkdown({
+      headers: new Headers({ "user-agent": "ClaudeBot/1.0" }),
+    });
+
+    expect(result.serve).toBe(true);
   });
 });

--- a/apps/docs/src/lib/agent-readability.test.ts
+++ b/apps/docs/src/lib/agent-readability.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest";
+import { GET as getMarkdown } from "../app/api/docs-md/[[...slug]]/route";
+import { allDocsPages } from "./docs-navigation";
+import { isSafePathSegments, loadAllDocsSources } from "./docs-source";
+import { isPreviewBot } from "./agent-routing";
+import { markdownForPathname } from "./page-markdown";
+
+describe("docs source", () => {
+  test("loads every inventory page as clean Markdown", async () => {
+    const sources = await loadAllDocsSources();
+    expect(sources).toHaveLength(allDocsPages.length);
+    for (const source of sources) {
+      expect(source.markdown).not.toMatch(/^(import|export) /m);
+      expect(source.markdown).not.toContain("className=");
+    }
+  });
+
+  test.each([
+    ["parent", [".."]],
+    ["slash", ["why/commands"]],
+    ["backslash", [String.raw`..\\why`]],
+    ["empty", [""]],
+  ])("rejects a decoded %s segment", (_name, segments) => {
+    expect(isSafePathSegments(segments)).toBe(false);
+  });
+});
+
+describe("public Markdown", () => {
+  test("renders canonical frontmatter for every page", async () => {
+    for (const page of allDocsPages) {
+      const rendered = await markdownForPathname(page.href);
+      expect(rendered.found).toBe(true);
+      expect(rendered.body).toContain(`canonical_url: ${JSON.stringify(rendered.canonicalUrl)}`);
+      expect(rendered.body).not.toContain("last_updated:");
+    }
+  });
+
+  test("returns a readable body for missing pages", async () => {
+    const rendered = await markdownForPathname("/missing");
+    expect(rendered.found).toBe(false);
+    expect(rendered.body).toContain("# Page Not Found");
+    expect(rendered.body).toContain("/sitemap.md");
+  });
+
+  test("serves missing pages with Markdown attribution", async () => {
+    const response = await getMarkdown(new Request("https://portless.sh/missing.md"), {
+      params: Promise.resolve({ slug: ["missing"] }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/markdown; charset=utf-8");
+    expect(response.headers.get("vary")).toContain("Accept");
+    expect(response.headers.get("link")).toBe('<https://portless.sh/missing>; rel="canonical"');
+    expect(await response.text()).toContain("# Page Not Found");
+  });
+});
+
+describe("social previews", () => {
+  test.each(["Slackbot-LinkExpanding 1.0", "Discordbot/2.0"])("bypasses %s", (ua) => {
+    expect(isPreviewBot(ua)).toBe(true);
+  });
+
+  test("does not bypass agents", () => {
+    expect(isPreviewBot("ClaudeBot/1.0")).toBe(false);
+  });
+});

--- a/apps/docs/src/lib/agent-routing.ts
+++ b/apps/docs/src/lib/agent-routing.ts
@@ -1,5 +1,0 @@
-const PREVIEW_BOTS = /slackbot|discordbot/i;
-
-export function isPreviewBot(userAgent: string): boolean {
-  return PREVIEW_BOTS.test(userAgent);
-}

--- a/apps/docs/src/lib/agent-routing.ts
+++ b/apps/docs/src/lib/agent-routing.ts
@@ -1,0 +1,5 @@
+const PREVIEW_BOTS = /slackbot|discordbot/i;
+
+export function isPreviewBot(userAgent: string): boolean {
+  return PREVIEW_BOTS.test(userAgent);
+}

--- a/apps/docs/src/lib/docs-source-retry.test.ts
+++ b/apps/docs/src/lib/docs-source-retry.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test, vi } from "vitest";
+
+const fsMock = vi.hoisted(() => ({ readFile: vi.fn() }));
+
+vi.mock("fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs/promises")>();
+  fsMock.readFile.mockImplementation(actual.readFile);
+  return { ...actual, readFile: fsMock.readFile };
+});
+
+describe("docs source cache", () => {
+  test("retries after a transient read failure", async () => {
+    const failure = new Error("transient read failure");
+    fsMock.readFile.mockRejectedValueOnce(failure);
+    const { loadDocsSource } = await import("./docs-source");
+
+    await expect(loadDocsSource("/why")).rejects.toBe(failure);
+    await expect(loadDocsSource("/why")).resolves.toMatchObject({ href: "/why" });
+    expect(fsMock.readFile).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/docs/src/lib/docs-source.ts
+++ b/apps/docs/src/lib/docs-source.ts
@@ -54,6 +54,11 @@ export async function loadDocsSource(href: string): Promise<DocsSource | null> {
       markdown: mdxToCleanMarkdown(raw),
     }));
     sourcePromises.set(normalized, pending);
+    pending.catch(() => {
+      if (sourcePromises.get(normalized) === pending) {
+        sourcePromises.delete(normalized);
+      }
+    });
   }
 
   return pending;

--- a/apps/docs/src/lib/docs-source.ts
+++ b/apps/docs/src/lib/docs-source.ts
@@ -1,0 +1,65 @@
+import { readFile } from "fs/promises";
+import { join } from "path";
+import { allDocsPages } from "./docs-navigation";
+import { mdxToCleanMarkdown } from "./mdx-to-markdown";
+import { canonicalUrlFor, siteDescription } from "./site";
+
+export type DocsSource = {
+  title: string;
+  href: string;
+  markdownHref: string;
+  canonicalUrl: string;
+  description: string;
+  markdown: string;
+};
+
+const sourcePromises = new Map<string, Promise<DocsSource>>();
+const pagesByHref = new Map(allDocsPages.map((page) => [page.href, page]));
+
+export function isSafePathSegments(segments: readonly string[]): boolean {
+  return segments.every(
+    (segment) =>
+      segment.length > 0 &&
+      segment !== "." &&
+      segment !== ".." &&
+      !segment.includes("/") &&
+      !segment.includes("\\")
+  );
+}
+
+export function normalizeDocsHref(pathname: string): string {
+  if (!pathname || pathname === "/") return "/";
+  return pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+}
+
+function sourcePath(href: string): string {
+  const docsRoot = join(process.cwd(), "src", "app");
+  if (href === "/") return join(docsRoot, "page.mdx");
+  return join(docsRoot, ...href.slice(1).split("/"), "page.mdx");
+}
+
+export async function loadDocsSource(href: string): Promise<DocsSource | null> {
+  const normalized = normalizeDocsHref(href);
+  const page = pagesByHref.get(normalized);
+  if (!page) return null;
+
+  let pending = sourcePromises.get(normalized);
+  if (!pending) {
+    pending = readFile(sourcePath(normalized), "utf-8").then((raw) => ({
+      title: page.name,
+      href: normalized,
+      markdownHref: normalized === "/" ? "/index.md" : `${normalized}.md`,
+      canonicalUrl: canonicalUrlFor(normalized),
+      description: siteDescription,
+      markdown: mdxToCleanMarkdown(raw),
+    }));
+    sourcePromises.set(normalized, pending);
+  }
+
+  return pending;
+}
+
+export async function loadAllDocsSources(): Promise<DocsSource[]> {
+  const sources = await Promise.all(allDocsPages.map((page) => loadDocsSource(page.href)));
+  return sources.filter((source): source is DocsSource => source !== null);
+}

--- a/apps/docs/src/lib/page-markdown.ts
+++ b/apps/docs/src/lib/page-markdown.ts
@@ -1,0 +1,64 @@
+import { generateNotFoundMarkdown } from "@vercel/agent-readability";
+import { loadAllDocsSources, loadDocsSource, normalizeDocsHref } from "./docs-source";
+import { canonicalUrlFor, siteName, siteUrl } from "./site";
+
+function frontmatter(fields: { title: string; description: string; canonicalUrl: string }): string {
+  return [
+    "---",
+    `title: ${JSON.stringify(fields.title)}`,
+    `description: ${JSON.stringify(fields.description)}`,
+    `canonical_url: ${JSON.stringify(fields.canonicalUrl)}`,
+    "---",
+    "",
+  ].join("\n");
+}
+
+async function sitemapMarkdown(): Promise<string> {
+  const sources = await loadAllDocsSources();
+  return [
+    `# ${siteName} documentation`,
+    "",
+    ...sources.map((source) => `- [${source.title}](${source.canonicalUrl})`),
+    "",
+  ].join("\n");
+}
+
+export async function markdownForPathname(pathname: string): Promise<{
+  body: string;
+  canonicalUrl: string;
+  found: boolean;
+}> {
+  const normalized = normalizeDocsHref(pathname);
+
+  if (normalized === "/sitemap") {
+    return {
+      body: await sitemapMarkdown(),
+      canonicalUrl: `${siteUrl}/sitemap.md`,
+      found: true,
+    };
+  }
+
+  const source = await loadDocsSource(normalized);
+  if (source) {
+    return {
+      body: `${frontmatter({
+        title: source.title,
+        description: source.description,
+        canonicalUrl: source.canonicalUrl,
+      })}${source.markdown}\n`,
+      canonicalUrl: source.canonicalUrl,
+      found: true,
+    };
+  }
+
+  return {
+    body: generateNotFoundMarkdown(normalized, {
+      sitemapUrl: "/sitemap.md",
+      indexUrl: "/llms.txt",
+      exampleUrl: "/commands",
+      baseUrl: siteUrl,
+    }),
+    canonicalUrl: canonicalUrlFor(normalized),
+    found: false,
+  };
+}

--- a/apps/docs/src/lib/page-metadata.ts
+++ b/apps/docs/src/lib/page-metadata.ts
@@ -14,6 +14,10 @@ export function pageMetadata(slug: string): Metadata {
 
   return {
     title: displayTitle,
+    alternates: {
+      canonical: `/${slug}`,
+      types: { "text/markdown": `/${slug}.md` },
+    },
     openGraph: {
       type: "website",
       locale: "en_US",

--- a/apps/docs/src/lib/search-index.ts
+++ b/apps/docs/src/lib/search-index.ts
@@ -1,7 +1,4 @@
-import { readFile } from "fs/promises";
-import { join } from "path";
-import { allDocsPages } from "./docs-navigation";
-import { mdxToCleanMarkdown } from "./mdx-to-markdown";
+import { loadAllDocsSources } from "./docs-source";
 
 export type IndexEntry = {
   title: string;
@@ -23,39 +20,14 @@ function stripMarkdown(md: string): string {
     .trim();
 }
 
-function mdxFileForSlug(slug: string): string {
-  const docsRoot = join(process.cwd(), "src", "app");
-  if (slug === "/") {
-    return join(docsRoot, "page.mdx");
-  }
-  const rest = slug.replace(/^\//, "");
-  return join(docsRoot, ...rest.split("/"), "page.mdx");
-}
-
 export async function getSearchIndex(): Promise<IndexEntry[]> {
   if (cached) return cached;
 
-  const entries: IndexEntry[] = [];
-
-  for (const item of allDocsPages) {
-    try {
-      const raw = await readFile(mdxFileForSlug(item.href), "utf-8");
-      const md = mdxToCleanMarkdown(raw);
-      const content = stripMarkdown(md);
-      entries.push({
-        title: item.name,
-        href: item.href,
-        content,
-      });
-    } catch {
-      entries.push({
-        title: item.name,
-        href: item.href,
-        content: "",
-      });
-    }
-  }
-
-  cached = entries;
-  return entries;
+  const sources = await loadAllDocsSources();
+  cached = sources.map((source) => ({
+    title: source.title,
+    href: source.href,
+    content: stripMarkdown(source.markdown),
+  }));
+  return cached;
 }

--- a/apps/docs/src/lib/site.ts
+++ b/apps/docs/src/lib/site.ts
@@ -1,0 +1,8 @@
+export const siteUrl = "https://portless.sh";
+export const siteName = "portless";
+export const siteDescription =
+  "Replace port numbers with stable, named .localhost URLs. For humans and agents.";
+
+export function canonicalUrlFor(href: string): string {
+  return `${siteUrl}${href === "/" ? "" : href}`;
+}

--- a/apps/docs/src/proxy.ts
+++ b/apps/docs/src/proxy.ts
@@ -1,20 +1,10 @@
 import { withAgentReadability } from "@vercel/agent-readability/next";
-import type { NextFetchEvent, NextRequest } from "next/server";
-import { NextResponse } from "next/server";
-import { isPreviewBot } from "@/lib/agent-routing";
 
-const agentMarkdown = withAgentReadability({
+export default withAgentReadability({
   docsPrefix: "/",
   rewrite: (pathname) => (pathname === "/" ? "/api/docs-md" : `/api/docs-md${pathname}`),
   canonicalUrl: () => null,
 });
-
-export default function proxy(request: NextRequest, event: NextFetchEvent) {
-  if (isPreviewBot(request.headers.get("user-agent") ?? "")) {
-    return NextResponse.next();
-  }
-  return agentMarkdown(request, event);
-}
 
 export const config = {
   matcher: "/((?!_next|api|og|.*\\..*|favicon|manifest|robots|health|status).*)",

--- a/apps/docs/src/proxy.ts
+++ b/apps/docs/src/proxy.ts
@@ -1,0 +1,21 @@
+import { withAgentReadability } from "@vercel/agent-readability/next";
+import type { NextFetchEvent, NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { isPreviewBot } from "@/lib/agent-routing";
+
+const agentMarkdown = withAgentReadability({
+  docsPrefix: "/",
+  rewrite: (pathname) => (pathname === "/" ? "/api/docs-md" : `/api/docs-md${pathname}`),
+  canonicalUrl: () => null,
+});
+
+export default function proxy(request: NextRequest, event: NextFetchEvent) {
+  if (isPreviewBot(request.headers.get("user-agent") ?? "")) {
+    return NextResponse.next();
+  }
+  return agentMarkdown(request, event);
+}
+
+export const config = {
+  matcher: "/((?!_next|api|og|.*\\..*|favicon|manifest|robots|health|status).*)",
+};

--- a/apps/docs/vitest.config.ts
+++ b/apps/docs/vitest.config.ts
@@ -1,0 +1,10 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^1.36.2
         version: 1.36.2
       '@vercel/agent-readability':
-        specifier: 0.5.0
-        version: 0.5.0(@sveltejs/kit@2.53.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.2)(vite@7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.97.1)(terser@5.46.0)(yaml@2.8.2)))(svelte@5.53.2)(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.97.1)(terser@5.46.0)(yaml@2.8.2)))(h3@1.15.5)(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.1))
+        specifier: 0.5.1
+        version: 0.5.1(@sveltejs/kit@2.53.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.2)(vite@7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.97.1)(terser@5.46.0)(yaml@2.8.2)))(svelte@5.53.2)(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.97.1)(terser@5.46.0)(yaml@2.8.2)))(h3@1.15.5)(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.1))
       ai:
         specifier: ^6.0.94
         version: 6.0.94(zod@4.3.5)
@@ -4027,8 +4027,8 @@ packages:
   '@upstash/redis@1.36.2':
     resolution: {integrity: sha512-C0Yt8hc12vLaQYRG1fMci8iPrLtnTdbJG0HR5T8vKnvEP/1RdMMblsOJs5/jp0JXZJ1oSzMnQz4J9EVezNpI6A==}
 
-  '@vercel/agent-readability@0.5.0':
-    resolution: {integrity: sha512-ZY2i+p2/YCu4kAMGeGCq7Dn22XFWmLwQ1+sa2PrvWdeGCKqcx+CNp+4RF022QI+/e8RgPRjwQurjpmafiZlhTA==}
+  '@vercel/agent-readability@0.5.1':
+    resolution: {integrity: sha512-iQih444RJMoAREej/ccTmAUc+PiSogRffqQZMvGdcfF/5GN/4VilXrMHYQWRIq75c70D2AIOxX5sh9EG23ZT3w==}
     engines: {node: '>=20.0.0'}
     hasBin: true
     peerDependencies:
@@ -12586,7 +12586,7 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/agent-readability@0.5.0(@sveltejs/kit@2.53.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.2)(vite@7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.97.1)(terser@5.46.0)(yaml@2.8.2)))(svelte@5.53.2)(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.97.1)(terser@5.46.0)(yaml@2.8.2)))(h3@1.15.5)(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.1))':
+  '@vercel/agent-readability@0.5.1(@sveltejs/kit@2.53.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.2)(vite@7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.97.1)(terser@5.46.0)(yaml@2.8.2)))(svelte@5.53.2)(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.97.1)(terser@5.46.0)(yaml@2.8.2)))(h3@1.15.5)(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.1))':
     optionalDependencies:
       '@sveltejs/kit': 2.53.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.2)(vite@7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.97.1)(terser@5.46.0)(yaml@2.8.2)))(svelte@5.53.2)(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.97.1)(terser@5.46.0)(yaml@2.8.2))
       h3: 1.15.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@upstash/redis':
         specifier: ^1.36.2
         version: 1.36.2
+      '@vercel/agent-readability':
+        specifier: 0.5.0
+        version: 0.5.0(@sveltejs/kit@2.53.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.2)(vite@7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.97.1)(terser@5.46.0)(yaml@2.8.2)))(svelte@5.53.2)(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.97.1)(terser@5.46.0)(yaml@2.8.2)))(h3@1.15.5)(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.1))
       ai:
         specifier: ^6.0.94
         version: 6.0.94(zod@4.3.5)
@@ -117,6 +120,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.11(@types/node@24.12.4)(typescript@5.9.3))(sass@1.97.1)(terser@5.46.0)(yaml@2.8.2)
 
   examples/google-oauth:
     dependencies:
@@ -4020,6 +4026,25 @@ packages:
 
   '@upstash/redis@1.36.2':
     resolution: {integrity: sha512-C0Yt8hc12vLaQYRG1fMci8iPrLtnTdbJG0HR5T8vKnvEP/1RdMMblsOJs5/jp0JXZJ1oSzMnQz4J9EVezNpI6A==}
+
+  '@vercel/agent-readability@0.5.0':
+    resolution: {integrity: sha512-ZY2i+p2/YCu4kAMGeGCq7Dn22XFWmLwQ1+sa2PrvWdeGCKqcx+CNp+4RF022QI+/e8RgPRjwQurjpmafiZlhTA==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@sveltejs/kit': '>=2'
+      '@vercel/functions': ^3
+      h3: '>=1.8 <2'
+      next: '>=14'
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      '@vercel/functions':
+        optional: true
+      h3:
+        optional: true
+      next:
+        optional: true
 
   '@vercel/nft@1.3.1':
     resolution: {integrity: sha512-ihNT1rswiq3cy4WKQAV5kJi6UjWX1vLUzlLc+Vvq83G8CU9nMgfDWz5f1tOnSlS8LeC4Wp4qTB3+HGj/ccUrFQ==}
@@ -12560,6 +12585,12 @@ snapshots:
   '@upstash/redis@1.36.2':
     dependencies:
       uncrypto: 0.1.3
+
+  '@vercel/agent-readability@0.5.0(@sveltejs/kit@2.53.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.2)(vite@7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.97.1)(terser@5.46.0)(yaml@2.8.2)))(svelte@5.53.2)(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.97.1)(terser@5.46.0)(yaml@2.8.2)))(h3@1.15.5)(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.1))':
+    optionalDependencies:
+      '@sveltejs/kit': 2.53.0(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.2)(vite@7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.97.1)(terser@5.46.0)(yaml@2.8.2)))(svelte@5.53.2)(typescript@5.9.3)(vite@7.3.1(@types/node@24.12.4)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.97.1)(terser@5.46.0)(yaml@2.8.2))
+      h3: 1.15.5
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.1)
 
   '@vercel/nft@1.3.1(encoding@0.1.13)(rollup@4.57.0)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,6 @@
 minimumReleaseAge: 2880
+minimumReleaseAgeExclude:
+  - "@vercel/agent-readability@0.5.1"
 
 allowBuilds:
   "@mongodb-js/zstd": false


### PR DESCRIPTION
## Summary

- add a shared `allDocsPages` MDX loader for search, docs chat, and public Markdown
- serve `/llms.txt`, `/sitemap.md`, direct `.md` mirrors, and negotiated Markdown through `@vercel/agent-readability@0.5.0`
- add canonical links, Markdown alternates, and sitewide `WebSite` JSON-LD
- preserve HTML for browsers, Slackbot, Discordbot, APIs, OG routes, and static assets
- keep browser misses as 404 while returning readable Markdown 200 responses to agents
- remove synthetic sitemap `lastModified` values

## Verification

- `pnpm --filter @portless/docs test` (11 tests)
- `pnpm --filter @portless/docs build`
- production-server route matrix across all six canonical pages for browser UA, ClaudeBot, `Accept: text/markdown`, and direct `.md`
- reserved route, social preview, encoded segment, canonical header, metadata, browser 404, and agent missing-page checks
- force-red mutations for Slackbot bypass and decoded parent-segment validation

The current production audit is 53/100. The projected result is 90 to 92 without fabricated freshness dates. The final score must be measured against this PR's Vercel preview because local discovery URLs intentionally point to the production canonical host.
