### PR TITLE
fix: reject leftover suffixes in alias port arguments

### DIFF
--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -866,6 +866,27 @@ describe("CLI", () => {
       expect(stderr).toContain("Invalid port");
     });
 
+    it("exits 1 for port arguments with leftover suffixes", () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-alias-port-"));
+      try {
+        for (const aliasPort of ["192.168.1.1:8123", "8123abc", "81.23"]) {
+          const { status, stderr } = run(["alias", "mydb", aliasPort], {
+            env: { PORTLESS_STATE_DIR: tmpDir },
+          });
+          expect(status).toBe(1);
+          expect(stderr).toContain(`Error: Invalid port "${aliasPort}". Must be 1-65535.`);
+        }
+
+        const routesPath = path.join(tmpDir, "routes.json");
+        if (fs.existsSync(routesPath)) {
+          const routes = JSON.parse(fs.readFileSync(routesPath, "utf-8")) as unknown;
+          expect(routes).toEqual([]);
+        }
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
     it("exits 1 when --remove has no name", () => {
       const { status, stderr } = run(["alias", "--remove"]);
       expect(status).toBe(1);

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -2325,8 +2325,8 @@ ${colors.bold("Examples:")}
   }
 
   const hostnames = buildHostnames(aliasName, tlds);
-  const port = parseInt(aliasPort, 10);
-  if (isNaN(port) || port < 1 || port > 65535) {
+  const port = /^\d+$/.test(aliasPort) ? Number(aliasPort) : NaN;
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
     console.error(colors.red(`Error: Invalid port "${aliasPort}". Must be 1-65535.`));
     process.exit(1);
   }


### PR DESCRIPTION
`portless alias` accepted arguments like `192.168.1.1:8123` because `parseInt` kept the numeric prefix (192) and registered a route.

Reject any alias port that is not a whole integer in 1-65535. The existing Invalid port error is unchanged.

Fixes #379