### PR TITLE
fix: trust Linux Chrome certificates in the user NSS database

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ On Linux, `portless trust` supports Debian/Ubuntu, Arch, Fedora/RHEL/CentOS, and
 
 On Linux, portless also trusts the CA in the invoking user's existing Chrome/Chromium NSS database: `~/.pki/nssdb` if present, otherwise `~/.local/share/pki/nssdb` (Chromium M146+). This requires NSS `certutil`: install `libnss3-tools` on Debian/Ubuntu, `nss-tools` on Fedora/RHEL, `nss` on Arch, or `mozilla-nss-tools` on openSUSE, then run `portless trust` and restart the browser. No NSS database is created if neither path exists; if you install Chrome later, open it once and rerun `portless trust`. `portless clean` also removes the CA from the active NSS database.
 
+If NSS registration fails (including when `certutil` is missing), successful system trust registration is preserved and `portless trust` exits successfully with a browser-trust warning. Chrome may still reject the certificate; install the NSS tools and rerun `portless trust`. `portless doctor` continues to report incomplete trust. NSS removal failures still leave `portless clean` incomplete and preserve the CA certificate and key for retry.
+
 ## Start at OS startup
 
 Install the proxy as an OS startup service so clean HTTPS URLs are available after reboot without starting the proxy from a terminal:

--- a/README.md
+++ b/README.md
@@ -286,6 +286,8 @@ portless trust
 
 On Linux, `portless trust` supports Debian/Ubuntu, Arch, Fedora/RHEL/CentOS, and openSUSE (via `update-ca-certificates` or `update-ca-trust`). On Windows, it uses `certutil` to add the CA to the system trust store. On WSL, it updates both the Linux trust store and the Windows current-user Root store so Windows browsers trust portless HTTPS certificates.
 
+On Linux, portless also trusts the CA in the invoking user's existing Chrome/Chromium NSS database: `~/.pki/nssdb` if present, otherwise `~/.local/share/pki/nssdb` (Chromium M146+). This requires NSS `certutil`: install `libnss3-tools` on Debian/Ubuntu, `nss-tools` on Fedora/RHEL, `nss` on Arch, or `mozilla-nss-tools` on openSUSE, then run `portless trust` and restart the browser. No NSS database is created if neither path exists; if you install Chrome later, open it once and rerun `portless trust`. `portless clean` also removes the CA from the active NSS database.
+
 ## Start at OS startup
 
 Install the proxy as an OS startup service so clean HTTPS URLs are available after reboot without starting the proxy from a terminal:

--- a/apps/docs/src/app/https/page.mdx
+++ b/apps/docs/src/app/https/page.mdx
@@ -4,6 +4,8 @@ HTTP/2 + TLS is enabled by default for faster dev server page loads. Browsers li
 
 First run generates a local CA and server certs, then adds the CA to your system trust store. After that, no prompts, no browser warnings.
 
+On Linux, `portless trust` also updates the invoking user's existing Chrome/Chromium NSS database, even under sudo. It uses `~/.pki/nssdb` if present, otherwise `~/.local/share/pki/nssdb` (Chromium M146+). Install NSS `certutil` first (`sudo apt install libnss3-tools` on Debian/Ubuntu), then run `portless trust` and restart the browser. If neither database exists, open Chrome once before rerunning `portless trust`. `portless clean` removes the CA from the active NSS database too.
+
 On WSL, portless updates both the Linux trust store and the Windows current-user Root store. Windows browsers can then verify portless HTTPS certificates served from WSL.
 
 ## Custom certificates

--- a/apps/docs/src/app/https/page.mdx
+++ b/apps/docs/src/app/https/page.mdx
@@ -6,6 +6,8 @@ First run generates a local CA and server certs, then adds the CA to your system
 
 On Linux, `portless trust` also updates the invoking user's existing Chrome/Chromium NSS database, even under sudo. It uses `~/.pki/nssdb` if present, otherwise `~/.local/share/pki/nssdb` (Chromium M146+). Install NSS `certutil` first (`sudo apt install libnss3-tools` on Debian/Ubuntu), then run `portless trust` and restart the browser. If neither database exists, open Chrome once before rerunning `portless trust`. `portless clean` removes the CA from the active NSS database too.
 
