### PR TITLE
Make privileged proxy elevation failures fatal

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ portless myapp next dev
 
 HTTPS with HTTP/2 is enabled by default. On first run, portless generates a local CA, trusts it, and binds port 443 (auto-elevates with sudo on macOS/Linux). Use `--no-tls` for plain HTTP.
 
+On macOS and Linux, a failed elevation exits nonzero and does not start the proxy on another port. Resolve the sudo error, then retry `portless proxy start` to keep clean URLs. To avoid sudo explicitly, run `portless proxy start -p 1355`; URLs then include `:1355`.
+
 The proxy auto-starts when you run an app. A random port (4000-4999) is assigned via the `PORT` environment variable. Most frameworks (Next.js, Express, Nuxt, etc.) respect this automatically. For frameworks that ignore `PORT` (Vite, VitePlus, Astro, React Router, Angular, Expo, React Native), portless auto-injects the right `--port` flag and, when needed, a matching `--host` flag. Injection reaches through a package script whose command starts with the framework or a known runner (`"dev": "vite"`, `"dev": "bunx vite"`). Only the framework's server commands get the flags (`dev`, `serve`, `preview`, `start`, a bare `vite`, or `vite [root]`); a command that does not serve, such as `vite build`, `vite optimize`, `vp test` or `astro check`, rejects them and is left alone. Expo connection modes (`--localhost`, `--lan`, `--tunnel`) are preserved while the assigned port is still injected. A script portless cannot classify is left alone too: a flag before the subcommand on a CLI whose flag grammar it does not track (`vp --mode dev build`). Portless also leaves a script alone when appending flags to it would not work: a compound command (`&&`, `|`, `;`), a trailing `#` comment, its own `--` option terminator, an env prefix (`NODE_ENV=production vite`), delegation to another script (`"dev": "npm run dev:vite"`), or runner flags before the script name (`bun run --bun dev`). Those keep their own port, so set it in the script yourself.
 
 When auto-starting, portless reuses the configuration (port, TLS, TLDs) from the most recent proxy run, so a restart or reboot does not silently revert to defaults. Explicit env vars (`PORTLESS_PORT`, `PORTLESS_HTTPS`, etc.) always take priority.
@@ -399,7 +401,7 @@ PORTLESS=0 pnpm dev              # Bypasses proxy, uses default port
 portless proxy start             # Start the HTTPS proxy (port 443, daemon)
 portless proxy start --no-tls    # Start without HTTPS (port 80)
 portless proxy start --lan       # Start in LAN mode (mDNS .local for devices)
-portless proxy start -p 1355     # Start on a custom port (no sudo)
+portless proxy start -p 1355     # Explicit custom port, no sudo; URLs include :1355
 portless proxy start --foreground  # Start in foreground (for debugging)
 portless proxy start --wildcard  # Allow unregistered subdomains to fall back to parent
 portless proxy stop              # Stop the proxy

