### PR TITLE
fix(cli): make get return registered routes only

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,16 @@ portless docs.myapp next dev
 
 By default, only explicitly registered subdomains are routed (strict mode). Use `--wildcard` when starting the proxy to allow any subdomain of a registered route to fall back to that app (e.g. `tenant1.myapp.localhost` routes to the `myapp` app without extra registration).
 
+## Get a service URL
+
+`portless get <name>` prints the URL of an active route. It exits with an error instead of returning a URL that is not registered.
+
+```bash
+BACKEND_URL=$(portless get backend)
+```
+
+Inside a git worktree, a route registered by the current worktree takes priority. If none exists and exactly one route from another worktree matches the name, that route is returned. Multiple matches are ambiguous and require the full registered name shown by `portless list`. Use `--no-worktree` to skip the current-worktree preference.
+
 ## Git Worktrees
 
 `portless run` automatically detects git worktrees. In a linked worktree, the branch name is prepended as a subdomain so each worktree gets its own URL without any config changes:
@@ -381,6 +391,7 @@ portless                        # Run dev script through proxy
 portless                        # From monorepo root: run all workspace packages
 portless run [--name <name>] [cmd] [args...]  # Infer name, run through proxy
 portless <name> <cmd> [args...]  # Run app at https://<name>.localhost
+portless get <name>              # Print the URL of an active route
 portless alias <name> <port>     # Register a static route (e.g. for Docker)
 portless alias <name> <port> --force  # Overwrite an existing route
 portless alias --remove <name>   # Remove a static route

