### PR TITLE
fix: count foreground tailscale sessions as used serve ports

### DIFF
--- a/packages/portless/src/tailscale.test.ts
+++ b/packages/portless/src/tailscale.test.ts
@@ -237,6 +237,27 @@ describe("tailscale", () => {
       expect(ports).toEqual(new Set([22, 443]));
     });
 
+    it("includes ports held by foreground serve or funnel sessions", () => {
+      const runner = createRunner({
+        "serve status --json": {
+          status: 0,
+          stdout: JSON.stringify({
+            TCP: { "8443": { HTTPS: true } },
+            Web: { "devbox.example.ts.net:8443": { Handlers: {} } },
+            Foreground: {
+              df16b397a48601e8: {
+                TCP: { "443": { HTTPS: true } },
+                Web: { "devbox.example.ts.net:443": { Handlers: {} } },
+                AllowFunnel: { "devbox.example.ts.net:443": true },
+              },
+            },
+          }),
+        },
+      });
+      const ports = getUsedServePorts(runner);
+      expect(ports).toEqual(new Set([443, 8443]));
+    });
+
     it("returns empty set on command failure", () => {
       const runner = createRunner({
         "serve status --json": { status: 1, stderr: "error" },

--- a/packages/portless/src/tailscale.ts
+++ b/packages/portless/src/tailscale.ts
@@ -209,11 +209,41 @@ interface ServeStatusWeb {
 interface ServeStatusJson {
   Web?: ServeStatusWeb;
   TCP?: Record<string, unknown>;
+  /**
+   * Foreground sessions (`tailscale serve` or `tailscale funnel` run without
+   * `--bg`). Each session carries its own Web/TCP maps and holds its ports
+   * just as firmly as a background config does.
+   */
+  Foreground?: Record<string, ServeStatusJson>;
+}
+
+function collectServePorts(config: ServeStatusJson, ports: Set<number>): void {
+  if (config.Web) {
+    for (const hostPort of Object.keys(config.Web)) {
+      const match = hostPort.match(/:(\d+)$/);
+      if (match) {
+        ports.add(parseInt(match[1], 10));
+      }
+    }
+  }
+  if (config.TCP) {
+    for (const portStr of Object.keys(config.TCP)) {
+      const p = parseInt(portStr, 10);
+      if (!isNaN(p)) ports.add(p);
+    }
+  }
+  if (config.Foreground) {
+    for (const session of Object.values(config.Foreground)) {
+      if (session && typeof session === "object") {
+        collectServePorts(session, ports);
+      }
+    }
+  }
 }
 
 /**
  * Query `tailscale serve status --json` and return the set of HTTPS ports
- * currently in use.
+ * currently in use, including ports held by foreground sessions.
  */
 export function getUsedServePorts(runner: TailscaleCommandRunner = defaultRunner): Set<number> {
   const result = runner(["serve", "status", "--json"]);
@@ -223,20 +253,7 @@ export function getUsedServePorts(runner: TailscaleCommandRunner = defaultRunner
   try {
     const config = JSON.parse(result.stdout) as ServeStatusJson;
     const ports = new Set<number>();
-    if (config.Web) {
-      for (const hostPort of Object.keys(config.Web)) {
-        const match = hostPort.match(/:(\d+)$/);
-        if (match) {
-          ports.add(parseInt(match[1], 10));
-        }
-      }
-    }
-    if (config.TCP) {
-      for (const portStr of Object.keys(config.TCP)) {
-        const p = parseInt(portStr, 10);
-        if (!isNaN(p)) ports.add(p);
-      }
-    }
+    collectServePorts(config, ports);
     return ports;
   } catch {
     return new Set();


### PR DESCRIPTION
## Symptom

With `PORTLESS_TAILSCALE=1` (or `--tailscale`), portless fails to start when another process holds a Tailscale HTTPS port through a **foreground** session, and the auto-assign retry never recovers:

```
Error: Tailscale HTTPS port 443 is already in use. Stop the existing serve or let portless auto-assign a different port.
```

The message suggests auto-assign, but auto-assign is exactly what ran: `findAvailableServePort()` picked 443 three times in a row because `getUsedServePorts()` never saw it as taken.

## Cause

`getUsedServePorts()` reads only the top-level `Web` and `TCP` maps of `tailscale serve status --json`. Sessions created with `tailscale serve` / `tailscale funnel` **without** `--bg` (the default for the current CLI) are reported under a separate `Foreground` key, one entry per session, each with its own `Web`/`TCP` (and `AllowFunnel`) maps. Ports held there are just as unavailable, but portless treated them as free.

Trimmed real output, with a background serve on 8443 and a foreground funnel on 443 owned by another tool:

```json
{
  "TCP": { "8443": { "HTTPS": true } },
  "Web": {
    "devbox.example.ts.net:8443": { "Handlers": { "/": { "Proxy": "http://127.0.0.1:7317" } } }
  },
  "Foreground": {
    "df16b397a48601e8": {
      "TCP": { "443": { "HTTPS": true } },
      "Web": {
        "devbox.example.ts.net:443": { "Handlers": { "/": { "Proxy": "http://127.0.0.1:51458" } } }
      },
      "AllowFunnel": { "devbox.example.ts.net:443": true }
    }
  }
}
```

Before this change the function returned `{8443}` for that input; 443 was then chosen, `tailscale serve --bg --https=443` reported a conflict, and the retry loop repeated the same computation.

## Fix

- Add `Foreground` to `ServeStatusJson` and walk each session's `Web`/`TCP` maps with the same parsing as the top level (factored into a small `collectServePorts` helper so both paths share one implementation).
- Add a test covering a background 8443 plus a foreground 443, expecting `{443, 8443}`.

With this, the same scenario auto-assigns the next free preferred port (8444 in the example above) and starts normally.

`pnpm vitest run src/tailscale.test.ts` (47 tests), `tsc --noEmit`, `eslint`, and `prettier --check` all pass.