--- a/apps/docs/src/app/commands/page.mdx
+++ b/apps/docs/src/app/commands/page.mdx
@@ -160,6 +160,8 @@ Finds and kills orphaned dev server processes left behind by crashed portless se
 portless proxy start
 ```
 
+On macOS and Linux, standard ports request sudo. If elevation fails, the command exits nonzero without starting or persisting a proxy on another port. Resolve the sudo error and retry `portless proxy start`. To avoid sudo explicitly, use `portless proxy start -p 1355`; URLs then include `:1355`. Windows does not require elevation.
+
 <table>
   <thead>
     <tr>
@@ -170,7 +172,7 @@ portless proxy start
   <tbody>
     <tr>
       <td>`-p, --port <number>`</td>
-      <td>Proxy port (default: 443, or 80 with `--no-tls`). Auto-elevates with sudo.</td>
+      <td>Proxy port (default: 443, or 80 with `--no-tls`). Standard ports request sudo on macOS/Linux, and failed elevation exits nonzero.</td>
     </tr>
     <tr>
       <td>`--no-tls`</td>

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -17,7 +17,7 @@ import { createLoopbackConnection, resolveUserHome } from "./utils.js";
 /** True when running on Windows. */
 export const isWindows = process.platform === "win32";
 
-/** Unprivileged fallback port used when standard ports are unavailable. */
+/** Well-known unprivileged port retained for explicit configuration and legacy discovery. */
 export const FALLBACK_PROXY_PORT = 1355;
 
 /**
@@ -785,7 +785,7 @@ export async function discoverState(): Promise<{
 
   // State files didn't help. Probe well-known ports as a last resort.
   // Standard ports first (443, 80) since those are the new defaults, then the
-  // legacy fallback port, then any PORTLESS_PORT override.
+  // legacy unprivileged port, then any PORTLESS_PORT override.
   const configuredPort = getDefaultPort();
   const probePorts = new Set([443, 80, FALLBACK_PROXY_PORT, configuredPort]);
   for (const port of probePorts) {

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -205,6 +205,8 @@ describe("CLI", () => {
       expect(stdout).toContain("PORTLESS_NGROK");
       expect(stdout).toContain("PORTLESS_NGROK_URL");
       expect(stdout).toContain("portless clean");
+      expect(stdout).toContain("Failed elevation exits nonzero without changing ports");
+      expect(stdout).toContain("Use -p 1355 explicitly to avoid sudo (URLs include :1355)");
     });
 
     it("prints help and exits 0 with -h", () => {
@@ -949,6 +951,8 @@ describe("CLI", () => {
       expect(stdout).toContain("portless proxy");
       expect(stdout).toContain("start");
       expect(stdout).toContain("stop");
+      expect(stdout).toContain("Failed elevation exits");
+      expect(stdout).toContain("explicitly use -p 1355 (URLs include :1355)");
     });
 
     it("prints help with -h", () => {
@@ -998,6 +1002,109 @@ describe("CLI", () => {
         expect(stderr).toContain("portless proxy stop");
       } finally {
         await new Promise<void>((resolve) => server.close(() => resolve()));
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe.skipIf(process.platform === "win32")("privileged proxy startup", () => {
+    function writeNonRootPreload(dir: string): string {
+      const preloadPath = path.join(dir, "non-root-preload.cjs");
+      fs.writeFileSync(
+        preloadPath,
+        'Object.defineProperty(process, "getuid", { value: () => 1000, configurable: true });\n'
+      );
+      return preloadPath;
+    }
+
+    function cleanupRecordedProxy(stateDir: string): void {
+      const pidPath = path.join(stateDir, "proxy.pid");
+      if (!fs.existsSync(pidPath)) return;
+      const pid = Number.parseInt(fs.readFileSync(pidPath, "utf-8"), 10);
+      if (!Number.isInteger(pid) || pid <= 0 || pid === process.pid) return;
+      try {
+        process.kill(pid, "SIGTERM");
+      } catch {
+        // The daemon may have already exited.
+      }
+    }
+
+    it("exits nonzero without starting or persisting a fallback when sudo fails", () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-sudo-failure-"));
+      const stateDir = path.join(tmpDir, "state");
+      const fakeBinDir = path.join(tmpDir, "bin");
+      fs.mkdirSync(fakeBinDir);
+      const fakeSudoPath = path.join(fakeBinDir, "sudo");
+      fs.writeFileSync(fakeSudoPath, "#!/bin/sh\nexit 23\n");
+      fs.chmodSync(fakeSudoPath, 0o755);
+      const preloadPath = writeNonRootPreload(tmpDir);
+      const certPath = path.join(tmpDir, "cert.pem");
+      const keyPath = path.join(tmpDir, "key.pem");
+      const env = {
+        PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        PORTLESS_STATE_DIR: stateDir,
+        NODE_OPTIONS: `--require=${preloadPath}`,
+      };
+      const args = [
+        "proxy",
+        "start",
+        "--cert",
+        certPath,
+        "--key",
+        keyPath,
+        "--tld",
+        "test",
+        "--wildcard",
+      ];
+
+      try {
+        for (let attempt = 0; attempt < 2; attempt += 1) {
+          const result = run(args, { env });
+          const output = result.stdout + result.stderr;
+          expect(result.status).toBe(1);
+          expect(result.stderr).toContain(
+            "Error: Port 443 requires elevated privileges, but sudo elevation failed"
+          );
+          expect(result.stderr).toContain(
+            `sudo portless proxy start --cert ${certPath} --key ${keyPath} --tld test --wildcard`
+          );
+          expect(output).not.toContain("Falling back");
+          expect(output).not.toContain("proxy start -p 1355");
+          expect(output).not.toContain("already running on port 1355");
+          expect(fs.existsSync(path.join(stateDir, "proxy.port"))).toBe(false);
+          expect(fs.existsSync(path.join(stateDir, "proxy.pid"))).toBe(false);
+        }
+      } finally {
+        cleanupRecordedProxy(stateDir);
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("uses the same fatal path when sudo cannot be spawned", () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-missing-sudo-"));
+      const stateDir = path.join(tmpDir, "state");
+      const emptyBinDir = path.join(tmpDir, "bin");
+      fs.mkdirSync(emptyBinDir);
+      const preloadPath = writeNonRootPreload(tmpDir);
+
+      try {
+        const result = run(["proxy", "start"], {
+          env: {
+            PATH: emptyBinDir,
+            PORTLESS_STATE_DIR: stateDir,
+            NODE_OPTIONS: `--require=${preloadPath}`,
+          },
+        });
+        const output = result.stdout + result.stderr;
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain("sudo elevation failed");
+        expect(result.stderr).toContain("spawnSync sudo ENOENT");
+        expect(result.stderr).toContain("sudo portless proxy start --https");
+        expect(output).not.toContain("Falling back");
+        expect(fs.existsSync(path.join(stateDir, "proxy.port"))).toBe(false);
+        expect(fs.existsSync(path.join(stateDir, "proxy.pid"))).toBe(false);
+      } finally {
+        cleanupRecordedProxy(stateDir);
         fs.rmSync(tmpDir, { recursive: true, force: true });
       }
     });
@@ -1704,6 +1811,17 @@ describe("CLI", () => {
       expect(start.stdout).toContain(`proxy started on port ${testPort}`);
 
       const stop = run(["proxy", "stop"], { env: proxyEnv() });
+      expect(stop.status).toBe(0);
+      expect(stop.stdout).toContain("Proxy stopped");
+    });
+
+    it("starts and stops an explicitly selected unprivileged port", () => {
+      const env = { PORTLESS_STATE_DIR: tmpDir };
+      const start = run(["proxy", "start", "-p", String(testPort), "--no-tls"], { env });
+      expect(start.status).toBe(0);
+      expect(start.stdout).toContain(`proxy started on port ${testPort}`);
+
+      const stop = run(["proxy", "stop", "-p", String(testPort)], { env });
       expect(stop.status).toBe(0);
       expect(stop.stdout).toContain("Proxy stopped");
     });

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1889,6 +1889,8 @@ ${colors.bold("Options:")}
   --script <name>               Run a specific package.json script (default: dev)
   -p, --port <number>           Port for the proxy (default: 443, or 80 with --no-tls)
                                 Standard ports auto-elevate with sudo on macOS/Linux
+                                Failed elevation exits nonzero without changing ports
+                                Use -p 1355 explicitly to avoid sudo (URLs include :1355)
   --no-tls                      Disable HTTPS (use plain HTTP on port 80)
   --https                       Enable HTTPS (default, accepted for compatibility)
   --lan                         Enable LAN mode (mDNS .local, for real device testing)
@@ -2886,6 +2888,11 @@ ${colors.bold("Usage:")}
   ${colors.cyan("portless proxy start --wildcard")}     Allow unregistered subdomains to fall back to parent
   ${colors.cyan("portless proxy stop")}                 Stop the proxy
 
+${colors.bold("Privileges:")}
+  Standard ports request sudo on macOS/Linux. Failed elevation exits
+  nonzero without starting on another port. Retry the requested command
+  and complete elevation, or explicitly use -p 1355 (URLs include :1355).
+
 ${colors.bold("LAN mode (--lan):")}
   Without LAN mode, the proxy listens only on 127.0.0.1 and ::1.
   LAN mode explicitly binds the proxy to 0.0.0.0 and ::.
@@ -3078,7 +3085,7 @@ ${colors.bold("LAN mode (--lan):")}
     console.warn(colors.cyan("  portless hosts sync"));
   }
 
-  let store = new RouteStore(stateDir, {
+  const store = new RouteStore(stateDir, {
     onWarning: (msg) => console.warn(colors.yellow(msg)),
   });
 
@@ -3149,8 +3156,7 @@ ${colors.bold("LAN mode (--lan):")}
     useWildcard: desiredWildcard,
   };
 
-  // Privileged ports require root on Unix. Auto-elevate with sudo when
-  // possible, falling back to the unprivileged port when sudo is unavailable.
+  // Privileged ports require root on Unix. Auto-elevate with sudo when possible.
   if (!isWindows && proxyPort < PRIVILEGED_PORT_THRESHOLD && (process.getuid?.() ?? -1) !== 0) {
     const startArgs = [
       process.execPath,
@@ -3172,15 +3178,11 @@ ${colors.bold("LAN mode (--lan):")}
         proxyPort,
       }).args,
     ];
-    const fallbackCommand = formatProxyStartCommand(FALLBACK_PROXY_PORT, resolvedConfig);
-    const currentCommand = formatProxyStartCommand(proxyPort, resolvedConfig);
+    const recoveryCommand = formatProxyStartCommand(proxyPort, resolvedConfig);
 
     console.log(
       colors.yellow(`Port ${proxyPort} requires elevated privileges. Requesting sudo...`)
     );
-    if (!hasExplicitPort) {
-      console.log(colors.gray(`(To skip sudo, use an unprivileged port: ${fallbackCommand})`));
-    }
     const result = spawnSync("sudo", ["env", ...collectPortlessEnvArgs(), ...startArgs], {
       stdio: "inherit",
       timeout: SUDO_SPAWN_TIMEOUT_MS,
@@ -3201,40 +3203,21 @@ ${colors.bold("LAN mode (--lan):")}
       return;
     }
 
-    if (result.signal) {
-      process.exit(1);
-    }
-
-    // sudo failed: fall back to the unprivileged port if the user didn't
-    // explicitly request a privileged one.
-    if (!hasExplicitPort) {
-      proxyPort = FALLBACK_PROXY_PORT;
-      console.log(colors.yellow(`Falling back to port ${proxyPort}.`));
-      console.log(
-        colors.blue(`For clean URLs without port numbers, re-run and accept the sudo prompt:`)
-      );
-      console.log(colors.cyan(`  ${fallbackCommand}`));
-
-      if (await isProxyRunning(proxyPort)) {
-        console.log(colors.yellow(`Proxy is already running on port ${proxyPort}.`));
-        return;
-      }
-
-      // Re-initialize state for the fallback port and fall through to the
-      // normal startup path below.
-      stateDir = resolveStateDir(proxyPort);
-      store = new RouteStore(stateDir, {
-        onWarning: (msg: string) => console.warn(colors.yellow(msg)),
-      });
-    } else {
-      // Explicit port was requested but sudo failed; error out.
-      console.error(
-        colors.red(`Error: Port ${proxyPort} requires elevated privileges and sudo failed.`)
-      );
-      console.error(colors.blue("Try again (portless will prompt for sudo):"));
-      console.error(colors.cyan(`  ${currentCommand}`));
-      process.exit(1);
-    }
+    const failure = result.error
+      ? result.error.message
+      : result.signal
+        ? `terminated by signal ${result.signal}`
+        : result.status === null
+          ? "did not return an exit status"
+          : `exited with status ${result.status}`;
+    console.error(
+      colors.red(
+        `Error: Port ${proxyPort} requires elevated privileges, but sudo elevation failed: ${failure}.`
+      )
+    );
+    console.error(colors.blue("Resolve the sudo error, then rerun the requested startup:"));
+    console.error(colors.cyan(`  ${recoveryCommand}`));
+    process.exit(1);
   }
 
   // Prepare TLS options if HTTPS is requested

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -161,7 +161,7 @@ period.
 
 ## How It Works
 
-1. `portless proxy start` starts an HTTPS reverse proxy on port 443 as a background daemon. Auto-elevates with sudo on macOS/Linux; falls back to port 1355 if sudo is unavailable. Use `--no-tls` for plain HTTP on port 80. Configurable with `-p` / `--port` or the `PORTLESS_PORT` env var. The proxy also auto-starts when you run an app.
+1. `portless proxy start` starts an HTTPS reverse proxy on port 443 as a background daemon. It auto-elevates with sudo on macOS/Linux. Failed elevation exits nonzero without starting on another port. Resolve the sudo error and retry, or explicitly use `-p 1355`; those URLs include `:1355`. Use `--no-tls` for plain HTTP on port 80. Configurable with `-p` / `--port` or the `PORTLESS_PORT` env var. The proxy also auto-starts when you run an app.
 2. `portless <name> <cmd>` assigns a random free port (4000-4999) via the `PORT` env var and registers the app with the proxy
 3. The browser hits `https://<name>.localhost`; the proxy forwards to the app's assigned port
 