+If NSS registration fails or `certutil` is missing, `portless trust` preserves successful system trust registration and exits successfully with a warning. Chrome may still reject the certificate; install the NSS tools and rerun `portless trust`. `portless doctor` reports incomplete trust until NSS verification succeeds. If NSS removal fails during `portless clean`, the CA certificate and key are retained for retry.
+
 On WSL, portless updates both the Linux trust store and the Windows current-user Root store. Windows browsers can then verify portless HTTPS certificates served from WSL.
 
 ## Custom certificates

--- a/packages/portless/src/certs-linux.test.ts
+++ b/packages/portless/src/certs-linux.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as crypto from "node:crypto";
+import * as childProcess from "node:child_process";
+import { ensureCerts, isCATrusted, trustCA, untrustCA } from "./certs.js";
+import type * as windowsCA from "./windows-ca.js";
+
+vi.mock("./windows-ca.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof windowsCA>()),
+  isWSL: () => false,
+}));
+
+// Keep system trust and NSS operations isolated from the developer's machine.
+vi.mock("node:fs", async (importOriginal) => ({
+  ...(await importOriginal<typeof fs>()),
+}));
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof childProcess>()),
+}));
+
+describe.skipIf(process.platform !== "linux")("Linux browser CA trust", () => {
+  let home: string;
+  let stateDir: string;
+  let ca: string;
+  let systemCA: string | undefined;
+  let databases: Map<string, Map<string, { pem: string; trust: string }>>;
+  let certutilError: Error | undefined;
+  let nssUsers: (string | undefined)[];
+  const systemPath = "/usr/local/share/ca-certificates/portless-ca.crt";
+
+  function createDB(relativePath = ".local/share/pki/nssdb") {
+    const db = path.join(home, relativePath);
+    fs.mkdirSync(db, { recursive: true });
+    databases.set(db, new Map());
+    return databases.get(db)!;
+  }
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "portless-nss-test-"));
+    stateDir = path.join(home, ".portless");
+    fs.mkdirSync(stateDir);
+    ensureCerts(stateDir);
+    ca = fs.readFileSync(path.join(stateDir, "ca.pem"), "utf-8");
+    systemCA = ca;
+    databases = new Map();
+    nssUsers = [];
+    certutilError = undefined;
+    vi.stubEnv("HOME", home);
+    vi.stubEnv("SUDO_USER", "");
+
+    const readFile = fs.readFileSync;
+    const access = fs.accessSync;
+    const copy = fs.copyFileSync;
+    const unlink = fs.unlinkSync;
+    vi.spyOn(fs, "readFileSync").mockImplementation((file, options) => {
+      if (file === "/etc/os-release") return "ID=ubuntu\n";
+      if (file === systemPath && systemCA !== undefined) return systemCA;
+      return readFile(file, options);
+    });
+    vi.spyOn(fs, "accessSync").mockImplementation((file, mode) => {
+      if (file === systemPath) {
+        if (systemCA === undefined) throw new Error("not installed");
+        return;
+      }
+      access(file, mode);
+    });
+    vi.spyOn(fs, "copyFileSync").mockImplementation((src, dest, mode) => {
+      if (dest === systemPath) systemCA = readFile(src, "utf-8");
+      else copy(src, dest, mode);
+    });
+    vi.spyOn(fs, "unlinkSync").mockImplementation((file) => {
+      if (file === systemPath) systemCA = undefined;
+      else unlink(file);
+    });
+    const exec = childProcess.execFileSync;
+    vi.spyOn(childProcess, "execFileSync").mockImplementation((command, args, options) => {
+      let user: string | undefined;
+      if (command === "sudo") {
+        user = args![1];
+        command = "certutil";
+        args = args!.slice(args!.indexOf("certutil") + 1);
+      }
+      if (command === "update-ca-certificates") return "";
+      if (command !== "certutil") return exec(command, args, options);
+      nssUsers.push(user);
+      if (certutilError) throw certutilError;
+      const dbPath = args![args!.indexOf("-d") + 1].replace(/^sql:/, "");
+      const db = databases.get(dbPath);
+      if (!db) throw new Error("NSS database unavailable");
+      const nickname = args!.includes("-n") ? args![args!.indexOf("-n") + 1] : undefined;
+      if (args!.includes("-A")) {
+        db.set(nickname!, { pem: String(options!.input), trust: args![args!.indexOf("-t") + 1] });
+        return "";
+      }
+      if (args!.includes("-D")) {
+        if (!db.delete(nickname!)) throw new Error("certificate not found");
+        return "";
+      }
+      if (nickname) {
+        const cert = db.get(nickname);
+        if (!cert) throw new Error("certificate not found");
+        return cert.pem;
+      }
+      return [...db].map(([name, cert]) => `${name}    ${cert.trust}`).join("\n");
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it("does not treat system trust or an old marker as browser trust", () => {
+    createDB();
+    fs.writeFileSync(
+      path.join(stateDir, "ca.trusted"),
+      crypto.createHash("sha256").update(ca).digest("hex")
+    );
+    expect(isCATrusted(stateDir)).toBe(false);
+  });
+
+  it("trusts the active browser DB and notices SSL trust removal despite its marker", () => {
+    const db = createDB();
+    expect(trustCA(stateDir)).toEqual({ trusted: true });
+    expect([...db.values()]).toEqual([{ pem: ca, trust: "C,," }]);
+    expect(isCATrusted(stateDir)).toBe(true);
+    [...db.values()][0].trust = ",,";
+    expect(isCATrusted(stateDir)).toBe(false);
+    expect(untrustCA(stateDir)).toEqual({ removed: true });
+    expect([...db.keys()]).toEqual([]);
+  });
+
+  it("prefers the existing legacy DB over the new default", () => {
+    const modern = createDB();
+    const legacy = createDB(".pki/nssdb");
+    expect(trustCA(stateDir)).toEqual({ trusted: true });
+    expect([...legacy.values()]).toEqual([{ pem: ca, trust: "C,," }]);
+    expect([...modern.values()]).toEqual([]);
+  });
+
+  it("runs NSS operations as the invoking user under sudo", () => {
+    createDB();
+    vi.stubEnv("SUDO_USER", "alice");
+    vi.spyOn(process, "getuid").mockReturnValue(0);
+    expect(trustCA(stateDir)).toEqual({ trusted: true });
+    expect(isCATrusted(stateDir)).toBe(true);
+    expect(new Set(nssUsers)).toEqual(new Set(["alice"]));
+  });
+
+  it("reports missing certutil instead of claiming browser trust", () => {
+    createDB();
+    certutilError = Object.assign(new Error("spawnSync certutil ENOENT"), { code: "ENOENT" });
+    const result = trustCA(stateDir);
+    expect(result.trusted).toBe(false);
+    expect(result.error).toContain("libnss3-tools");
+    expect(isCATrusted(stateDir)).toBe(false);
+  });
+
+  it("preserves system-only support when no browser DB exists", () => {
+    expect(trustCA(stateDir)).toEqual({ trusted: true });
+    expect(isCATrusted(stateDir)).toBe(true);
+    expect(nssUsers).toEqual([]);
+    createDB();
+    expect(isCATrusted(stateDir)).toBe(false);
+  });
+
+  it("removes its NSS root without removing unrelated certificates", () => {
+    const db = createDB();
+    db.set("another CA", { pem: "unrelated", trust: "C,," });
+    expect(trustCA(stateDir)).toEqual({ trusted: true });
+    expect(untrustCA(stateDir)).toEqual({ removed: true });
+    expect([...db.keys()]).toEqual(["another CA"]);
+    expect(isCATrusted(stateDir)).toBe(false);
+  });
+
+  it("keeps cleanup retryable when the NSS database cannot be accessed", () => {
+    const db = createDB();
+    expect(trustCA(stateDir)).toEqual({ trusted: true });
+    certutilError = new Error("NSS database unavailable");
+    expect(untrustCA(stateDir).removed).toBe(false);
+    expect(fs.existsSync(path.join(stateDir, "ca.pem"))).toBe(true);
+    certutilError = undefined;
+    expect(untrustCA(stateDir)).toEqual({ removed: true });
+    expect([...db.keys()]).toEqual([]);
+  });
+});