--- a/apps/docs/src/app/commands/page.mdx
+++ b/apps/docs/src/app/commands/page.mdx
@@ -87,13 +87,13 @@ portless myapp --ngrok next dev
 portless get <name>
 ```
 
-Print the URL for a service. Useful for wiring services together in scripts or env vars:
+Print the URL for an active route. The command exits with an error when no matching route is registered. Useful for wiring services together in scripts or env vars:
 
 ```bash
 BACKEND_URL=$(portless get backend)
 ```
 
-Applies worktree prefix detection by default. Use `--no-worktree` to skip it.
+Inside a git worktree, the current worktree's route takes priority. If it is not registered and exactly one route from another worktree matches, that route is returned. Multiple matches require the full registered name from `portless list`. Use `--no-worktree` to skip the current-worktree preference.
 
 ## Alias (static routes)
 

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -1565,6 +1565,28 @@ describe("CLI", () => {
     });
 
     const getEnv = () => ({ PORTLESS_STATE_DIR: tmpDir });
+    const writeRoutes = (...routes: Array<string | { hostname: string; baseHostname: string }>) => {
+      fs.writeFileSync(
+        path.join(tmpDir, "routes.json"),
+        JSON.stringify(
+          routes.map((route, index) => ({
+            hostname: typeof route === "string" ? route : route.hostname,
+            port: 4100 + index,
+            pid: process.pid,
+            ...(typeof route === "string" ? {} : { baseHostname: route.baseHostname }),
+          }))
+        )
+      );
+    };
+    const makeCallerWorktree = (branch: string) => {
+      const callerDir = path.join(tmpDir, `caller-${branch}`);
+      const gitDir = path.join(tmpDir, "fake-bare.git", "worktrees", branch);
+      fs.mkdirSync(callerDir);
+      fs.mkdirSync(gitDir, { recursive: true });
+      fs.writeFileSync(path.join(gitDir, "HEAD"), `ref: refs/heads/${branch}\n`);
+      fs.writeFileSync(path.join(callerDir, ".git"), `gitdir: ${gitDir}\n`);
+      return callerDir;
+    };
 
     it("prints help with --help", () => {
       const { status, stdout } = run(["get", "--help"]);
@@ -1586,15 +1608,75 @@ describe("CLI", () => {
     });
 
     it("prints URL for a given service name", () => {
+      writeRoutes("backend.localhost");
       const { status, stdout } = run(["get", "backend"], { env: getEnv() });
       expect(status).toBe(0);
       expect(stdout.trim()).toMatch(/^https?:\/\/backend\.localhost(:\d+)?$/);
     });
 
     it("prints URL for a dotted service name", () => {
+      writeRoutes("api.backend.localhost");
       const { status, stdout } = run(["get", "api.backend"], { env: getEnv() });
       expect(status).toBe(0);
       expect(stdout.trim()).toMatch(/^https?:\/\/api\.backend\.localhost(:\d+)?$/);
+    });
+
+    it("finds a uniquely registered route from another worktree on the first call", () => {
+      writeRoutes({
+        hostname: "registered-branch.api-1522.localhost",
+        baseHostname: "api-1522.localhost",
+      });
+
+      const { status, stdout } = run(["get", "api-1522"], {
+        cwd: makeCallerWorktree("caller-branch"),
+        env: getEnv(),
+      });
+
+      expect(status).toBe(0);
+      expect(new URL(stdout.trim()).hostname).toBe("registered-branch.api-1522.localhost");
+    });
+
+    it("prefers the current worktree's registered route when multiple routes match", () => {
+      writeRoutes("caller-branch.backend.localhost", "other-branch.backend.localhost");
+
+      const { status, stdout } = run(["get", "backend"], {
+        cwd: makeCallerWorktree("caller-branch"),
+        env: getEnv(),
+      });
+
+      expect(status).toBe(0);
+      expect(new URL(stdout.trim()).hostname).toBe("caller-branch.backend.localhost");
+    });
+
+    it("fails instead of composing a URL for an unregistered name", () => {
+      const { status, stdout, stderr } = run(["get", "backend"], { env: getEnv() });
+      expect(status).toBe(1);
+      expect(stdout).toBe("");
+      expect(stderr).toContain('No active route matches "backend"');
+    });
+
+    it("fails when the requested name matches multiple worktree routes", () => {
+      writeRoutes(
+        { hostname: "feature-a.backend.localhost", baseHostname: "backend.localhost" },
+        { hostname: "feature-b.backend.localhost", baseHostname: "backend.localhost" }
+      );
+      const { status, stdout, stderr } = run(["get", "backend"], { env: getEnv() });
+      expect(status).toBe(1);
+      expect(stdout).toBe("");
+      expect(stderr).toContain('Multiple active routes match "backend"');
+      expect(stderr).toContain("feature-a.backend.localhost");
+      expect(stderr).toContain("feature-b.backend.localhost");
+    });
+
+    it("does not mistake a dotted service name for a worktree route", () => {
+      writeRoutes({
+        hostname: "api.backend.localhost",
+        baseHostname: "api.backend.localhost",
+      });
+      const { status, stdout, stderr } = run(["get", "backend"], { env: getEnv() });
+      expect(status).toBe(1);
+      expect(stdout).toBe("");
+      expect(stderr).toContain('No active route matches "backend"');
     });
 
     it("rejects unknown flags", () => {
@@ -1604,6 +1686,7 @@ describe("CLI", () => {
     });
 
     it("accepts --no-worktree flag", () => {
+      writeRoutes("backend.localhost");
       const { status, stdout } = run(["get", "--no-worktree", "backend"], { env: getEnv() });
       expect(status).toBe(0);
       expect(stdout.trim()).toMatch(/^https?:\/\/backend\.localhost(:\d+)?$/);

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -502,13 +502,14 @@ function addRoutes(
   hostnames: readonly string[],
   port: number,
   pid: number,
-  force = false
+  force = false,
+  baseHostnames?: readonly string[]
 ): number[] {
   const registered: string[] = [];
   const killedPids: number[] = [];
   try {
-    for (const hostname of hostnames) {
-      const killedPid = store.addRoute(hostname, port, pid, force);
+    for (const [index, hostname] of hostnames.entries()) {
+      const killedPid = store.addRoute(hostname, port, pid, force, baseHostnames?.[index]);
       registered.push(hostname);
       if (killedPid !== undefined) {
         killedPids.push(killedPid);
@@ -1329,8 +1330,8 @@ async function runApp(
   } else {
     console.log(chalk.gray(`-- ${hostnames.join(", ")} (auto-resolves to 127.0.0.1)`));
   }
+  const baseName = autoInfo?.prefix ? name.slice(autoInfo.prefix.length + 1) : name;
   if (autoInfo) {
-    const baseName = autoInfo.prefix ? name.slice(autoInfo.prefix.length + 1) : name;
     console.log(chalk.gray(`-- Name "${baseName}" (from ${autoInfo.nameSource})`));
     if (autoInfo.prefix) {
       console.log(chalk.gray(`-- Prefix "${autoInfo.prefix}" (from ${autoInfo.prefixSource})`));
@@ -1347,7 +1348,14 @@ async function runApp(
   // Register route (--force kills the existing owner if any)
   let killedPids: number[] = [];
   try {
-    killedPids = addRoutes(store, hostnames, port, process.pid, force);
+    killedPids = addRoutes(
+      store,
+      hostnames,
+      port,
+      process.pid,
+      force,
+      buildHostnames(baseName, tlds)
+    );
     await reportHostsSyncHere(hostnames, proxyPort, tls, lanMode);
   } catch (err) {
     if (err instanceof RouteConflictError) {
@@ -2278,14 +2286,15 @@ ${colors.bold("portless get")} - Print the URL for a service.
 ${colors.bold("Usage:")}
   ${colors.cyan("portless get <name>")}
 
-Constructs the URL using the same hostname and worktree logic as
-"portless run", then prints it to stdout. Useful for wiring services
-together:
+Finds an active route by name, then prints its URL to stdout. In a git
+worktree, a route registered by the current worktree takes priority. When
+there is one matching route from another worktree, that route is returned.
+Useful for wiring services together:
 
   BACKEND_URL=$(portless get backend)
 
 ${colors.bold("Options:")}
-  --no-worktree          Skip worktree prefix detection
+  --no-worktree          Skip current-worktree route preference
   --help, -h             Show this help
 
 ${colors.bold("Examples:")}
@@ -2322,11 +2331,41 @@ ${colors.bold("Examples:")}
 
   const name = positional[0];
   const worktree = skipWorktree ? null : detectWorktreePrefix();
-  const effectiveName = worktree ? `${worktree.prefix}.${name}` : name;
+  const { dir, port, tls, tlds } = await discoverState();
+  const requestedHostname = buildHostnames(name, tlds)[0]!;
+  const store = new RouteStore(dir, {
+    onWarning: (msg) => console.warn(colors.yellow(msg)),
+  });
+  const routes = store.loadRoutes();
 
-  const { port, tls, tlds } = await discoverState();
-  const hostname = buildHostnames(effectiveName, tlds)[0]!;
-  const url = formatUrl(hostname, port, tls);
+  let route = worktree
+    ? routes.find(
+        (candidate) => candidate.hostname === buildHostnames(`${worktree.prefix}.${name}`, tlds)[0]
+      )
+    : undefined;
+  route ??= routes.find((candidate) => candidate.hostname === requestedHostname);
+
+  if (!route) {
+    const matchingRoutes = routes.filter(
+      (candidate) => candidate.baseHostname === requestedHostname
+    );
+    if (matchingRoutes.length === 1) {
+      route = matchingRoutes[0];
+    } else if (matchingRoutes.length > 1) {
+      console.error(colors.red(`Error: Multiple active routes match "${name}":`));
+      for (const candidate of matchingRoutes) {
+        console.error(colors.cyan(`  ${candidate.hostname}`));
+      }
+      console.error(colors.blue("Use the full registered name shown above."));
+      process.exit(1);
+    } else {
+      console.error(colors.red(`Error: No active route matches "${name}".`));
+      console.error(colors.blue("List active routes with: portless list"));
+      process.exit(1);
+    }
+  }
+
+  const url = formatUrl(route.hostname, port, tls);
   // Print bare URL to stdout so it works in $(portless get <name>)
   process.stdout.write(url + "\n");
 }
@@ -3584,6 +3623,8 @@ interface MultiAppEntry {
   pkg: WorkspacePackage;
   /** Portless hostname (e.g. "web.json-render") */
   name: string;
+  /** Portless hostname before a git worktree prefix is applied. */
+  baseName: string;
   /** Human-readable package label for display (e.g. "web") */
   label: string;
   commandArgs: string[];
@@ -3669,7 +3710,7 @@ async function spawnProxiedApp(
     const url = urls[0]!;
     displayUrl = url;
 
-    addRoutes(store, hostnames, appPort, process.pid);
+    addRoutes(store, hostnames, appPort, process.pid, false, buildHostnames(app.baseName, tlds));
     await reportHostsSyncHere(hostnames, proxyPort, tls, lanMode);
 
     env = {
@@ -3842,9 +3883,10 @@ async function handleDefaultMulti(
       label = pkg.scope ? `@${pkg.scope}/${pkg.name}` : (pkg.name ?? rel);
     }
 
-    name = applyWorktreePrefix(name, worktree);
+    const baseName = name;
+    name = applyWorktreePrefix(baseName, worktree);
 
-    apps.push({ pkg, name, label, commandArgs, appPort: appOverride.appPort, proxied });
+    apps.push({ pkg, name, baseName, label, commandArgs, appPort: appOverride.appPort, proxied });
   }
 
   if (apps.length === 0) {
@@ -3938,7 +3980,7 @@ async function runWithTurbo(
     const url = urls[0]!;
     appUrls.push({ label: app.label, url });
 
-    addRoutes(store, hostnames, appPort, process.pid);
+    addRoutes(store, hostnames, appPort, process.pid, false, buildHostnames(app.baseName, tlds));
     await reportHostsSyncHere(hostnames, proxyPort, tls, lanMode);
     routes.push({ hostnames });
 

--- a/packages/portless/src/routes.test.ts
+++ b/packages/portless/src/routes.test.ts
@@ -169,6 +169,11 @@ describe("RouteStore", () => {
       });
     });
 
+    it("persists the base hostname used before a worktree prefix", () => {
+      store.addRoute("feature-a.myapp.localhost", 4001, process.pid, false, "myapp.localhost");
+      expect(store.loadRoutes()[0].baseHostname).toBe("myapp.localhost");
+    });
+
     it("replaces existing route with same hostname", () => {
       store.addRoute("myapp.localhost", 4001, process.pid);
       store.addRoute("myapp.localhost", 4002, process.pid);

--- a/packages/portless/src/routes.ts
+++ b/packages/portless/src/routes.ts
@@ -23,6 +23,8 @@ export const DIR_MODE = 0o755;
 
 export interface RouteMapping extends RouteInfo {
   pid: number;
+  /** Route hostname before a git worktree prefix was applied. */
+  baseHostname?: string;
   tailscaleUrl?: string;
   tailscaleHttpsPort?: number;
   tailscaleFunnel?: boolean;
@@ -45,7 +47,9 @@ function isValidRoute(value: unknown): value is RouteMapping {
     value !== null &&
     typeof (value as RouteMapping).hostname === "string" &&
     typeof (value as RouteMapping).port === "number" &&
-    typeof (value as RouteMapping).pid === "number"
+    typeof (value as RouteMapping).pid === "number" &&
+    ((value as RouteMapping).baseHostname === undefined ||
+      typeof (value as RouteMapping).baseHostname === "string")
   );
 }
 
@@ -219,7 +223,13 @@ export class RouteStore {
    * replaced. Returns the PID of the killed process (if any) so the caller can
    * log it.
    */
-  addRoute(hostname: string, port: number, pid: number, force = false): number | undefined {
+  addRoute(
+    hostname: string,
+    port: number,
+    pid: number,
+    force = false,
+    baseHostname?: string
+  ): number | undefined {
     this.ensureDir();
     if (!this.acquireLock()) {
       throw new Error("Failed to acquire route lock");
@@ -241,7 +251,7 @@ export class RouteStore {
         }
       }
       const filtered = routes.filter((r) => r.hostname !== hostname);
-      const entry: RouteMapping = { hostname, port, pid };
+      const entry: RouteMapping = { hostname, port, pid, ...(baseHostname && { baseHostname }) };
       filtered.push(entry);
       this.saveRoutes(filtered);
     } finally {

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -147,6 +147,10 @@ portless run next dev   # -> https://fix-ui.myapp.localhost
 
 No config changes needed. Put `portless run` in `package.json` once and it works in all worktrees.
 
+### Get a service URL
+
+`portless get <name>` prints the URL of an active route and fails when no route is registered. In a git worktree, it prefers the current worktree's route. If that route does not exist and exactly one route from another worktree matches, it returns that route. Multiple matches require the full registered name from `portless list`. Use `--no-worktree` to skip the current-worktree preference.
+
 ### Bypassing portless
 
 Set `PORTLESS=0` to run the command directly without the proxy:
@@ -291,8 +295,8 @@ The chosen service configuration is written into launchd, systemd, or Task Sched
 | `portless run [cmd] [args...]`                    | Infer name from project, run through proxy (auto-starts)       |
 | `portless run --name <name> <cmd>`                | Override inferred base name (worktree prefix still applies)    |
 | `portless <name> <cmd> [args...]`                 | Run app at `https://<name>.localhost` (auto-starts proxy)      |