@@ -396,11 +396,11 @@ For other frameworks that don't read `PORT`, pass the port manually:
 
 ### Permission errors
 
-The default ports (80 for HTTP, 443 for HTTPS) require `sudo` on macOS and Linux. Portless auto-elevates with sudo when needed. If sudo is unavailable, it falls back to port 1355 (no sudo needed). On Windows, no elevation is required.
+The default ports (80 for HTTP, 443 for HTTPS) require `sudo` on macOS and Linux. Portless auto-elevates with sudo when needed. If elevation fails, portless exits nonzero without starting or persisting another endpoint. Resolve the sudo error and retry the requested startup. To avoid sudo, explicitly select port 1355; URLs then include `:1355`. On Windows, no elevation is required.
 
 ```bash
 portless proxy start --https           # Auto-elevates with sudo for port 443
-portless proxy start -p 1355 --https   # No sudo needed (URLs include :1355)
+portless proxy start -p 1355 --https   # Explicit alternative; URLs include :1355
 portless proxy stop                    # Stop (use sudo if started with sudo)
 ```
 


### PR DESCRIPTION
## Summary

- Exit with status 1 when a privileged proxy port cannot obtain sudo elevation.
- Preserve the requested proxy configuration in recovery guidance, including TLS, certificate, TLD, and wildcard options.
- Avoid starting or persisting an implicit port 1355 proxy while keeping port 1355 available when selected explicitly.
- Document the failure and recovery behavior in CLI help, the README, command documentation, and the portless skill.
- Add Unix regression coverage for failed and missing sudo, plus lifecycle coverage for an explicitly selected unprivileged port.

## Why

Scripted callers need a reliable failure when the requested privileged endpoint is unavailable. Silently switching ports reported success for a different endpoint and could persist unintended proxy state for later startups.

## Verification

- `pnpm --filter portless exec vitest run src/cli.test.ts --reporter=dot` (135 passed, 1 skipped)
- `pnpm --filter portless type-check`
- `pnpm --filter portless lint`
- `pnpm exec prettier --check README.md apps/docs/src/app/commands/page.mdx packages/portless/src/cli-utils.ts packages/portless/src/cli.test.ts packages/portless/src/cli.ts skills/portless/SKILL.md`

Closes #392