### PR TITLE
fix: clean up on terminal hangup

### DIFF
--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -1124,6 +1124,7 @@ export function spawnCommand(
     if (graceTimer) clearTimeout(graceTimer);
     if (forceTimer) clearTimeout(forceTimer);
     if (shutdownPoll) clearInterval(shutdownPoll);
+    process.removeListener("SIGHUP", onSigHup);
     process.removeListener("SIGINT", onSigInt);
     process.removeListener("SIGTERM", onSigTerm);
     options?.onCleanup?.();
@@ -1164,9 +1165,11 @@ export function spawnCommand(
     shutdownPoll = setInterval(finishShutdownIfComplete, COMMAND_SHUTDOWN_POLL_MS);
   };
 
+  const onSigHup = () => handleSignal("SIGHUP");
   const onSigInt = () => handleSignal("SIGINT");
   const onSigTerm = () => handleSignal("SIGTERM");
 
+  process.on("SIGHUP", onSigHup);
   process.on("SIGINT", onSigInt);
   process.on("SIGTERM", onSigTerm);
 


### PR DESCRIPTION
## Summary

- Route `SIGHUP` through the existing graceful command shutdown path.
- Remove the `SIGHUP` listener during cleanup alongside the other signal listeners.

## Context

Closing a terminal can send `SIGHUP`. Without a handler, the Portless CLI can exit before its cleanup callback removes routes and Tailscale Serve registrations. This addresses one interruption path described in #280. It does not cover `SIGKILL` or failed Tailscale unregister calls, so #280 should remain open for broader recovery work.

Related to #280.

## Testing

- `pnpm --filter portless build`
- `pnpm --filter portless test`
- `pnpm --filter portless lint`
- `pnpm --filter portless type-check`
- Manual POSIX signal check: the child received `SIGHUP`, the CLI exited with code 129, and the active route was removed.