-| `portless get <name>`                             | Print URL for a service (for cross-service wiring)             |
-| `portless get <name> --no-worktree`               | Print URL without worktree prefix                              |
+| `portless get <name>`                             | Print URL for a matching active route                          |
+| `portless get <name> --no-worktree`               | Skip current-worktree route preference                         |
 | `portless list`                                   | Show active routes                                             |
 | `portless doctor`                                 | Check proxy, routes, DNS, CA trust, and LAN prerequisites      |
 | `portless trust`                                  | Add local CA to system trust store (for HTTPS)                 |


### PR DESCRIPTION
`portless get` currently builds a URL from the caller's worktree even when that hostname is not registered. A call from a different worktree can therefore print a plausible but wrong URL while `portless list` shows the real route.

This changes `get` to resolve only active route entries. Registrations now retain their unprefixed base hostname, which lets `get` prefer the current worktree, return one unique route from another worktree, and reject zero or ambiguous matches without confusing nested service names for worktree prefixes.

The CLI help, README, docs site, and bundled skill describe the new contract.

Tracks https://github.com/vladbisceanu/setup-works/issues/574

## Tests

- `pnpm --filter portless exec vitest run src/cli.test.ts src/routes.test.ts` (174 passed, 1 platform-only skip)
- `pnpm --filter portless type-check`
- `pnpm --filter portless lint`
- `pnpm format:check`
