### PR TITLE
feat: let the worktree prefix be set explicitly (--prefix / PORTLESS_PREFIX)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,15 @@ portless run --name myapp next dev   # -> https://fix-ui.myapp.localhost
 
 Put `portless run` in your `package.json` once and it works everywhere. The main checkout uses the plain name, each worktree gets a unique subdomain. No collisions, no `--force`.
 
+The branch is a good default, but it is only a guess at what you call the checkout. Worktree tooling often names branches on a pattern you never say aloud, and only the last `/` segment is used, so `worktree-fix-ui` or `jd/fix-ui` becomes a hostname nobody recognizes. `--name` cannot fix that: it replaces the base name and the prefix is still prepended. Use `--prefix` to choose the prefix itself:
+
+```bash
+portless run --prefix fix-ui next dev   # -> https://fix-ui.myapp.localhost
+portless run --prefix "" next dev       # -> https://myapp.localhost (no prefix)
+```
+
+`PORTLESS_PREFIX` does the same for a whole shell, which is what a worktree manager should export when it opens one.
+
 ## Custom TLD
 
 By default, portless uses `.localhost` which auto-resolves to `127.0.0.1` in most browsers. If you prefer a different TLD (e.g. `.test`), use `--tld`:
@@ -445,6 +454,7 @@ PORTLESS_HTTPS=0                 Disable HTTPS (same as --no-tls)
 PORTLESS_LAN=1                   Enable LAN mode when set to 1 (auto-detects LAN IP)
 PORTLESS_LAN_IP=<address>        Pin a specific LAN IP for LAN mode
 PORTLESS_TLD=<tld>[,<tld>]       Use one or more TLDs (e.g. localhost,test)
+PORTLESS_PREFIX=<prefix>         Set the worktree prefix ("" for none, same as --prefix)
 PORTLESS_WILDCARD=1              Allow unregistered subdomains to fall back to parent route
 PORTLESS_SYNC_HOSTS=0            Disable auto-sync of /etc/hosts (on by default)
 PORTLESS_TAILSCALE=1             Share apps on your Tailscale network (same as --tailscale)

