### PR TITLE
feat: give every app its peers' URLs in a monorepo run

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,29 @@ portless run --name myapp next dev   # -> https://fix-ui.myapp.localhost
 
 Put `portless run` in your `package.json` once and it works everywhere. The main checkout uses the plain name, each worktree gets a unique subdomain. No collisions, no `--force`.
 
+### Referencing another app
+
+A service that calls another service cannot hardcode its hostname, because the worktree prefix moves it. A monorepo run therefore gives every app the URL of every app, itself included:
+
+```bash
+PORTLESS_URL_WEB_MYREPO=https://fix-ui.web.myrepo.localhost
+PORTLESS_URL_API_MYREPO=https://fix-ui.api.myrepo.localhost
+```
+
+The variable is named from the app name uppercased, with dots and dashes as underscores (`api.myrepo` becomes `PORTLESS_URL_API_MYREPO`). That name is the same in every worktree, while the URL it holds carries the branch prefix, so the reference can live in committed config:
+
+```ts
+const api = process.env.PORTLESS_URL_API_MYREPO ?? "https://api.myrepo.localhost";
+```
+
+Two apps whose names differ only in punctuation (`web.api` and `web-api`) collapse to one variable name. The first keeps it and portless reports the second, rather than handing out a URL for the wrong app.
+
+An app whose dev script is itself `portless` registers its own route, so this process does not know its URL and it gets no variable. Outside a monorepo run, `portless get <name>` prints the same URL for wiring one app at a time:
+
+```bash
+API_URL=$(portless get api.myrepo)
+```
+
 ## Custom TLD
 
 By default, portless uses `.localhost` which auto-resolves to `127.0.0.1` in most browsers. If you prefer a different TLD (e.g. `.test`), use `--tld`:
