### PR TITLE
fix: inject --port for astro when global flags precede the subcommand

### DIFF
--- a/packages/portless/src/cli-utils.test.ts
+++ b/packages/portless/src/cli-utils.test.ts
@@ -549,6 +549,23 @@ describe("injectFrameworkFlags", () => {
     expect(args).toEqual(["astro", "dev", "--port", "4567", "--host", "127.0.0.1"]);
   });
 
+  it("injects for astro when global flags come before the subcommand", () => {
+    // Documented as `astro --root <dir> dev`. Without valueFlags this was
+    // declined and the app kept its own port.
+    const args = ["astro", "--root", "apps/web", "dev"];
+    injectFrameworkFlags(args, 4567);
+    expect(args).toEqual([
+      "astro",
+      "--root",
+      "apps/web",
+      "dev",
+      "--port",
+      "4567",
+      "--host",
+      "127.0.0.1",
+    ]);
+  });
+
   it("injects for ng without --strictPort", () => {
     const args = ["ng", "serve"];
     injectFrameworkFlags(args, 4567);

--- a/packages/portless/src/cli-utils.ts
+++ b/packages/portless/src/cli-utils.ts
@@ -1466,7 +1466,16 @@ const FRAMEWORKS_NEEDING_PORT: Record<string, FrameworkSpec> = {
       "--root",
     ],
   },
-  astro: { strictPort: false, serverSubcommands: ["dev", "preview"], defaultIsServer: false },
+  astro: {
+    strictPort: false,
+    serverSubcommands: ["dev", "preview"],
+    defaultIsServer: false,
+    // Global flags that take a value. Astro documents them before the
+    // subcommand (`astro --root apps/web dev`). Without this list,
+    // frameworkPositionals treats a leading flag as unknown grammar and
+    // skips --port/--host injection.
+    valueFlags: ["--root", "--config", "-c", "--site", "--base", "--port", "--host", "--open", "--mode"],
+  },
   ng: { strictPort: false, serverSubcommands: ["serve", "dev", "s"], defaultIsServer: false },
   "react-native": { strictPort: false, serverSubcommands: ["start"], defaultIsServer: false },
   expo: { strictPort: false, serverSubcommands: ["start", "serve"], defaultIsServer: true },


### PR DESCRIPTION
## Summary
Astro documents `astro --root <dir> dev`. Portless had no `valueFlags` for astro, so a flag before the subcommand made `frameworkPositionals` give up and skip `--port` / `--host`. The app then listened on its own port and the proxy 502ed.

Vite and rsbuild already list value flags. This adds the same for astro globals (`--root`, `--config`, `--site`, `--base`, plus `--port` / `--host` / `--open` / `--mode`).

## Test plan
- [x] `astro dev` still gets `--port` and `--host 127.0.0.1`
- [x] `astro --root apps/web dev` now gets the same injection