--- a/packages/portless/src/auto.test.ts
+++ b/packages/portless/src/auto.test.ts
@@ -217,6 +217,48 @@ describe("detectWorktreePrefix", () => {
     fs.writeFileSync(path.join(dir, ".git"), `gitdir: ${gitdir}\n`);
   }
 
+  describe("PORTLESS_PREFIX", () => {
+    const saved = process.env.PORTLESS_PREFIX;
+
+    afterEach(() => {
+      if (saved === undefined) delete process.env.PORTLESS_PREFIX;
+      else process.env.PORTLESS_PREFIX = saved;
+    });
+
+    it("overrides the branch name", () => {
+      setupWorktree(tmpDir, "worktree-auth");
+      process.env.PORTLESS_PREFIX = "auth";
+      expect(detectWorktreePrefix(tmpDir)).toEqual({
+        prefix: "auth",
+        source: "PORTLESS_PREFIX",
+      });
+    });
+
+    it("sanitizes the value it is given", () => {
+      setupWorktree(tmpDir, "worktree-auth");
+      process.env.PORTLESS_PREFIX = "Feature/Auth Flow";
+      expect(detectWorktreePrefix(tmpDir)).toEqual({
+        prefix: "feature-auth-flow",
+        source: "PORTLESS_PREFIX",
+      });
+    });
+
+    it("means no prefix when empty", () => {
+      setupWorktree(tmpDir, "worktree-auth");
+      process.env.PORTLESS_PREFIX = "";
+      expect(detectWorktreePrefix(tmpDir)).toBeNull();
+    });
+
+    it("applies outside a worktree too", () => {
+      fs.mkdirSync(path.join(tmpDir, ".git"));
+      process.env.PORTLESS_PREFIX = "staging";
+      expect(detectWorktreePrefix(tmpDir)).toEqual({
+        prefix: "staging",
+        source: "PORTLESS_PREFIX",
+      });
+    });
+  });
+
   it("returns null for a main checkout (.git directory)", () => {
     fs.mkdirSync(path.join(tmpDir, ".git"));
     const result = detectWorktreePrefix(tmpDir);

--- a/packages/portless/src/auto.ts
+++ b/packages/portless/src/auto.ts
@@ -185,6 +185,28 @@ function branchToPrefix(branch: string): string | null {
 }
 
 /**
+ * Read an explicit prefix from `PORTLESS_PREFIX`, when it is set.
+ *
+ * Returns `undefined` when the variable is absent, meaning "no opinion, go and
+ * ask git". An empty value is an opinion: it means no prefix at all, and is how
+ * a single worktree opts out of prefixing without opting out of portless.
+ *
+ * The branch is a good default but it is only a guess at what the checkout is
+ * called. Worktree tooling often names branches on a pattern the person never
+ * says aloud, and `branchToPrefix` splits on `/` alone, so a `worktree-auth`
+ * or `jd/auth` branch becomes a hostname nobody recognizes. `--name` cannot fix
+ * it: it replaces the base name and the prefix is still prepended in front.
+ */
+function prefixFromEnv(): WorktreePrefix | null | undefined {
+  const raw = process.env.PORTLESS_PREFIX;
+  if (raw === undefined) return undefined;
+
+  const prefix = sanitizeForHostname(raw);
+  if (!prefix) return null;
+  return { prefix, source: "PORTLESS_PREFIX" };
+}
+
+/**
  * Detect if the current directory is inside a multi-worktree git repo and
  * return the current branch name as a prefix for hostname composition.
  *
@@ -198,6 +220,10 @@ function branchToPrefix(branch: string): string | null {
  * Falls back to parsing `.git` file + HEAD when git CLI is unavailable.
  */
 export function detectWorktreePrefix(cwd: string = process.cwd()): WorktreePrefix | null {
+  // An explicit prefix wins over anything git can tell us.
+  const override = prefixFromEnv();
+  if (override !== undefined) return override;
+
   // Primary: git CLI
   const cliResult = detectWorktreeViaCli(cwd);
   if (cliResult !== undefined) return cliResult;

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1642,12 +1642,18 @@ ${colors.bold("Name inference (in order):")}
   In git worktrees, the branch name is prepended as a subdomain prefix
   (e.g. feature-auth.myapp.localhost).
 
+  Use --prefix to choose that prefix yourself when the branch name is not what
+  you call the checkout, or --prefix "" for no prefix at all. PORTLESS_PREFIX
+  does the same thing for a whole shell.
+
 ${colors.bold("Examples:")}
   portless run                        # Run dev script through proxy
   portless run next dev               # -> https://<project>.localhost
   portless run --name myapp next dev  # -> https://myapp.localhost
   portless run vite dev               # -> https://<project>.localhost
   portless run --app-port 3000 pnpm start
+  portless run --prefix auth next dev  # -> https://auth.<project>.localhost
+  portless run --prefix "" next dev    # -> https://<project>.localhost
 `);
       process.exit(0);
     } else if (args[i] === "--force") {
@@ -1663,13 +1669,26 @@ ${colors.bold("Examples:")}
         process.exit(1);
       }
       name = args[i];
+    } else if (args[i] === "--prefix") {
+      i++;
+      if (args[i] === undefined || (args[i].startsWith("-") && args[i] !== "")) {
+        console.error(colors.red("Error: --prefix requires a value."));
+        console.error(colors.cyan("  portless run --prefix <prefix> <command...>"));
+        console.error(colors.cyan('  portless run --prefix "" <command...>   # no prefix'));
+        process.exit(1);
+      }
+      // Assigned to the environment rather than threaded as a value: the prefix
+      // is consumed by detectWorktreePrefix(), which several call sites reach
+      // with no arguments, and PORTLESS_PREFIX is already the documented way to
+      // say this. One reader, one meaning.
+      process.env.PORTLESS_PREFIX = args[i];
     } else if (applySharingFlag(args[i])) {
       // handled
     } else {
       console.error(colors.red(`Error: Unknown flag "${args[i]}".`));
       console.error(
         colors.blue(
-          "Known flags: --name, --force, --app-port, --tailscale, --funnel, --ngrok, --help"
+          "Known flags: --name, --prefix, --force, --app-port, --tailscale, --funnel, --ngrok, --help"
         )
       );
       process.exit(1);
@@ -1886,6 +1905,7 @@ ${colors.bold("ngrok sharing:")}
 ${colors.bold("Options:")}
   run [--name <name>] <cmd>      Infer project name (or override with --name)
                                 Adds worktree prefix in git worktrees
+  --prefix <prefix>             Set the worktree prefix yourself ("" for none)
   --script <name>               Run a specific package.json script (default: dev)
   -p, --port <number>           Port for the proxy (default: 443, or 80 with --no-tls)
                                 Standard ports auto-elevate with sudo on macOS/Linux
@@ -4222,7 +4242,7 @@ async function main() {
 
     if (mode === "run") {
       index++;
-      const runValueFlags = new Set(["--name", "--app-port"]);
+      const runValueFlags = new Set(["--name", "--prefix", "--app-port"]);
       while (index < limit) {
         const next = advancePortlessFlag(index, runValueFlags);
         if (next === null) break;

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -147,6 +147,15 @@ portless run next dev   # -> https://fix-ui.myapp.localhost
 
 No config changes needed. Put `portless run` in `package.json` once and it works in all worktrees.
 
+The prefix comes from the branch, using only the last `/` segment. When the branch is not what the checkout is called (`worktree-fix-ui`, `jd/fix-ui`), set the prefix yourself. `--name` will not do it: that replaces the base name and the prefix is still prepended.
+
+```bash
+portless run --prefix fix-ui next dev   # -> https://fix-ui.myapp.localhost
+portless run --prefix "" next dev       # -> https://myapp.localhost (no prefix)
+```
+
+`PORTLESS_PREFIX` is the same setting for a whole shell.
+
 ### Bypassing portless
 
 Set `PORTLESS=0` to run the command directly without the proxy:
@@ -189,6 +198,7 @@ Portless stores its state (routes, PID file, port file) in `~/.portless`. When t
 | `PORTLESS_LAN`        | Set to `1` to always enable LAN mode (auto-detects LAN IP)                     |
 | `PORTLESS_LAN_IP`     | Pin a specific LAN IP for LAN mode                                             |
 | `PORTLESS_TLD`        | Use one or more TLDs, single or multi-segment (e.g. localhost,dev.example.com) |
+| `PORTLESS_PREFIX`     | Set the worktree prefix, `""` for none (same as `--prefix`)                    |
 | `PORTLESS_WILDCARD`   | Set to `1` to allow unregistered subdomains to fall back to parent             |
 | `PORTLESS_SYNC_HOSTS` | Set to `0` to disable auto-sync of /etc/hosts (on by default)                  |
 | `PORTLESS_TAILSCALE`  | Set to `1` to share apps on your Tailscale network (same as `--tailscale`)     |
@@ -290,6 +300,7 @@ The chosen service configuration is written into launchd, systemd, or Task Sched
 | `portless --script <name>`                        | Run a specific package.json script (default: dev)              |
 | `portless run [cmd] [args...]`                    | Infer name from project, run through proxy (auto-starts)       |
 | `portless run --name <name> <cmd>`                | Override inferred base name (worktree prefix still applies)    |
+| `portless run --prefix <prefix> <cmd>`            | Set the worktree prefix ("" for none)                          |
 | `portless <name> <cmd> [args...]`                 | Run app at `https://<name>.localhost` (auto-starts proxy)      |
 | `portless get <name>`                             | Print URL for a service (for cross-service wiring)             |
 | `portless get <name> --no-worktree`               | Print URL without worktree prefix                              |


### PR DESCRIPTION
## What

`--prefix <value>` on `portless run`, and `PORTLESS_PREFIX` for a whole shell. Both set the worktree subdomain prefix directly, and `""` means no prefix.

```bash
portless run --prefix fix-ui next dev   # -> https://fix-ui.myapp.localhost
portless run --prefix "" next dev       # -> https://myapp.localhost
```

## Why

The branch is a good default, but it is only a guess at what the checkout is called. Worktree tooling routinely names branches on a pattern the person never says aloud, and `branchToPrefix` splits on `/` alone — so `worktree-fix-ui` or `jd/fix-ui` becomes a hostname nobody recognizes.

There was no way to fix that today:

- `--name` replaces the *base* name; the prefix is still prepended in front of it, so you get `worktree-fix-ui.<whatever>.localhost` either way.
- `--no-worktree` exists on `get`, but not on `run`.

Concretely: I am wiring portless into [holt](https://github.com/hausfold/holt), a git-worktree manager for parallel coding agents. It names branches `worktree-<lane>`, so every lane's URL reads `worktree-wiggly-crane.myapp.localhost` instead of `wiggly-crane.myapp.localhost`. The worktree detection is already doing exactly the right thing — the only missing piece is being able to say what the checkout is called.

## How

`prefixFromEnv()` is read at the top of `detectWorktreePrefix`, so one setting reaches every call site that composes a hostname (`run`, monorepo mode, `get`) rather than being threaded through each. That is also what lets a worktree manager export it once when it opens a shell.

Absent and empty are read differently on purpose:

- unset — no opinion, ask git (today's behavior, unchanged)
- `""` — an answer: no prefix. This is the `run` side of `get --no-worktree`.

The value goes through `sanitizeForHostname`, same as a branch does.

`--prefix` assigns `process.env.PORTLESS_PREFIX` rather than threading a value, so there is one reader and one meaning; happy to thread it explicitly instead if you would rather.

## Tests

Four cases added to `auto.test.ts` — override, sanitizing, empty, and outside a worktree. `pnpm --filter portless exec tsc --noEmit` is clean and `auto.test.ts` is 53/53.

Verified by hand against a real worktree on branch `worktree-wiggly-crane`:

```
-- wiggly-crane.myapp.localhost (auto-resolves to 127.0.0.1)
-- Name "myapp" (from package.json)
-- Prefix "wiggly-crane" (from PORTLESS_PREFIX)
```

and `--prefix ""` giving plain `myapp.localhost`. Both served 200 through the proxy.

Heads up: `src/routes.test.ts`'s parallel-`addRoute` case and the `cli.test.ts` CLI suite already fail on a clean checkout of `main` on my machine (macOS 26, Node 24.0.1), unrelated to this change.

## Docs

Per `AGENTS.md`, all three surfaces are updated: `README.md`, `skills/portless/SKILL.md`, and the `--help` output in `cli.ts` (both the `run` help and the top-level options list).