### PR TITLE
Prepare v0.15.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,27 @@
 # Changelog
 
-## 0.15.5
+## 0.15.6
 
 <!-- release:start -->
+
+### New Features
+
+- **Agent-readable documentation**: The documentation site now exposes clean Markdown pages and an `llms.txt` index so agents can discover and consume the docs directly. (#387)
+
+### Bug Fixes
+
+- **Framework flags through package scripts**: Frameworks that ignore `PORT` now receive the assigned `--port` and `--host` flags when launched through supported package-manager scripts, while non-server and unsafe scripts are left untouched. (#366)
+- **Windows service lifetime**: The Windows startup service now registers a UTF-16 Task Scheduler definition with no execution time limit and replaces existing tasks atomically. (#381)
+- **Ctrl+C process cleanup**: Interrupt handling now waits for the command's process tree to exit and terminates remaining descendants after a short grace period. (#385)
+
+### Contributors
+
+- @Railly
+- @EfeDurmaz16
+- @JohnPhamous
+<!-- release:end -->
+
+## 0.15.5
 
 ### Bug Fixes
 
@@ -15,7 +34,6 @@
 - @KingPsychopath
 - @erichurkman
 - @sanjevirau
-<!-- release:end -->
 
 ## 0.15.4
 

--- a/apps/docs/src/app/changelog/page.mdx
+++ b/apps/docs/src/app/changelog/page.mdx
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.15.6
+
+### New Features
+
+- **Agent-readable documentation**: The documentation site now exposes clean Markdown pages and an `llms.txt` index so agents can discover and consume the docs directly
+
+### Bug Fixes
+
+- **Framework flags through package scripts**: Frameworks that ignore `PORT` now receive the assigned `--port` and `--host` flags when launched through supported package-manager scripts, while non-server and unsafe scripts are left untouched
+- **Windows service lifetime**: The Windows startup service now registers a Task Scheduler definition with no execution time limit and replaces existing tasks atomically
+- **Ctrl+C process cleanup**: Interrupt handling now waits for the command's process tree to exit and terminates remaining descendants after a short grace period
+
 ## 0.15.5
 
 ### Bug Fixes

--- a/packages/portless/package.json
+++ b/packages/portless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portless",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "description": "Replace port numbers with stable, named .localhost URLs. For humans and agents.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
- Bump the portless package to 0.15.6.
- Document agent-readable docs, framework flag forwarding, Windows service reliability, and Ctrl+C cleanup.
- Synchronize release notes and keep automated release markers current.