### PR TITLE
fix(service): resolve node from PATH at service start instead of pinning the absolute binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,8 @@ The service uses portless defaults unless install options or `PORTLESS_*` enviro
 
 The chosen service configuration is written into launchd, systemd, or Task Scheduler and reused after reboot. `portless service status` reports the installed port, HTTPS mode, TLDs, LAN mode, wildcard mode, and state directory. macOS and Linux install a root-owned service so port 443 can bind at boot. Windows installs a Task Scheduler startup task that runs as SYSTEM. Installation and removal may require administrator privileges. `portless clean` automatically removes the service.
 
+The service resolves `node` from the PATH captured at install time (with the Node directory that ran the install placed first), so it is not pinned to the exact binary that existed during install. If you switch Node versions with a version manager such as nvm, re-run `portless service install` to refresh the service definition.
+
 ## LAN mode
 
 ```bash

--- a/packages/portless/src/service.test.ts
+++ b/packages/portless/src/service.test.ts
@@ -109,8 +109,11 @@ describe("buildServiceSpec", () => {
     expect(spec.platform).toBe("darwin");
     if (spec.platform !== "darwin") throw new Error("Expected macOS service spec");
     expect(spec.plistPath).toBe("/Library/LaunchDaemons/sh.portless.proxy.plist");
+    // node is resolved from PATH at start instead of pinning the absolute
+    // binary, so removing that Node install does not break boot (#393).
     expect(spec.programArguments).toEqual([
-      "/usr/local/bin/node",
+      "/usr/bin/env",
+      "node",
       "/usr/local/lib/node_modules/portless/dist/cli.js",
       "proxy",
       "start",
@@ -126,6 +129,10 @@ describe("buildServiceSpec", () => {
     expect(spec.plist).toContain("<string>/Users/alice/.portless</string>");
     expect(spec.plist).toContain("<key>SUDO_UID</key>");
     expect(spec.plist).toContain("<string>501</string>");
+    // launchd daemons start with a minimal PATH; the install-time Node
+    // directory is baked in so `/usr/bin/env node` resolves.
+    expect(spec.plist).toContain("<key>PATH</key>");
+    expect(spec.plist).toContain("<string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>");
   });
 
   it("builds a Linux systemd unit for the HTTPS proxy", () => {
@@ -141,8 +148,11 @@ describe("buildServiceSpec", () => {
     expect(spec.platform).toBe("linux");
     if (spec.platform !== "linux") throw new Error("Expected Linux service spec");
     expect(spec.unitPath).toBe("/etc/systemd/system/portless.service");
+    // node is resolved from PATH at start instead of pinning the absolute
+    // binary, so removing that Node install does not break boot (#393).
     expect(spec.execStart).toEqual([
-      "/usr/bin/node",
+      "/usr/bin/env",
+      "node",
       "/usr/lib/node_modules/portless/dist/cli.js",
       "proxy",
       "start",
@@ -156,9 +166,27 @@ describe("buildServiceSpec", () => {
     expect(spec.unit).toContain('Environment=PORTLESS_STATE_DIR="/home/alice/.portless"');
     expect(spec.unit).toContain('Environment=SUDO_UID="1000"');
     expect(spec.unit).toContain(
-      'ExecStart="/usr/bin/node" "/usr/lib/node_modules/portless/dist/cli.js" "proxy" "start" "--foreground" "--port" "443" "--https" "--skip-trust"'
+      'ExecStart="/usr/bin/env" "node" "/usr/lib/node_modules/portless/dist/cli.js" "proxy" "start" "--foreground" "--port" "443" "--https" "--skip-trust"'
     );
     expect(spec.unit).toContain("WantedBy=multi-user.target");
+  });
+
+  it("bakes the install-time Node directory into the Linux service PATH", () => {
+    // sudo often sanitizes PATH (secure_path), dropping version-manager
+    // directories; the captured Node directory must be baked in so
+    // `/usr/bin/env node` resolves even for nvm-style installs (#393).
+    const spec = buildServiceSpec({
+      platform: "linux",
+      nodePath: "/home/alice/.nvm/versions/node/v24.1.0/bin/node",
+      entryScript: "/usr/lib/node_modules/portless/dist/cli.js",
+      userHome: "/home/alice",
+      pathEnv: "/usr/local/bin:/usr/bin:/bin",
+    });
+
+    if (spec.platform !== "linux") throw new Error("Expected Linux service spec");
+    expect(spec.unit).toContain(
+      'Environment=PATH="/home/alice/.nvm/versions/node/v24.1.0/bin:/usr/local/bin:/usr/bin:/bin"'
+    );
   });
 
   it("builds a Windows startup task for the HTTPS proxy", () => {
@@ -191,7 +219,12 @@ describe("buildServiceSpec", () => {
       "<Arguments>/d /s /c &quot;&quot;C:\\ProgramData\\portless\\service\\portless-service.cmd&quot;&quot;</Arguments>"
     );
     expect(spec.script).toContain("PORTLESS_STATE_DIR=C:\\Users\\Alice\\.portless");
-    expect(spec.script).toContain('"C:\\Program Files\\nodejs\\node.exe"');
+    // node is resolved from the PATH baked into the script instead of pinning
+    // the absolute binary (#393).
+    expect(spec.script).not.toContain('"C:\\Program Files\\nodejs\\node.exe"');
+    expect(spec.script).toContain(
+      'node "C:\\Users\\Alice\\AppData\\Roaming\\npm\\node_modules\\portless\\dist\\cli.js"'
+    );
     expect(spec.script).toContain("proxy");
     expect(spec.script).toContain("--port");
     expect(spec.script).toContain("443");
@@ -209,8 +242,10 @@ describe("buildServiceSpec", () => {
     });
 
     if (spec.platform !== "win32") throw new Error("Expected Windows service spec");
+    // The Node directory that ran the install is prepended so `node` resolves
+    // even under a PATH that does not include it (#393).
     expect(spec.script).toContain(
-      'set "PATH=C:\\Program Files\\Git\\mingw64\\bin;C:\\Tools\\100%%Done"'
+      'set "PATH=C:\\nodejs;C:\\Program Files\\Git\\mingw64\\bin;C:\\Tools\\100%%Done"'
     );
   });
 

--- a/packages/portless/src/service.ts
+++ b/packages/portless/src/service.ts
@@ -431,14 +431,31 @@ function buildServiceEnv(ctx: ServiceContext): Record<string, string> {
 
   if (ctx.platform === "win32") {
     env.USERPROFILE = ctx.user.home;
-    env.PATH = ctx.pathEnv;
   } else {
     env.HOME = ctx.user.home;
     if (ctx.user.uid) env.SUDO_UID = ctx.user.uid;
     if (ctx.user.gid) env.SUDO_GID = ctx.user.gid;
   }
 
+  // Bake in a PATH that starts with the Node directory that ran the install,
+  // so the service resolves `node` from PATH at start instead of depending on
+  // the pinned absolute binary still existing (#393).
+  env.PATH = servicePathEnv(ctx);
+
   return env;
+}
+
+/// Prepends the install-time Node directory to the captured PATH so the
+/// service can resolve `node` even when the service manager sanitizes PATH
+/// (for example sudo `secure_path` on Linux) (#393).
+function servicePathEnv(ctx: ServiceContext): string {
+  const separator = ctx.platform === "win32" ? ";" : ":";
+  const nodeDir = (ctx.platform === "win32" ? path.win32 : path.posix).dirname(ctx.nodePath);
+  const entries = ctx.pathEnv.split(separator).filter((entry) => entry.length > 0);
+  if (!entries.includes(nodeDir)) {
+    entries.unshift(nodeDir);
+  }
+  return entries.join(separator);
 }
 
 function defaultStateDir(platform: SupportedPlatform, userHome: string): string {
@@ -498,7 +515,6 @@ Wants=network-online.target
 [Service]
 Type=simple
 ${envLines}
-Environment=PATH=${systemdEscape(ctx.pathEnv)}
 ExecStart=${execStart.map(systemdEscape).join(" ")}
 Restart=on-failure
 RestartSec=2
@@ -515,7 +531,9 @@ function buildWindowsScript(ctx: ServiceContext, command: string[]): string {
   const setEnv = Object.entries(env)
     .map(([key, value]) => `set "${key}=${value.replace(/"/g, "").replace(/%/g, "%%")}"`)
     .join("\r\n");