--- a/packages/portless/src/certs-linux.test.ts
+++ b/packages/portless/src/certs-linux.test.ts
@@ -150,13 +150,29 @@ describe.skipIf(process.platform !== "linux")("Linux browser CA trust", () => {
     expect(new Set(nssUsers)).toEqual(new Set(["alice"]));
   });
 
-  it("reports missing certutil instead of claiming browser trust", () => {
+  it("reports partial success when certutil is missing and completes trust on retry", () => {
     createDB();
     certutilError = Object.assign(new Error("spawnSync certutil ENOENT"), { code: "ENOENT" });
     const result = trustCA(stateDir);
-    expect(result.trusted).toBe(false);
-    expect(result.error).toContain("libnss3-tools");
+    expect(result.trusted).toBe(true);
+    expect(result.warning).toContain("libnss3-tools");
+    expect(result.error).toBeUndefined();
     expect(isCATrusted(stateDir)).toBe(false);
+    certutilError = undefined;
+    expect(trustCA(stateDir)).toEqual({ trusted: true });
+    expect(isCATrusted(stateDir)).toBe(true);
+  });
+
+  it("still fails when the system trust update fails", () => {
+    createDB();
+    vi.mocked(childProcess.execFileSync).mockImplementationOnce(() => {
+      throw new Error("EACCES: permission denied");
+    });
+    const result = trustCA(stateDir);
+    expect(result.trusted).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.warning).toBeUndefined();
+    expect(nssUsers).toEqual([]);
   });
 
   it("preserves system-only support when no browser DB exists", () => {

--- a/packages/portless/src/certs.ts
+++ b/packages/portless/src/certs.ts
@@ -980,8 +980,11 @@ export function createSNICallback(
  * Windows current-user Root store.
  *
  * Supported Linux distros: Debian/Ubuntu, Arch, Fedora/RHEL/CentOS, openSUSE.
+ *
+ * `trusted` reports OS trust installation. A warning means Linux browser NSS
+ * trust is incomplete; isCATrusted still checks both stores.
  */
-export function trustCA(stateDir: string): { trusted: boolean; error?: string } {
+export function trustCA(stateDir: string): { trusted: boolean; error?: string; warning?: string } {
   const caCertPath = path.join(stateDir, CA_CERT_FILE);
   if (!fileExists(caCertPath)) {
     return {
@@ -1025,10 +1028,18 @@ export function trustCA(stateDir: string): { trusted: boolean; error?: string } 
       const dest = path.join(config.certDir, "portless-ca.crt");
       fs.copyFileSync(caCertPath, dest);
       execFileSync(config.updateCommand, [], { stdio: "pipe", timeout: 30_000 });
-      updateCATrustNSS(caCertPath);
+      let warning: string | undefined;
+      try {
+        updateCATrustNSS(caCertPath);
+      } catch (err) {
+        warning =
+          "Chrome/Chromium may still show certificate warnings.\n" +
+          (err instanceof Error ? err.message : String(err));
+      }
       if (isWSL()) {
         trustWindowsCA(caCertPath, wslWindowsCAStoreOptions());
       }
+      if (warning) return { trusted: true, warning };
       writeTrustMarker(stateDir);
       return { trusted: true };
     } else if (process.platform === "win32") {

--- a/packages/portless/src/certs.ts
+++ b/packages/portless/src/certs.ts
@@ -4,7 +4,7 @@ import * as crypto from "node:crypto";
 import * as tls from "node:tls";
 import { execFile as execFileCb, execFileSync } from "node:child_process";
 import { promisify } from "node:util";
-import { fixOwnership } from "./utils.js";
+import { fixOwnership, resolveUserHome } from "./utils.js";
 import {
   isWSL,
   isWindowsCATrusted,
@@ -456,8 +456,8 @@ export function isCATrusted(stateDir: string): boolean {
   const caCertPath = path.join(stateDir, CA_CERT_FILE);
   if (!fileExists(caCertPath)) return false;
 
-  // Fast path: if we previously trusted this exact CA, skip the OS check.
-  const marker = readTrustMarker(stateDir);
+  // Linux browser trust is per-user and may change independently of this marker.
+  const marker = process.platform === "linux" ? null : readTrustMarker(stateDir);
   if (marker) {
     const fp = caFingerprint(stateDir);
     const expected = fp && isWSL() ? `wsl:${fp}` : fp;
@@ -468,6 +468,7 @@ export function isCATrusted(stateDir: string): boolean {
     return isCATrustedMacOS(caCertPath);
   } else if (process.platform === "linux") {
     if (!isCATrustedLinux(stateDir)) return false;
+    if (!isCATrustedNSS(caCertPath)) return false;
     if (!isWSL()) return true;
     try {
       return isWindowsCATrusted(caCertPath, wslWindowsCAStoreOptions());
@@ -619,6 +620,89 @@ function isCATrustedLinux(
     return ours === installed;
   } catch {
     return false;
+  }
+}
+
+/** Chromium prefers the legacy DB when present, otherwise the M146+ location. */
+function linuxNSSDatabase(): string | undefined {
+  const home = resolveUserHome();
+  const legacy = path.join(home, ".pki", "nssdb");
+  if (fs.existsSync(legacy)) return legacy;
+  const current = path.join(home, ".local", "share", "pki", "nssdb");
+  return fs.existsSync(current) ? current : undefined;
+}
+
+function nssCertutil(database: string, args: string[], input?: string): string {
+  const commandArgs = ["-d", `sql:${database}`, ...args];
+  const sudoUser = process.getuid?.() === 0 ? process.env.SUDO_USER : undefined;
+  try {
+    // Drop privileges, not just HOME, so NSS never creates root-owned user files.
+    // Pass the public CA via stdin because the state directory may be root-only.
+    return execFileSync(
+      sudoUser && sudoUser !== "root" ? "sudo" : "certutil",
+      sudoUser && sudoUser !== "root"
+        ? ["-u", sudoUser, "--", "certutil", ...commandArgs]
+        : commandArgs,
+      { encoding: "utf-8", stdio: "pipe", timeout: 15_000, input }
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Chrome/Chromium NSS trust failed (${database}): ${message}\n` +
+        "Ensure NSS certutil is installed (Debian/Ubuntu: sudo apt install libnss3-tools; " +
+        "Fedora/RHEL: sudo dnf install nss-tools; Arch: sudo pacman -S nss; " +
+        "openSUSE: sudo zypper install mozilla-nss-tools), then retry."
+    );
+  }
+}
+
+function nssNickname(caCertPath: string): string {
+  const cert = new crypto.X509Certificate(fs.readFileSync(caCertPath));
+  // NSS interprets colons in nicknames as token separators.
+  return `${CA_COMMON_NAME} ${cert.fingerprint256.replace(/:/g, "")}`;
+}
+
+function nssTrustFlags(database: string, nickname: string): string | undefined {
+  const listing = nssCertutil(database, ["-L"]);
+  for (const line of listing.split("\n")) {
+    const match = line.trim().match(/^(.*?)\s+([^\s,]*,[^\s,]*,[^\s,]*)$/);
+    if (match?.[1] === nickname) return match[2];
+  }
+  return undefined;
+}
+
+function isCATrustedNSS(caCertPath: string): boolean {
+  const database = linuxNSSDatabase();
+  if (!database) return true;
+  try {
+    const nickname = nssNickname(caCertPath);
+    const flags = nssTrustFlags(database, nickname);
+    if (!flags?.split(",")[0].includes("C")) return false;
+    const installed = nssCertutil(database, ["-L", "-n", nickname, "-a"]);
+    return (
+      new crypto.X509Certificate(installed).fingerprint256 ===
+      new crypto.X509Certificate(fs.readFileSync(caCertPath)).fingerprint256
+    );
+  } catch {
+    return false;
+  }
+}
+
+function updateCATrustNSS(caCertPath: string, remove = false): void {
+  const database = linuxNSSDatabase();
+  if (!database) return;
+  const nickname = nssNickname(caCertPath);
+  if (remove) {
+    // Listing distinguishes an absent certificate from an inaccessible database.
+    if (nssTrustFlags(database, nickname) !== undefined) {
+      nssCertutil(database, ["-D", "-n", nickname]);
+    }
+  } else {
+    nssCertutil(
+      database,
+      ["-A", "-n", nickname, "-t", "C,,"],
+      fs.readFileSync(caCertPath, "utf-8")
+    );
   }
 }
 
@@ -891,8 +975,9 @@ export function createSNICallback(
  *
  * On macOS, adds to the login keychain (no sudo required; the OS shows a
  * GUI authorization prompt to confirm). On Linux, copies to the distro-specific
- * CA directory and runs the appropriate update command (requires sudo). WSL
- * also adds the CA to the Windows current-user Root store.
+ * CA directory and runs the appropriate update command (requires sudo), then
+ * updates the user's existing Chromium NSS DB. WSL also adds the CA to the
+ * Windows current-user Root store.
  *
  * Supported Linux distros: Debian/Ubuntu, Arch, Fedora/RHEL/CentOS, openSUSE.
  */
@@ -940,6 +1025,7 @@ export function trustCA(stateDir: string): { trusted: boolean; error?: string } 
       const dest = path.join(config.certDir, "portless-ca.crt");
       fs.copyFileSync(caCertPath, dest);
       execFileSync(config.updateCommand, [], { stdio: "pipe", timeout: 30_000 });
+      updateCATrustNSS(caCertPath);
       if (isWSL()) {
         trustWindowsCA(caCertPath, wslWindowsCAStoreOptions());
       }
@@ -995,6 +1081,12 @@ export function untrustCA(stateDir: string): { removed: boolean; error?: string 
       result = untrustCAMacOS(caCertPath);
     } else if (process.platform === "linux") {
       result = runningInWSL ? untrustCAWSL(stateDir, caCertPath) : untrustCALinux(stateDir);
+      try {
+        updateCATrustNSS(caCertPath, true);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        result = { removed: false, error: [result.error, message].filter(Boolean).join("; ") };
+      }
     } else if (process.platform === "win32") {
       result = untrustWindowsCA(caCertPath);
     } else {

--- a/packages/portless/src/cli.test.ts
+++ b/packages/portless/src/cli.test.ts
@@ -951,18 +951,6 @@ describe("CLI", () => {
       expect(stderr).toContain("Unknown argument");
     });
 
-    it("does not bypass when PORTLESS=0 is set", () => {
-      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "portless-bypass-clean-"));
-      const { stderr } = run(["clean"], {
-        env: {
-          PORTLESS: "0",
-          PORTLESS_STATE_DIR: tmpDir,
-        },
-      });
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-      expect(stderr).not.toContain("ENOENT");
-    });
-
     it("does not bypass clean with extra args when PORTLESS=0", () => {
       const { status, stderr } = run(["clean", "typo"], { env: { PORTLESS: "0" } });
       expect(status).toBe(1);

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1903,6 +1903,11 @@ ${colors.bold("HTTP/2 + HTTPS (default):")}
   extended CONNECT), so dev server HMR works through the proxy.
   On first use, portless generates a local CA and adds it to your
   system trust store. No browser warnings. Disable with --no-tls.
+  Linux also updates the invoking user's existing Chrome/Chromium NSS DB:
+  ~/.pki/nssdb if present, otherwise ~/.local/share/pki/nssdb (M146+).
+  Requires NSS certutil (Debian/Ubuntu: sudo apt install libnss3-tools).
+  If neither DB exists, open Chrome once, then rerun portless trust.
+  Restart the browser after trusting. portless clean removes NSS trust too.
   On WSL, portless also adds the CA to the Windows user certificate store.
 
 ${colors.bold("LAN mode:")}
@@ -2026,7 +2031,7 @@ async function handleTrust(): Promise<void> {
   const result = trustCA(dir);
   if (result.trusted) {
     console.log(colors.green("Local CA added to system trust store."));
-    console.log(colors.gray("Browsers will now trust portless HTTPS certificates."));
+    console.log(colors.gray("Restart your browser to use the updated certificate trust."));
     return;
   }
 
@@ -2778,11 +2783,11 @@ ${colors.bold("Options:")}
     const caPath = path.join(state.dir, "ca.pem");
     if (fs.existsSync(caPath)) {
       if (isCATrusted(state.dir)) {
-        add("ok", "Local CA is trusted by the OS trust store.");
+        add("ok", "Local CA is trusted by the required trust stores.");
       } else {
         add(
           "warn",
-          "Local CA exists but is not trusted by the OS trust store.",
+          "Local CA exists but is not trusted by all required trust stores.",
           "Run: portless trust"
         );
       }
@@ -3348,7 +3353,7 @@ ${colors.bold("LAN mode (--lan):")}
         const trustResult = trustCA(stateDir);
         if (trustResult.trusted) {
           console.log(
-            colors.green("CA added to system trust store. Browsers will trust portless certs.")
+            colors.green("CA trust installed. Restart your browser to use the updated trust.")
           );
         } else {
           console.warn(colors.yellow("Could not add CA to system trust store."));

--- a/packages/portless/src/cli.ts
+++ b/packages/portless/src/cli.ts
@@ -1905,7 +1905,9 @@ ${colors.bold("HTTP/2 + HTTPS (default):")}
   system trust store. No browser warnings. Disable with --no-tls.
   Linux also updates the invoking user's existing Chrome/Chromium NSS DB:
   ~/.pki/nssdb if present, otherwise ~/.local/share/pki/nssdb (M146+).
-  Requires NSS certutil (Debian/Ubuntu: sudo apt install libnss3-tools).
+  NSS registration needs certutil (Debian/Ubuntu: sudo apt install libnss3-tools).
+  If NSS registration fails, system trust still succeeds with a warning;
+  Chrome may remain untrusted. Install the tools and rerun portless trust.
   If neither DB exists, open Chrome once, then rerun portless trust.
   Restart the browser after trusting. portless clean removes NSS trust too.
   On WSL, portless also adds the CA to the Windows user certificate store.
@@ -2031,7 +2033,11 @@ async function handleTrust(): Promise<void> {
   const result = trustCA(dir);
   if (result.trusted) {
     console.log(colors.green("Local CA added to system trust store."));
-    console.log(colors.gray("Restart your browser to use the updated certificate trust."));
+    if (result.warning) {
+      console.warn(colors.yellow(result.warning));
+    } else {
+      console.log(colors.gray("Restart your browser to use the updated certificate trust."));
+    }
     return;
   }
 
@@ -3352,9 +3358,14 @@ ${colors.bold("LAN mode (--lan):")}
         console.log(colors.yellow("Adding CA to system trust store..."));
         const trustResult = trustCA(stateDir);
         if (trustResult.trusted) {
-          console.log(
-            colors.green("CA trust installed. Restart your browser to use the updated trust.")
-          );
+          if (trustResult.warning) {
+            console.log(colors.green("CA added to system trust store."));
+            console.warn(colors.yellow(trustResult.warning));
+          } else {
+            console.log(
+              colors.green("CA trust installed. Restart your browser to use the updated trust.")
+            );
+          }
         } else {
           console.warn(colors.yellow("Could not add CA to system trust store."));
           if (trustResult.error) {

--- a/packages/portless/src/service.ts
+++ b/packages/portless/src/service.ts
@@ -988,6 +988,7 @@ function prepareTrust(stateDir: string): void {
   const trustResult = trustCA(stateDir);
   if (trustResult.trusted) {
     console.log(colors.green("CA added to the system trust store."));
+    if (trustResult.warning) console.warn(colors.yellow(trustResult.warning));
     return;
   }
 

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -209,6 +209,8 @@ portless trust                                      # Add CA to trust store late
 
 On Linux, `portless trust` supports Debian/Ubuntu, Arch, Fedora/RHEL/CentOS, and openSUSE (via `update-ca-certificates` or `update-ca-trust`). On Windows, it uses `certutil` to add the CA to the system trust store. On WSL, it updates both the Linux trust store and the Windows current-user Root store so Windows browsers trust portless HTTPS certificates.
 
+For Linux Chrome/Chromium, `portless trust` also updates the invoking user's existing NSS database, including when run via sudo. It prefers `~/.pki/nssdb`, otherwise `~/.local/share/pki/nssdb` (Chromium M146+). If `certutil` is missing, install `libnss3-tools` (Debian/Ubuntu), `nss-tools` (Fedora/RHEL), `nss` (Arch), or `mozilla-nss-tools` (openSUSE), rerun `portless trust`, and restart the browser. If neither database exists, no NSS database is created; open Chrome once before rerunning `portless trust`. `portless clean` removes the CA from the active NSS database too.
+
 ### LAN mode
 
 ```bash

--- a/skills/portless/SKILL.md
+++ b/skills/portless/SKILL.md
@@ -211,6 +211,8 @@ On Linux, `portless trust` supports Debian/Ubuntu, Arch, Fedora/RHEL/CentOS, and
 
 For Linux Chrome/Chromium, `portless trust` also updates the invoking user's existing NSS database, including when run via sudo. It prefers `~/.pki/nssdb`, otherwise `~/.local/share/pki/nssdb` (Chromium M146+). If `certutil` is missing, install `libnss3-tools` (Debian/Ubuntu), `nss-tools` (Fedora/RHEL), `nss` (Arch), or `mozilla-nss-tools` (openSUSE), rerun `portless trust`, and restart the browser. If neither database exists, no NSS database is created; open Chrome once before rerunning `portless trust`. `portless clean` removes the CA from the active NSS database too.
 
+Linux NSS registration failure is partial success: after successful system trust registration, `portless trust` exits successfully but prints a browser-trust warning. Do not infer Chrome trust from the exit code alone. Install the NSS tools and rerun `portless trust`; `portless doctor` continues to report incomplete trust until NSS verification succeeds. NSS removal failures still preserve the CA certificate and key so `portless clean` can retry.
+
 ### LAN mode
 
 ```bash


### PR DESCRIPTION
## Summary

Fix Linux Chrome/Chromium certificate warnings when the Portless CA is installed in the distro trust store but missing from the browser's NSS Shared DB.

- Add, verify, and remove the CA in the invoking user's existing NSS DB. Prefer `~/.pki/nssdb`; otherwise use `~/.local/share/pki/nssdb`, matching Chromium M146+.
- Import with SSL CA trust (`C,,`). Use a certificate-fingerprint nickname without colons, which NSS interprets as token separators.
- Run NSS commands as the invoking user under sudo and send the public CA through stdin, avoiding root-owned browser files and access to root-only state directories.
- Do not let the Linux trust marker bypass per-user NSS checks. `portless doctor` continues to warn if browser trust is incomplete.
- Keep system-only behavior when neither NSS path exists. No new NSS DB is created and no package dependency is added.

## Partial success and cleanup

Linux NSS registration is best-effort after successful system trust installation:

- If `certutil` is missing or NSS registration otherwise fails, `trustCA()` returns `trusted: true` with a browser-trust warning. `portless trust` exits with code 0 and prints the warning and remediation instructions. It does not claim Chrome trust is complete.
- Proxy startup and service installation also surface the warning and continue. System trust failures remain errors, and the Windows trust step on WSL is still required.
- Chrome may still reject the CA until NSS tools are installed and `portless trust` is rerun. A successful command exit alone does not establish browser trust.
- Cleanup remains conservative: `portless clean` attempts both stores. NSS removal failure keeps cleanup incomplete and preserves the CA certificate and key for retry, rather than silently abandoning a trusted root.

Certificate generation and signing, macOS/Windows behavior, versions, and release changelogs are unchanged. Update CLI guidance, README, the agent skill, and the HTTPS docs page.

Chromium's documented path selection and trust flags: https://chromium.googlesource.com/chromium/src/+/main/docs/linux/cert_management.md

## Verification

- Google Chrome 151.0.7922.173, with an isolated HOME/NSS DB and fixture-backed system-store operations: `NET::ERR_CERT_AUTHORITY_INVALID` before NSS registration, then successful HTTPS navigation after registration and a browser restart. OpenSSL, NSS certutil, and Chrome were real; the host trust store was not modified by this smoke scenario.
- Real NSS leaf validation succeeds after registration and fails again after removal.
- Follow-up smoke of the built CLI, with fixture-backed system-store operations and genuinely missing certutil: `portless trust` exits 0 with a browser warning; a system trust refresh failure exits 1. The foreground HTTPS proxy starts despite missing certutil, and `portless doctor` reports 0 failures and 1 incomplete-trust warning.
- Nine Linux regression tests cover stale trust markers, SSL trust revocation, legacy-path precedence, sudo user execution, partial success and retry after missing certutil, fatal system trust failure, absent/new browser DBs, unrelated certificates, and retryable cleanup failure.
- `pnpm test`: 939 passed, 3 skipped.
- `pnpm test:e2e`: 16 passed, 2 skipped.
- `pnpm lint`, `pnpm type-check`, `pnpm build`, and `pnpm format:check` passed. Commit hooks passed.

Remove one existing CLI cleanup test that only asserted stderr did not contain `ENOENT`: a legitimate missing-certutil error invalidates that assertion, and it did not establish whether command bypass occurred. The neighboring explicit `PORTLESS=0` command-dispatch regression remains.