@@ -456,6 +479,7 @@ PORTLESS_STATE_DIR=<path>        Override the state directory
 PORT                             Ephemeral port the child should listen on
 HOST                             Usually 127.0.0.1 (omitted for Expo in LAN mode)
 PORTLESS_URL                     Primary public URL (e.g. https://myapp.localhost)
+PORTLESS_URL_<APP>               URL of each app in a monorepo run (e.g. PORTLESS_URL_API_MYREPO)
 PORTLESS_TAILSCALE_URL           Tailscale URL of the app (when --tailscale is active)
 PORTLESS_NGROK_URL               ngrok URL of the app (when --ngrok is active)
 NODE_EXTRA_CA_CERTS              Path to the portless CA (when HTTPS is active)

--- a/apps/docs/src/app/configuration/page.mdx
+++ b/apps/docs/src/app/configuration/page.mdx
@@ -215,6 +215,11 @@ For `appPort`: CLI `--app-port` flag > `PORTLESS_APP_PORT` env var > `package.js
       <td>Set to `0` to bypass the proxy</td>
       <td>enabled</td>
     </tr>
+    <tr>
+      <td>`PORTLESS_URL_<APP>`</td>
+      <td>Set by portless, not read: URL of each app in a monorepo run</td>
+      <td>monorepo runs only</td>
+    </tr>
   </tbody>
 </table>
 

--- a/apps/docs/src/app/page.mdx
+++ b/apps/docs/src/app/page.mdx
@@ -101,6 +101,29 @@ Use `--name` to override the inferred base name while keeping the worktree prefi
 portless run --name myapp next dev   # -> https://fix-ui.myapp.localhost
 ```
 
+## Referencing another app
+
+A service that calls another service cannot hardcode its hostname, because the worktree prefix moves it. A monorepo run therefore gives every app the URL of every app, itself included:
+
+```bash
+PORTLESS_URL_WEB_MYREPO=https://fix-ui.web.myrepo.localhost
+PORTLESS_URL_API_MYREPO=https://fix-ui.api.myrepo.localhost
+```
+
+The variable is named from the app name uppercased, with dots and dashes as underscores (`api.myrepo` becomes `PORTLESS_URL_API_MYREPO`). That name is the same in every worktree while the URL it holds carries the branch prefix, so the reference can live in committed config:
+
+```ts
+const api = process.env.PORTLESS_URL_API_MYREPO ?? "https://api.myrepo.localhost";
+```
+
+Two apps whose names differ only in punctuation (`web.api` and `web-api`) collapse to one variable name. The first keeps it and portless reports the second, rather than handing out a URL for the wrong app. An app whose dev script is itself `portless` registers its own route, so it gets no variable.
+
+Outside a monorepo run, `portless get <name>` prints the same URL for wiring one app at a time:
+
+```bash
+API_URL=$(portless get api.myrepo)
+```
+
 ## Custom TLD
 
 By default, portless uses `.localhost` which auto-resolves to `127.0.0.1` in most browsers. If you prefer a different TLD (e.g. `.test`), use `--tld`:

--- a/packages/portless/src/auto.test.ts
+++ b/packages/portless/src/auto.test.ts
@@ -9,6 +9,8 @@ import {
   inferProjectName,
   detectWorktreePrefix,
   applyWorktreePrefix,
+  peerUrlEnvName,
+  buildPeerUrlEnv,
 } from "./auto.js";
 
 // ---------------------------------------------------------------------------
@@ -479,5 +481,84 @@ describe("applyWorktreePrefix", () => {
     expect(applyWorktreePrefix("api", { prefix: "feature-x", source: "git branch" })).toBe(
       "feature-x.api"
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// peerUrlEnvName
+// ---------------------------------------------------------------------------
+
+describe("peerUrlEnvName", () => {
+  it("uppercases and replaces dots with underscores", () => {
+    expect(peerUrlEnvName("web.myrepo")).toBe("PORTLESS_URL_WEB_MYREPO");
+  });
+
+  it("handles a single-label name", () => {
+    expect(peerUrlEnvName("api")).toBe("PORTLESS_URL_API");
+  });
+
+  it("replaces hyphens too, so the result is a usable shell variable", () => {
+    expect(peerUrlEnvName("web.json-render")).toBe("PORTLESS_URL_WEB_JSON_RENDER");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildPeerUrlEnv
+// ---------------------------------------------------------------------------
+
+describe("buildPeerUrlEnv", () => {
+  it("maps every app to its own variable", () => {
+    expect(
+      buildPeerUrlEnv([
+        { baseName: "web.myrepo", url: "https://web.myrepo.localhost" },
+        { baseName: "api.myrepo", url: "https://api.myrepo.localhost" },
+      ])
+    ).toEqual({
+      PORTLESS_URL_WEB_MYREPO: "https://web.myrepo.localhost",
+      PORTLESS_URL_API_MYREPO: "https://api.myrepo.localhost",
+    });
+  });
+
+  it("names variables from the base name while values carry the worktree prefix", () => {
+    expect(
+      buildPeerUrlEnv([{ baseName: "api.myrepo", url: "https://feature-x.api.myrepo.localhost" }])
+    ).toEqual({ PORTLESS_URL_API_MYREPO: "https://feature-x.api.myrepo.localhost" });
+  });
+
+  it("keeps the first of two names that collapse to one variable, and reports it", () => {
+    const warnings: string[] = [];
+    const env = buildPeerUrlEnv(
+      [
+        { baseName: "web.api", url: "https://web.api.localhost" },
+        { baseName: "web-api", url: "https://web-api.localhost" },
+      ],
+      (msg) => warnings.push(msg)
+    );
+
+    expect(env).toEqual({ PORTLESS_URL_WEB_API: "https://web.api.localhost" });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("PORTLESS_URL_WEB_API");
+    expect(warnings[0]).toContain("web-api");
+  });
+
+  it("does not report a repeated identical name", () => {
+    const warnings: string[] = [];
+    buildPeerUrlEnv(
+      [
+        { baseName: "api", url: "https://api.localhost" },
+        { baseName: "api", url: "https://api.localhost" },
+      ],
+      (msg) => warnings.push(msg)
+    );
+
+    expect(warnings).toEqual([]);
+  });
+
+  it("skips a name that sanitizes to nothing", () => {
+    expect(buildPeerUrlEnv([{ baseName: "...", url: "https://x.localhost" }])).toEqual({});
+  });
+
+  it("returns an empty map for no apps", () => {
+    expect(buildPeerUrlEnv([])).toEqual({});
   });
 });

--- a/packages/portless/src/auto.ts
+++ b/packages/portless/src/auto.ts
@@ -169,6 +169,66 @@ export function applyWorktreePrefix(baseName: string, worktree: WorktreePrefix |
   return worktree ? `${worktree.prefix}.${baseName}` : baseName;
 }
 
+/** Prefix of the generated peer URL environment variables. */
+export const PEER_URL_ENV_PREFIX = "PORTLESS_URL_";
+
+/**
+ * Environment variable name carrying one app's URL in a multi-app run. Derived
+ * from the app's base name, before any worktree prefix, so the variable name
+ * stays the same in every worktree while its value follows the prefix. That is
+ * what lets a service reference a peer from committed config: the value moves,
+ * the name does not.
+ */
+export function peerUrlEnvName(baseName: string): string {
+  return PEER_URL_ENV_PREFIX + baseName.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+}
+
+/**
+ * A name made only of punctuation would yield a variable of bare underscores,
+ * which tells a reader nothing and cannot be guessed from the app name.
+ */
+function hasUsableEnvName(baseName: string): boolean {
+  return /[a-z0-9]/i.test(baseName);
+}
+
+/**
+ * Build the peer URL environment every app in a multi-app run receives, so one
+ * service can reach another without a hardcoded hostname that a worktree prefix
+ * would invalidate. Each app appears once, the reader's own entry included, so
+ * the map does not vary by reader.
+ *
+ * Two apps whose names differ only in punctuation (`web.api` and `web-api`)
+ * collapse to one variable name. The first wins and the second is reported,
+ * rather than silently overwriting a peer URL with the wrong host.
+ */
+export function buildPeerUrlEnv(
+  peers: { baseName: string; url: string }[],
+  onWarning?: (message: string) => void
+): Record<string, string> {
+  const env: Record<string, string> = {};
+  const claimedBy = new Map<string, string>();
+
+  for (const { baseName, url } of peers) {
+    if (!hasUsableEnvName(baseName)) continue;
+    const varName = peerUrlEnvName(baseName);
+
+    const owner = claimedBy.get(varName);
+    if (owner !== undefined) {
+      if (owner !== baseName) {
+        onWarning?.(
+          `Peer URL variable ${varName} is already taken by "${owner}", so "${baseName}" gets none. Rename one of them to give both a peer URL.`
+        );
+      }
+      continue;
+    }
+
+    claimedBy.set(varName, baseName);
+    env[varName] = url;
+  }
+
+  return env;
+}
+
 /** Branch names that represent the default/primary checkout — no prefix needed. */
 const DEFAULT_BRANCHES = new Set(["main", "master"]);
 

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -2419,4 +2419,125 @@ describe("CLI", () => {
       60_000
     );
   });
+
+  describe("multi-app peer URLs", () => {
+    // Skipped on Windows for the same reason as multi-app worktree routing:
+    // spawnChildProcess runs `npm run dev` without a shell, which fails on
+    // npm.cmd. The peer URL map itself is platform-agnostic and unit-tested in
+    // auto.test.ts.
+    it.skipIf(process.platform === "win32")(
+      "gives every app its peers' URLs, named from the base name in a worktree",
+      async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), "portless-multi-peer-"));
+        const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-peer-state-"));
+        const proxyPort = await getFreePort();
+        const capFile = (name: string) => path.join(stateDir, `peers-${name}.json`);
+        const readCap = (name: string) => {
+          try {
+            return fs.readFileSync(capFile(name), "utf-8");
+          } catch {
+            return "";
+          }
+        };
+        let cli: ReturnType<typeof spawn> | undefined;
+
+        try {
+          fs.writeFileSync(
+            path.join(root, "package.json"),
+            JSON.stringify({
+              name: "myrepo",
+              private: true,
+              packageManager: "npm@10.0.0",
+              workspaces: ["packages/*"],
+            })
+          );
+
+          // Fake a linked worktree on branch feature-x, so hostnames carry a
+          // prefix that the variable names must not inherit.
+          const gitdir = path.join(root, "fake-bare.git", "worktrees", "wt");
+          fs.mkdirSync(gitdir, { recursive: true });
+          fs.writeFileSync(path.join(gitdir, "HEAD"), "ref: refs/heads/feature-x\n");
+          fs.writeFileSync(path.join(root, ".git"), `gitdir: ${gitdir}\n`);
+
+          for (const name of ["web", "api"]) {
+            const dir = path.join(root, "packages", name);
+            fs.mkdirSync(dir, { recursive: true });
+            fs.writeFileSync(
+              path.join(dir, "capture.cjs"),
+              `require("node:fs").writeFileSync(${JSON.stringify(capFile(name))}, JSON.stringify({\n` +
+                `  self: process.env.PORTLESS_URL || "",\n` +
+                `  web: process.env.PORTLESS_URL_WEB_MYREPO || "",\n` +
+                `  api: process.env.PORTLESS_URL_API_MYREPO || "",\n` +
+                `}));\n`
+            );
+            fs.writeFileSync(
+              path.join(dir, "package.json"),
+              JSON.stringify({
+                name,
+                version: "0.0.0",
+                scripts: { dev: "node capture.cjs" },
+                portless: { proxy: true },
+              })
+            );
+          }
+
+          const childEnv: Record<string, string | undefined> = { ...process.env };
+          for (const key of Object.keys(childEnv)) {
+            if (key.startsWith("npm_") || key.startsWith("PNPM_")) delete childEnv[key];
+          }
+          childEnv.PORTLESS_STATE_DIR = stateDir;
+          childEnv.PORTLESS_PORT = proxyPort.toString();
+          childEnv.PORTLESS_HTTPS = "0";
+          childEnv.NO_COLOR = "1";
+
+          let output = "";
+          cli = spawn(process.execPath, [CLI_PATH], {
+            cwd: root,
+            env: childEnv,
+            stdio: ["ignore", "pipe", "pipe"],
+          });
+          cli.stdout?.on("data", (chunk) => (output += chunk.toString()));
+          cli.stderr?.on("data", (chunk) => (output += chunk.toString()));
+
+          for (let i = 0; i < 60; i++) {
+            if (readCap("web") && readCap("api")) break;
+            await new Promise((resolve) => setTimeout(resolve, 500));
+          }
+
+          const rawWeb = readCap("web");
+          const rawApi = readCap("api");
+          if (!rawWeb || !rawApi) {
+            throw new Error(
+              `capture incomplete (web=${JSON.stringify(rawWeb)}, api=${JSON.stringify(rawApi)}). CLI output:\n${output}`
+            );
+          }
+
+          const web = JSON.parse(rawWeb) as Record<string, string>;
+          const api = JSON.parse(rawApi) as Record<string, string>;
+
+          const webUrl = `http://feature-x.web.myrepo.localhost:${proxyPort}`;
+          const apiUrl = `http://feature-x.api.myrepo.localhost:${proxyPort}`;
+
+          // Each app can reach its peer without knowing the branch.
+          expect(web.api).toBe(apiUrl);
+          expect(api.web).toBe(webUrl);
+
+          // The map is the same for every app, own entry included, and agrees
+          // with the app's own PORTLESS_URL.
+          expect(web.web).toBe(webUrl);
+          expect(api.api).toBe(apiUrl);
+          expect(web.self).toBe(webUrl);
+          expect(api.self).toBe(apiUrl);
+        } finally {
+          if (cli) await stopChild(cli);
+          run(["proxy", "stop"], {
+            env: { PORTLESS_STATE_DIR: stateDir, PORTLESS_HTTPS: "0" },
+          });
+          fs.rmSync(root, { recursive: true, force: true });
+          fs.rmSync(stateDir, { recursive: true, force: true });
+        }
+      },
+      60_000
+    );
+  });
 });

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -44,6 +44,7 @@ import {
   inferProjectName,
   detectWorktreePrefix,
   applyWorktreePrefix,
+  buildPeerUrlEnv,
   truncateLabel,
   sanitizeForHostname,
 } from "./auto.js";
@@ -1982,10 +1983,20 @@ ${colors.bold("Child process environment:")}
   PORT                          Ephemeral port the child should listen on
   HOST                          Usually 127.0.0.1 (omitted for Expo in LAN mode)
   PORTLESS_URL                  Primary public URL of the app
+  PORTLESS_URL_<APP>            URL of each app in a monorepo run (see below)
   PORTLESS_LAN                  Set to 1 when proxy is in LAN mode
   PORTLESS_TAILSCALE_URL        Tailscale URL of the app (when --tailscale is active)
   PORTLESS_NGROK_URL            ngrok URL of the app (when --ngrok is active)
   NODE_EXTRA_CA_CERTS           Path to the portless CA (set when HTTPS is active)
+
+${colors.bold("Referencing another app (monorepo run):")}
+  A monorepo run gives every app the URL of every app, including itself, as
+  PORTLESS_URL_<APP>. The name comes from the app name uppercased with dots and
+  dashes as underscores (api.myrepo -> PORTLESS_URL_API_MYREPO), and does not
+  change in a git worktree even though the URL it holds gains the branch prefix.
+  So a service reads its peers from committed config, with no hardcoded host:
+    fetch(process.env.PORTLESS_URL_API_MYREPO + "/health")
+  Outside a monorepo run, "portless get <name>" prints the same URL.
 
 ${colors.bold("Safari / DNS:")}
   .localhost subdomains auto-resolve in Chrome, Firefox, and Edge.
@@ -3584,6 +3595,8 @@ interface MultiAppEntry {
   pkg: WorkspacePackage;
   /** Portless hostname (e.g. "web.json-render") */
   name: string;
+  /** Hostname before any worktree prefix, which names this app's peer URL variable */
+  baseName: string;
   /** Human-readable package label for display (e.g. "web") */
   label: string;
   commandArgs: string[];
@@ -3632,6 +3645,30 @@ function pipeOutput(child: ReturnType<typeof spawn>, prefix: string): void {
   prefixStream(child.stderr, process.stderr, prefix);
 }
 
+/**
+ * Peer URLs handed to every app in a multi-app run. An app URL depends only on
+ * its name, the proxy port and the TLDs, never on the app's own port, so the
+ * whole map is known before the first app is spawned.
+ *
+ * Apps that run their own `portless` are left out: they register their own
+ * routes, so this process does not own their URL.
+ */
+function buildPeerUrls(
+  proxiedApps: MultiAppEntry[],
+  proxyPort: number,
+  tls: boolean,
+  tlds: string[]
+): Record<string, string> {
+  const peers = proxiedApps
+    .filter((app) => app.commandArgs[0] !== "portless")
+    .map((app) => ({
+      baseName: app.baseName,
+      url: formatUrls(buildHostnames(app.name, tlds), proxyPort, tls)[0]!,
+    }));
+
+  return buildPeerUrlEnv(peers, (msg) => console.warn(colors.yellow(msg)));
+}
+
 async function spawnProxiedApp(
   app: MultiAppEntry,
   stateDir: string,
@@ -3639,7 +3676,8 @@ async function spawnProxiedApp(
   tls: boolean,
   tlds: string[],
   lanMode: boolean,
-  exitCodes: Map<string, number | null>
+  exitCodes: Map<string, number | null>,
+  peerUrls: Record<string, string>
 ): Promise<{
   child: ReturnType<typeof spawn>;
   displayUrl: string;
@@ -3674,6 +3712,7 @@ async function spawnProxiedApp(
 
     env = {
       ...pkgEnv,
+      ...peerUrls,
       PORT: String(appPort),
       HOST: "127.0.0.1",
       PORTLESS_URL: url,
@@ -3842,9 +3881,18 @@ async function handleDefaultMulti(
       label = pkg.scope ? `@${pkg.scope}/${pkg.name}` : (pkg.name ?? rel);
     }
 
+    const baseName = name;
     name = applyWorktreePrefix(name, worktree);
 
-    apps.push({ pkg, name, label, commandArgs, appPort: appOverride.appPort, proxied });
+    apps.push({
+      pkg,
+      name,
+      baseName,
+      label,
+      commandArgs,
+      appPort: appOverride.appPort,
+      proxied,
+    });
   }
 
   if (apps.length === 0) {
@@ -3924,6 +3972,7 @@ async function runWithTurbo(
   const manifest: Record<string, ManifestEntry> = {};
   const routes: { hostnames: string[] }[] = [];
   const appUrls: { label: string; url: string }[] = [];
+  const peerUrls = buildPeerUrls(proxiedApps, proxyPort, tls, tlds);
 
   for (const app of proxiedApps) {
     const usesPortless = app.commandArgs[0] === "portless";
@@ -3943,6 +3992,7 @@ async function runWithTurbo(
     routes.push({ hostnames });
 
     const entry: ManifestEntry = {
+      ...peerUrls,
       PORT: String(appPort),
       HOST: "127.0.0.1",
       PORTLESS_URL: url,
@@ -4036,6 +4086,7 @@ async function runWithDirectSpawn(
   const exitCodes = new Map<string, number | null>();
   const appUrls: { label: string; url: string }[] = [];
   const routeEntries: { store: RouteStore; hostnames: string[] }[] = [];
+  const peerUrls = buildPeerUrls(proxiedApps, proxyPort, tls, tlds);
 
   // Sequential: each spawnProxiedApp calls findFreePort() which binds/releases
   // a port, so parallel spawning could cause port collisions.
@@ -4047,7 +4098,8 @@ async function runWithDirectSpawn(
       tls,
       tlds,
       lanMode,
-      exitCodes
+      exitCodes,
+      peerUrls
     );
     children.push(child);
     if (route) routeEntries.push(route);

--- a/packages/portless/src/turbo.ts
+++ b/packages/portless/src/turbo.ts
@@ -58,6 +58,11 @@ export interface ManifestEntry {
   PORTLESS_URL: string;
   __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS?: string;
   NODE_EXTRA_CA_CERTS?: string;
+  /**
+   * `PORTLESS_URL_<BASE_NAME>` for every app in the run, the entry's own app
+   * included. See buildPeerUrlEnv in auto.ts.
+   */
+  [peerUrl: `PORTLESS_URL_${string}`]: string | undefined;
 }
 
 /**

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -147,6 +147,16 @@ portless run next dev   # -> https://fix-ui.myapp.localhost
 
 No config changes needed. Put `portless run` in `package.json` once and it works in all worktrees.
 
+### Referencing another app
+
+A monorepo run gives every app the URL of every app, itself included, as `PORTLESS_URL_<APP>`. The name is the app name uppercased with dots and dashes as underscores (`api.myrepo` becomes `PORTLESS_URL_API_MYREPO`). The name is the same in every worktree while its value carries the branch prefix, so a cross-service reference can live in committed config instead of a hardcoded hostname a worktree would invalidate:
+
+```ts
+const api = process.env.PORTLESS_URL_API_MYREPO ?? "https://api.myrepo.localhost";
+```
+
+Names that differ only in punctuation (`web.api` and `web-api`) collapse to one variable; the first keeps it and portless reports the second. An app whose dev script is itself `portless` registers its own route and gets no variable. Outside a monorepo run, use `portless get <name>`, e.g. `API_URL=$(portless get api.myrepo)`.
+
 ### Bypassing portless
 
 Set `PORTLESS=0` to run the command directly without the proxy:
@@ -181,21 +191,22 @@ Portless stores its state (routes, PID file, port file) in `~/.portless`. When t
 
 ### Environment variables
 
-| Variable              | Description                                                                    |
-| --------------------- | ------------------------------------------------------------------------------ |
-| `PORTLESS_PORT`       | Override the default proxy port (default: 443 with HTTPS, 80 without)          |
-| `PORTLESS_APP_PORT`   | Use a fixed port for the app (skip auto-assignment)                            |
-| `PORTLESS_HTTPS`      | HTTPS on by default; set to `0` to disable (same as `--no-tls`)                |
-| `PORTLESS_LAN`        | Set to `1` to always enable LAN mode (auto-detects LAN IP)                     |
-| `PORTLESS_LAN_IP`     | Pin a specific LAN IP for LAN mode                                             |
-| `PORTLESS_TLD`        | Use one or more TLDs, single or multi-segment (e.g. localhost,dev.example.com) |
-| `PORTLESS_WILDCARD`   | Set to `1` to allow unregistered subdomains to fall back to parent             |
-| `PORTLESS_SYNC_HOSTS` | Set to `0` to disable auto-sync of /etc/hosts (on by default)                  |
-| `PORTLESS_TAILSCALE`  | Set to `1` to share apps on your Tailscale network (same as `--tailscale`)     |
-| `PORTLESS_FUNNEL`     | Set to `1` to share apps publicly via Tailscale Funnel (same as `--funnel`)    |
-| `PORTLESS_NGROK`      | Set to `1` to share apps publicly via ngrok (same as `--ngrok`)                |
-| `PORTLESS_STATE_DIR`  | Override the state directory                                                   |
-| `PORTLESS=0`          | Bypass the proxy, run the command directly                                     |
+| Variable              | Description                                                                      |
+| --------------------- | -------------------------------------------------------------------------------- |
+| `PORTLESS_PORT`       | Override the default proxy port (default: 443 with HTTPS, 80 without)            |
+| `PORTLESS_APP_PORT`   | Use a fixed port for the app (skip auto-assignment)                              |
+| `PORTLESS_HTTPS`      | HTTPS on by default; set to `0` to disable (same as `--no-tls`)                  |
+| `PORTLESS_LAN`        | Set to `1` to always enable LAN mode (auto-detects LAN IP)                       |
+| `PORTLESS_LAN_IP`     | Pin a specific LAN IP for LAN mode                                               |
+| `PORTLESS_TLD`        | Use one or more TLDs, single or multi-segment (e.g. localhost,dev.example.com)   |
+| `PORTLESS_WILDCARD`   | Set to `1` to allow unregistered subdomains to fall back to parent               |
+| `PORTLESS_SYNC_HOSTS` | Set to `0` to disable auto-sync of /etc/hosts (on by default)                    |
+| `PORTLESS_TAILSCALE`  | Set to `1` to share apps on your Tailscale network (same as `--tailscale`)       |
+| `PORTLESS_FUNNEL`     | Set to `1` to share apps publicly via Tailscale Funnel (same as `--funnel`)      |
+| `PORTLESS_NGROK`      | Set to `1` to share apps publicly via ngrok (same as `--ngrok`)                  |
+| `PORTLESS_STATE_DIR`  | Override the state directory                                                     |
+| `PORTLESS_URL_<APP>`  | Set by portless: URL of each app in a monorepo run (see Referencing another app) |
+| `PORTLESS=0`          | Bypass the proxy, run the command directly                                       |
 
 ### HTTP/2 + HTTPS
 


### PR DESCRIPTION
## The problem

In a git worktree the branch prefix moves every hostname in the run. That is the point of the feature, but it means a service that calls another service cannot name it in committed config: the hostname it hardcodes is the main checkout's, so the worktree's frontend talks to the main checkout's backend. `PORTLESS_URL` does not help, because it holds only the reader's own URL.

This is easy to hit and hard to diagnose — the symptom is cross-talk between checkouts, or an auth failure when the two happen to be on different environments, with nothing pointing at hostnames. The docs do not mention it: the Git Worktrees section is written for one app with one URL, and the Vite snippet under "Proxying Between Portless Apps" hardcodes `https://api.myapp.localhost`, which a worktree invalidates.

`portless get <name>` is the existing answer and stays the right one for a single-app run. But a monorepo run already knows every app's URL before it spawns anything, so it can just say so.

## The change

Every app in a monorepo run receives the URL of every app as `PORTLESS_URL_<APP>`:

```bash
PORTLESS_URL_WEB_MYREPO=https://fix-ui.web.myrepo.localhost
PORTLESS_URL_API_MYREPO=https://fix-ui.api.myrepo.localhost
```

The variable is named from the app's **base** name, before the worktree prefix is applied, so the name is identical in every worktree while the URL it holds carries the prefix. That is the property that lets the reference live in committed config:

```ts
const api = process.env.PORTLESS_URL_API_MYREPO ?? "https://api.myrepo.localhost";
```

Details:

- Both multi-app paths inject it: the turbo manifest (`runWithTurbo`) and the direct spawn (`spawnProxiedApp`). An app's URL depends only on its name, the proxy port and the TLDs, never on its own port, so the whole map is computable before the first spawn.
- Every app appears once, the reader's own entry included, so the map does not vary by reader and agrees with that app's `PORTLESS_URL`.
- Two names that differ only in punctuation (`web.api` and `web-api`) collapse to one variable name. The first keeps it and the second is reported on stderr, rather than silently handing out a URL for the wrong app.
- An app whose dev script is itself `portless` registers its own route, so this process does not own its URL and it gets no variable.
- Single-app mode is unchanged. One `portless` invocation knows only its own app.

`ManifestEntry` gained a `PORTLESS_URL_${string}` template-literal index signature, so the extra keys are typed rather than cast. The existing loader applies every key in an entry, so it needed no change.

## Tests

- `auto.test.ts` — unit tests for the variable naming and map building: dots and dashes to underscores, base-name naming with a prefixed value, collision reported once, repeated identical name not reported, punctuation-only name skipped.
- `cli.test.ts` — an integration test alongside the existing multi-app worktree test. It fakes a linked worktree on `feature-x`, runs two apps, and has each capture its own env: each app sees its peer at `feature-x.<peer>.myrepo.localhost` under a variable named without the prefix. Skipped on Windows for the same `npm.cmd` reason as the neighbouring test.

Full suite passes (944 tests). Docs updated in the four places `AGENTS.md` lists: `README.md`, `skills/portless/SKILL.md`, the `--help` output, and the docs site (home page plus the configuration env table). `CHANGELOG.md` deliberately untouched, since releases are maintainer-authored.

## Notes for the maintainer

Two things I noticed but did not change, happy to fold in either:

1. The Vite/webpack snippets under "Proxying Between Portless Apps" hardcode a peer hostname and so break in a worktree. They could use this variable.
2. The Git Worktrees section could mention cross-service references directly — that is where a reader with a mesh will look first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
