### PR TITLE
feat(package): include agent skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ coverage/
 .pnpm-store/
 .turbo
 .next/
+packages/portless/README.md
+packages/portless/skills/
+packages/portless/examples/
 next-env.d.ts
 .env*
 !.env.example

--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ npm install -g portless
 npm install -D portless
 ```
 
+**Agent skills for Pi and OMP:**
+
+```bash
+pi install npm:portless
+omp install portless
+```
+
+These commands install the bundled Portless and OAuth skills. Install the CLI globally or as a project dependency as shown above.
+
 > portless is pre-1.0. When installed per-project, different contributors may run different versions. The state directory format may change between releases, which can require re-running `portless trust`.
 
 ## Run your app

--- a/packages/portless/package.json
+++ b/packages/portless/package.json
@@ -15,7 +15,9 @@
     "portless": "./dist/cli.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "skills",
+    "examples/google-oauth"
   ],
   "engines": {
     "node": ">=24"
@@ -30,17 +32,25 @@
     "dev": "tsup --watch",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
-    "prepublishOnly": "cp ../../README.md . && pnpm build",
+    "prepack": "rm -rf skills examples && cp -R ../../skills ./skills && mkdir -p examples && cp -R ../../examples/google-oauth ./examples/google-oauth && cp ../../README.md . && pnpm build",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "type-check": "tsc --noEmit"
   },
+  "pi": {
+    "skills": [
+      "./skills"
+    ]
+  },
   "keywords": [
     "local",
     "development",
     "proxy",
-    "localhost"
+    "localhost",
+    "pi-package",
+    "agent-skills",
+    "oh-my-pi"
   ],
   "author": "Vercel Labs",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- Ship the existing Portless and OAuth skills in the published npm package.
- Declare the `pi.skills` manifest so Pi and OMP package managers discover them.
- Include the Google OAuth example referenced by the OAuth skill.
- Document agent skill installation for both package managers.

## Testing

- `pnpm format:check`
- `pnpm --filter portless lint`
- `pnpm --filter portless type-check`
- `pnpm --filter portless test`
- `pnpm --filter portless pack --pack-destination /tmp/portless-package-proof`
- Installed the tarball in an isolated project and ran `portless --version`
- Verified OMP recognizes `./skills` from the installed tarball with `omp install ./node_modules/portless --dry-run --json`
