### PR TITLE
feat(cli): add `--no-worktree` to `portless run` to match `portless get`

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,13 @@ Use `--name` to override the inferred base name while keeping the worktree prefi
 portless run --name myapp next dev   # -> https://fix-ui.myapp.localhost
 ```
 
+Use `--no-worktree` to skip worktree prefix detection:
+
+```bash
+portless run --no-worktree --name api.fix-ui.example pnpm dev
+# -> https://api.fix-ui.example.localhost
+```
+
 Put `portless run` in your `package.json` once and it works everywhere. The main checkout uses the plain name, each worktree gets a unique subdomain. No collisions, no `--force`.
 
 ## Custom TLD

--- a/apps/docs/src/app/commands/page.mdx
+++ b/apps/docs/src/app/commands/page.mdx
@@ -49,6 +49,10 @@ portless docs.myapp next dev
       <td>Override the inferred base name (worktree prefix still applies). Only for `portless run`.</td>
     </tr>
     <tr>
+      <td>`--no-worktree`</td>
+      <td>skip worktree prefix detection.</td>
+    </tr>
+    <tr>
       <td>`--script <name>`</td>
       <td>Run a specific `package.json` script instead of the default (`"dev"`). Global flag.</td>
     </tr>

--- a/apps/docs/src/app/page.mdx
+++ b/apps/docs/src/app/page.mdx
@@ -101,6 +101,13 @@ Use `--name` to override the inferred base name while keeping the worktree prefi
 portless run --name myapp next dev   # -> https://fix-ui.myapp.localhost
 ```
 
+Use `--no-worktree` to skip worktree prefix detection:
+
+```bash
+portless run --no-worktree --name api.fix-ui.example pnpm dev
+# -> https://api.fix-ui.example.localhost
+```
+
 ## Custom TLD
 
 By default, portless uses `.localhost` which auto-resolves to `127.0.0.1` in most browsers. If you prefer a different TLD (e.g. `.test`), use `--tld`:

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -1609,6 +1609,24 @@ describe("CLI", () => {
       expect(stdout.trim()).toMatch(/^https?:\/\/backend\.localhost(:\d+)?$/);
     });
 
