### PR TITLE
Update Immutable to address prototype pollution

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5685,8 +5685,8 @@ packages:
   image-meta@0.2.2:
     resolution: {integrity: sha512-3MOLanc3sb3LNGWQl1RlQlNWURE5g32aUphrDyFeCsxBTk08iE3VNe4CwsUZ0Qs1X+EfX0+r29Sxdpza4B+yRA==}
 
-  immutable@5.1.4:
-    resolution: {integrity: sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==}
+  immutable@5.1.9:
+    resolution: {integrity: sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -14606,7 +14606,7 @@ snapshots:
 
   image-meta@0.2.2: {}
 
-  immutable@5.1.4: {}
+  immutable@5.1.9: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -17240,7 +17240,7 @@ snapshots:
   sass@1.97.1:
     dependencies:
       chokidar: 4.0.3
-      immutable: 5.1.4
+      immutable: 5.1.9
       source-map-js: 1.2.1
     optionalDependencies:
       '@parcel/watcher': 2.5.6


### PR DESCRIPTION
## Summary

- Update the transitive Immutable resolution used by Sass from 5.1.4 to 5.1.9.
- Refresh the matching integrity hash, package snapshot, and Sass dependency edge without changing unrelated lockfile resolutions.

## Why

Immutable 5.1.4 is affected by a prototype-pollution vulnerability. Resolving the patched release removes the affected version from the workspace's build and test dependency graph without changing direct dependencies.

## Verification

- `git diff --check main...HEAD`
- `pnpm why immutable --recursive` confirms the workspace resolves a single Immutable version at 5.1.9 through Sass.
- `pnpm audit --json` reports no advisory for Immutable.

Closes #395