-  const proxyCommand = [windowsQuote(ctx.nodePath), ...command.map(windowsQuote)].join(" ");
+  // Resolve node from the PATH set above instead of pinning the absolute
+  // binary, so the task keeps working if that Node install is removed (#393).
+  const proxyCommand = ["node", ...command.map(windowsQuote)].join(" ");
   return `@echo off\r\n${setEnv}\r\n${proxyCommand}\r\n`;
 }
 
@@ -613,7 +631,9 @@ export function buildServiceSpec(options: {
   const proxyCommand = buildProxyCommand(ctx.entryScript, ctx.config);
 
   if (ctx.platform === "darwin") {
-    const programArguments = [ctx.nodePath, ...proxyCommand];
+    // Resolve node from PATH at start (launchd gets PATH from the plist env)
+    // so the service keeps working if the pinned binary is removed (#393).
+    const programArguments = ["/usr/bin/env", "node", ...proxyCommand];
     return {
       platform: "darwin",
       label: SERVICE_LABEL,
@@ -626,7 +646,9 @@ export function buildServiceSpec(options: {
   }
 
   if (ctx.platform === "linux") {
-    const execStart = [ctx.nodePath, ...proxyCommand];
+    // Resolve node from PATH at start (systemd gets PATH from the unit env)
+    // so the service keeps working if the pinned binary is removed (#393).
+    const execStart = ["/usr/bin/env", "node", ...proxyCommand];
     return {
       platform: "linux",
       serviceName: SYSTEMD_SERVICE,
@@ -1225,6 +1247,10 @@ ${colors.bold("Notes:")}
   environment variables are provided during install.
   macOS and Linux install a root-owned service so port 443 can bind at boot.
   Windows installs a Task Scheduler startup task that runs as SYSTEM.
+  The service resolves node from the PATH captured at install time (with the
+  Node directory that ran the install placed first), so it is not pinned to
+  the exact binary that existed during install. If you switch Node versions
+  with a version manager, re-run "portless service install" to refresh it.
 `);
 }
 

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -281,6 +281,8 @@ The service uses portless defaults unless install options or `PORTLESS_*` enviro
 
 The chosen service configuration is written into launchd, systemd, or Task Scheduler and reused after reboot. `portless service status` reports the installed port, HTTPS mode, TLDs, LAN mode, wildcard mode, and state directory. macOS and Linux install a root-owned service so port 443 can bind at boot. Windows installs a Task Scheduler startup task that runs as SYSTEM. Installation and removal may require administrator privileges. `portless clean` automatically removes the service.
 
+The service resolves `node` from the PATH captured at install time (with the Node directory that ran the install placed first), so it is not pinned to the exact binary that existed during install. If you switch Node versions with a version manager such as nvm, re-run `portless service install` to refresh the service definition.
+
 ## CLI Reference
 
 | Command                                           | Description                                                    |


### PR DESCRIPTION
Fixes #393.

## What

`portless service install` pinned the absolute path of the Node binary that ran it into the service definition (systemd `ExecStart`, launchd `ProgramArguments`, the Windows startup script). Removing that Node install (nvm cleanup, switching version managers) silently disabled the proxy at the next boot with nothing pointing at the cause.

The service now resolves `node` from PATH at start instead of depending on the pinned binary:

- Linux: `ExecStart=/usr/bin/env node ...` — the unit already carried `Environment=PATH=...`, so `env` resolves from it.
- macOS: `ProgramArguments` starts with `/usr/bin/env node`, and the plist now includes a `PATH` environment entry (launchd daemons otherwise start with a minimal PATH).
- Windows: the startup script invokes bare `node` after setting `PATH` (it already baked the install-time PATH in).

In addition, the baked `PATH` now starts with the directory of the Node binary that ran the install (prepended if not already present), on all three platforms.

## Why the prepended Node directory matters

Two reasons this is not just `env node`:

1. **sudo sanitizes PATH.** On Linux the install re-elevates through `sudo`, whose `secure_path` commonly drops version-manager directories. Without prepending the install-time Node directory, every nvm user installing through the elevated path would get a unit whose PATH cannot resolve `node` — a regression. Prepending keeps the current behavior exactly (the install-time Node is still found first) while adding the fallback.
2. **Boot environments are minimal.** launchd's default PATH would not find Homebrew/nvm Node; the baked PATH (with the Node dir first) makes the resolution deterministic.

## Known boundary (stated up front)

The PATH baked into the service is captured at install time. nvm PATH entries are version-specific, so switching Node versions with nvm still requires re-running `portless service install` — the one-command recovery path the issue already notes. What this change fixes is the failure class where a Node binary still resolvable from the captured PATH (reinstall at a standard path, stable shims like volta/asdf/mise, system package updates) would previously break the boot silently: the service now keeps working, and if `node` truly cannot be resolved, the failure is a visible `env: 'node': No such file or directory` in the service log instead of "all URLs just stop resolving". The README, `skills/portless/SKILL.md`, and `portless service --help` now document this. A `portless doctor` check for the installed service's node resolution seems a good follow-up but is out of scope here.

## Compatibility

- `portless service status` config read-back parses installed definitions by locating `proxy start` in the command line, which is unaffected by the `/usr/bin/env node` prefix; the existing status round-trip test covers the new format.
- Existing installed services keep their pinned path until the next `portless service install`, which rewrites the definition.

## Tests

- `pnpm --filter portless exec vitest run src/service.test.ts` — 29 passed, including:
  - updated specs asserting `env node` invocations on darwin/linux and bare `node` in the Windows script (absolute node path no longer present);
  - new test asserting the install-time Node directory is prepended to the Linux unit PATH for an nvm-style `nodePath` with a `secure_path`-like captured PATH;
  - darwin plist now asserts the `PATH` environment entry.
- `pnpm lint`, `pnpm type-check`, `pnpm build` all green. (`pnpm --filter portless test` has pre-existing failures in `certs.test.ts`/`windows-ca.test.ts` on this Windows checkout — they fail identically on unmodified `main` and are unrelated.)