+    it("skips the detected worktree prefix with --no-worktree", () => {
+      const gitdir = path.join(tmpDir, "fake-bare.git", "worktrees", "wt");
+      fs.mkdirSync(gitdir, { recursive: true });
+      fs.writeFileSync(path.join(gitdir, "HEAD"), "ref: refs/heads/feature-a\n");
+      fs.writeFileSync(path.join(tmpDir, ".git"), `gitdir: ${gitdir}\n`);
+
+      const prefixed = run(["get", "backend"], { cwd: tmpDir, env: getEnv() });
+      const unprefixed = run(["get", "--no-worktree", "backend"], {
+        cwd: tmpDir,
+        env: getEnv(),
+      });
+
+      expect(prefixed.status).toBe(0);
+      expect(prefixed.stdout.trim()).toMatch(/^https?:\/\/feature-a\.backend\.localhost(:\d+)?$/);
+      expect(unprefixed.status).toBe(0);
+      expect(unprefixed.stdout.trim()).toMatch(/^https?:\/\/backend\.localhost(:\d+)?$/);
+    });
+
     it("exits 1 for invalid hostname", () => {
       const { status, stderr } = run(["get", "my@app"]);
       expect(status).toBe(1);
@@ -1617,6 +1635,14 @@ describe("CLI", () => {
   });
 
   describe("--name flag", () => {
+    it("accepts --no-worktree before --name", () => {
+      const { status, stdout } = run(["--no-worktree", "--name", "run", "echo", "ok"], {
+        env: { PORTLESS: "0" },
+      });
+      expect(status).toBe(0);
+      expect(stdout.trim()).toBe("ok");
+    });
+
     it("treats reserved word as app name with PORTLESS=0", () => {
       const { status, stdout } = run(["--name", "run", "echo", "ok"], {
         env: { PORTLESS: "0" },
@@ -1651,7 +1677,61 @@ describe("CLI", () => {
       const { status, stdout } = run(["run", "--help"]);
       expect(status).toBe(0);
       expect(stdout).toContain("--name");
+      expect(stdout).toContain("--no-worktree");
     });
+
+    it.each([
+      ["an explicit name", ["--name", "api.feature-a.example"], "api.feature-a.example", false],
+      ["an inferred name", [], "api-feature-a-example", false],
+      ["a bare inferred name", [], "api-feature-a-example", true],
+    ])(
+      "skips the worktree prefix with --no-worktree and %s",
+      async (_label, nameArgs, name, bare) => {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-no-worktree-"));
+        let proxyChild: ReturnType<typeof spawn> | undefined;
+
+        try {
+          const proxy = await startMockProxy(tmpDir);
+          proxyChild = proxy.child;
+          fs.writeFileSync(path.join(tmpDir, "proxy.port"), proxy.port.toString());
+          fs.writeFileSync(
+            path.join(tmpDir, "package.json"),
+            JSON.stringify({
+              name: "api.feature-a.example",
+              scripts: { dev: "node capture-url.cjs" },
+            })
+          );
+
+          const gitdir = path.join(tmpDir, "fake-bare.git", "worktrees", "wt");
+          fs.mkdirSync(gitdir, { recursive: true });
+          fs.writeFileSync(path.join(gitdir, "HEAD"), "ref: refs/heads/feature-a\n");
+          fs.writeFileSync(path.join(tmpDir, ".git"), `gitdir: ${gitdir}\n`);
+
+          const capturePath = path.join(tmpDir, "url.txt");
+          const scriptPath = path.join(tmpDir, "capture-url.cjs");
+          fs.writeFileSync(
+            scriptPath,
+            `require("node:fs").writeFileSync(${JSON.stringify(capturePath)}, process.env.PORTLESS_URL);\n`
+          );
+
+          const args = bare
+            ? ["--no-worktree"]
+            : ["run", "--no-worktree", ...nameArgs, "node", scriptPath];
+          const { status } = run(args, {
+            cwd: tmpDir,
+            env: { PORTLESS_STATE_DIR: tmpDir, PORTLESS_HTTPS: "0" },
+          });
+
+          expect(status).toBe(0);
+          expect(fs.readFileSync(capturePath, "utf-8")).toBe(
+            `http://${name}.localhost:${proxy.port}`
+          );
+        } finally {
+          if (proxyChild) await stopChild(proxyChild);
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+      }
+    );
 
     it("strips --name and passes command through (PORTLESS=0)", () => {
       const { status, stdout } = run(["run", "--name", "custom", "echo", "ok"], {
@@ -2314,9 +2394,12 @@ describe("CLI", () => {
     // a separate limitation of the multi-app spawn path, not the worktree-prefix
     // logic under test here, which is platform-agnostic and covered
     // cross-platform by the detectWorktreePrefix unit tests. Runs on macOS/Linux.
-    it.skipIf(process.platform === "win32")(
-      "prefixes every app hostname with the worktree branch",
-      async () => {
+    it.skipIf(process.platform === "win32").each([
+      ["prefixes every app hostname with the worktree branch", [], "feature-x."],
+      ["skips the worktree prefix with --no-worktree", ["--no-worktree"], ""],
+    ])(
+      "%s",
+      async (_label, args, prefix) => {
         const root = fs.mkdtempSync(path.join(os.tmpdir(), "portless-multi-wt-"));
         const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-multi-state-"));
         const proxyPort = await getFreePort();
@@ -2381,7 +2464,7 @@ describe("CLI", () => {
           childEnv.NO_COLOR = "1";
 
           let output = "";
-          cli = spawn(process.execPath, [CLI_PATH], {
+          cli = spawn(process.execPath, [CLI_PATH, ...args], {
             cwd: root,
             env: childEnv,
             stdio: ["ignore", "pipe", "pipe"],
@@ -2403,10 +2486,8 @@ describe("CLI", () => {
               `capture incomplete (web=${JSON.stringify(webUrl)}, api=${JSON.stringify(apiUrl)}). CLI output:\n${output}`
             );
           }
-          // Routed URL must carry the worktree prefix, in the full multi-app
-          // form <branch>.<pkg>.<project>.<tld>.
-          expect(webUrl).toContain("feature-x.web.myrepo.localhost");
-          expect(apiUrl).toContain("feature-x.api.myrepo.localhost");
+          expect(webUrl).toContain(`${prefix}web.myrepo.localhost`);
+          expect(apiUrl).toContain(`${prefix}api.myrepo.localhost`);
         } finally {
           if (cli) await stopChild(cli);
           run(["proxy", "stop"], {

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1681,6 +1681,7 @@ ${colors.bold("Usage:")}
 
 ${colors.bold("Options:")}
   --name <name>          Override the inferred base name (worktree prefix still applies)
+  --no-worktree          Skip worktree prefix detection
   --force                Kill the existing process and take over its route
   --app-port <number>    Use a fixed port for the app (skip auto-assignment)
   --tailscale            Share the app on your Tailscale network (tailnet)
@@ -1961,6 +1962,7 @@ ${colors.bold("Options:")}
   --ngrok                       Share the app publicly via ngrok
   --force                       Kill the existing process and take over its route
   --name <name>                 Use <name> as the app name (bypasses subcommand dispatch)
+  --no-worktree                 Skip worktree prefix detection
   --                            Stop flag parsing; everything after is passed to the child
 
 ${colors.bold("Environment variables:")}
@@ -2270,7 +2272,7 @@ async function handleList(): Promise<void> {
   listRoutes(store, port, tls);
 }
 
-async function handleGet(args: string[]): Promise<void> {
+async function handleGet(args: string[], skipWorktree = false): Promise<void> {
   if (args[1] === "--help" || args[1] === "-h") {
     console.log(`
 ${colors.bold("portless get")} - Print the URL for a service.
@@ -2296,7 +2298,6 @@ ${colors.bold("Examples:")}
     process.exit(0);
   }
 
-  let skipWorktree = false;
   const positional: string[] = [];
 
   for (let i = 1; i < args.length; i++) {
@@ -3487,7 +3488,8 @@ function loadAppConfig(cwd: string = process.cwd()): AppConfig | null {
  */
 async function handleDefaultMode(
   globalScript?: string,
-  extraArgs: string[] = []
+  extraArgs: string[] = [],
+  skipWorktree = false
 ): Promise<boolean> {
   const cwd = process.cwd();
 
@@ -3509,7 +3511,7 @@ async function handleDefaultMode(
     }
     const hasMatchingPackages = packages.some((p) => p.scripts[wsScriptName]);
     if (hasMatchingPackages) {
-      await handleDefaultMulti(cwd, globalScript, extraArgs);
+      await handleDefaultMulti(cwd, globalScript, extraArgs, skipWorktree);
       return true;
     }
   }
@@ -3517,7 +3519,7 @@ async function handleDefaultMode(
   const appConfig = loadAppConfig(cwd);
   const scriptName = globalScript ?? appConfig?.script ?? "dev";
   if (hasScript(scriptName, cwd)) {
-    await handleDefaultSingle(cwd, scriptName, appConfig);
+    await handleDefaultSingle(cwd, scriptName, appConfig, skipWorktree);
     return true;
   }
 
@@ -3530,7 +3532,8 @@ async function handleDefaultMode(
 async function handleDefaultSingle(
   cwd: string,
   scriptName: string,
-  appConfig: AppConfig | null
+  appConfig: AppConfig | null,
+  skipWorktree = false
 ): Promise<void> {
   const resolved = resolveScriptCommand(scriptName, cwd);
   if (!resolved) {
@@ -3553,7 +3556,7 @@ async function handleDefaultSingle(
     nameSource = inferred.source;
   }
 
-  const worktree = detectWorktreePrefix(cwd);
+  const worktree = skipWorktree ? null : detectWorktreePrefix(cwd);
   const effectiveName = applyWorktreePrefix(baseName, worktree);
 
   const { dir, port, tls, tlds, lanMode, lanIp } = await discoverState();
@@ -3734,7 +3737,8 @@ function spawnTaskApp(
 async function handleDefaultMulti(
   wsRoot: string,
   globalScript?: string,
-  extraArgs: string[] = []
+  extraArgs: string[] = [],
+  skipWorktree = false
 ): Promise<void> {
   let loaded: ReturnType<typeof loadConfig>;
   try {
@@ -3788,7 +3792,7 @@ async function handleDefaultMulti(
   // In a git worktree, prefix every app's hostname with the branch name so
   // parallel worktrees of the same monorepo don't collide on <name>.localhost.
   // Mirrors handleDefaultSingle; single-app mode already does this.
-  const worktree = detectWorktreePrefix(wsRoot);
+  const worktree = skipWorktree ? null : detectWorktreePrefix(wsRoot);
 
   for (const pkg of packages) {
     const rel = path.relative(wsRoot, pkg.dir).replace(/\\/g, "/");
@@ -4116,7 +4120,11 @@ async function runWithDirectSpawn(
   }
 }
 
-async function handleRunMode(args: string[], globalScript?: string): Promise<void> {
+async function handleRunMode(
+  args: string[],
+  globalScript?: string,
+  skipWorktree = false
+): Promise<void> {
   const parsed = parseRunArgs(args);
 
   const appConfig = loadAppConfig();
@@ -4165,7 +4173,7 @@ async function handleRunMode(args: string[], globalScript?: string): Promise<voi
     parsed.appPort = appConfig.appPort;
   }
 
-  const worktree = detectWorktreePrefix();
+  const worktree = skipWorktree ? null : detectWorktreePrefix();
   const effectiveName = worktree ? `${worktree.prefix}.${baseName}` : baseName;
 
   const { dir, port, tls, tlds, lanMode, lanIp } = await discoverState();
@@ -4265,7 +4273,13 @@ async function main() {
     process.exit(1);
   }
 
-  const globalBooleanFlags = new Set(["--lan", "--tailscale", "--funnel", "--ngrok"]);
+  const globalBooleanFlags = new Set([
+    "--lan",
+    "--tailscale",
+    "--funnel",
+    "--ngrok",
+    "--no-worktree",
+  ]);
   const globalValueFlags = new Set(["--ip", INTERNAL_LAN_IP_FLAG, "--script"]);
   const childlessCommands = new Set([
     "--help",
@@ -4384,6 +4398,7 @@ async function main() {
   if (stripGlobalFlag("--ngrok", false)) {
     process.env.PORTLESS_NGROK = "1";
   }
+  const skipWorktree = stripGlobalFlag("--no-worktree", false) === true;
 
   // --script flag: override the default "dev" script for zero-arg mode.
   const scriptResult = stripGlobalFlag("--script", true);
@@ -4467,7 +4482,7 @@ async function main() {
     }
     if (args.length === 0 || args[0] === "--") {
       const extraArgs = args[0] === "--" ? args.slice(1) : [];
-      const handled = await handleDefaultMode(globalScript, extraArgs);
+      const handled = await handleDefaultMode(globalScript, extraArgs, skipWorktree);
       if (handled) return;
       printHelp();
       return;
@@ -4497,7 +4512,7 @@ async function main() {
       return;
     }
     if (args[0] === "get") {
-      await handleGet(args);
+      await handleGet(args, skipWorktree);
       return;
     }
     if (args[0] === "alias") {
@@ -4520,7 +4535,7 @@ async function main() {
 
   // Run app (either `portless run <cmd>` or `portless <name> <cmd>`)
   if (isRunCommand) {
-    await handleRunMode(args, globalScript);
+    await handleRunMode(args, globalScript, skipWorktree);
   } else {
     await handleNamedMode(args);
   }

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -143,6 +143,10 @@ portless run next dev   # -> https://myapp.localhost
 
 # Linked worktree on branch "fix-ui"
 portless run next dev   # -> https://fix-ui.myapp.localhost
+
+# Skip worktree prefix detection
+portless run --no-worktree --name api.fix-ui.example pnpm dev
+# -> https://api.fix-ui.example.localhost
 ```
 
 No config changes needed. Put `portless run` in `package.json` once and it works in all worktrees.
@@ -290,6 +294,7 @@ The chosen service configuration is written into launchd, systemd, or Task Sched
 | `portless --script <name>`                        | Run a specific package.json script (default: dev)              |
 | `portless run [cmd] [args...]`                    | Infer name from project, run through proxy (auto-starts)       |
 | `portless run --name <name> <cmd>`                | Override inferred base name (worktree prefix still applies)    |
+| `portless run --no-worktree --name <name> <cmd>`  | Skip worktree prefix detection                                 |
 | `portless <name> <cmd> [args...]`                 | Run app at `https://<name>.localhost` (auto-starts proxy)      |
 | `portless get <name>`                             | Print URL for a service (for cross-service wiring)             |
 | `portless get <name> --no-worktree`               | Print URL without worktree prefix                              |


### PR DESCRIPTION
## Summary
Adds the --no-worktree flag to portless run and default mode, allowing users to skip automatic worktree hostname prefixes.
## Changes
- Added --no-worktree CLI flag support.
- Applied the flag to single-app and multi-app execution modes.
- Updated CLI help output.
- Added documentation to the README, docs site, and agent skill.
- Added coverage for explicit, inferred, bare, and multi-app hostname behavior.
## Testing
- Added unit and integration tests covering worktree prefix suppression.
- Existing worktree prefix behavior remains covered.

Fixes #326 